### PR TITLE
bugfix: gdb unittest TestModel_Update fail

### DIFF
--- a/g/database/gdb/gdb_unit_model_test.go
+++ b/g/database/gdb/gdb_unit_model_test.go
@@ -209,7 +209,7 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	gtest.Case(t, func() {
-		result, err := db.Table("user").Data("passport", "t22").Where("passport=?", "t2").Update()
+		result, err := db.Table(table).Data("passport", "t22").Where("passport=?", "t2").Update()
 		if err != nil {
 			gtest.Fatal(err)
 		}
@@ -218,7 +218,7 @@ func TestModel_Update(t *testing.T) {
 	})
 
 	gtest.Case(t, func() {
-		result, err := db.Table("user").Data("passport", "t2").Where("passport='t22'").Update()
+		result, err := db.Table(table).Data("passport", "t2").Where("passport='t22'").Update()
 		if err != nil {
 			gtest.Fatal(err)
 		}


### PR DESCRIPTION
#255 
单独执行 TestModel_Update 测试失败，检查源码后发现有两处
`db.Table("user").Data(...)`
应改为
`db.Table(table).Data(...)`