### PR TITLE
Fix

### DIFF
--- a/util/gconv/gconv.go
+++ b/util/gconv/gconv.go
@@ -207,11 +207,6 @@ func String(i interface{}) string {
 			return ""
 		}
 		return value.String()
-	case *time.Time:
-		if value == nil {
-			return ""
-		}
-		return value.String()
 	case gtime.Time:
 		if value.IsZero() {
 			return ""

--- a/util/gconv/gconv.go
+++ b/util/gconv/gconv.go
@@ -217,11 +217,6 @@ func String(i interface{}) string {
 			return ""
 		}
 		return value.String()
-	case *gtime.Time:
-		if value == nil {
-			return ""
-		}
-		return value.String()
 	default:
 		// Empty checks.
 		if value == nil {

--- a/util/gconv/gconv_unsafe.go
+++ b/util/gconv/gconv_unsafe.go
@@ -16,7 +16,7 @@ func UnsafeStrToBytes(s string) []byte {
 }
 
 // UnsafeBytesToStr converts []byte to string without memory copy.
-// Note that, if you completely sure you will never use <s> in the feature,
+// Note that, if you completely sure you will never use <b> in the feature,
 // you can use this unsafe function to implement type conversion in high performance.
 func UnsafeBytesToStr(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))


### PR DESCRIPTION
*gtime.Time与*time.Time实现了apiString接口，因此可以去掉直接在default分支中判断。