### PR TITLE
修改sql打印debug信息，增加数据库配置的group名称，用于区分sql来源，尤其是多数据库配置的时候

### DIFF
--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -11,9 +11,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/gogf/gf/container/gvar"
 	"github.com/gogf/gf/internal/intlog"
-	"time"
 
 	"github.com/gogf/gf/os/glog"
 
@@ -144,12 +145,13 @@ type Driver interface {
 
 // Sql is the sql recording struct.
 type Sql struct {
-	Sql    string        // SQL string(may contain reserved char '?').
-	Args   []interface{} // Arguments for this sql.
-	Format string        // Formatted sql which contains arguments in the sql.
-	Error  error         // Execution result.
-	Start  int64         // Start execution timestamp in milliseconds.
-	End    int64         // End execution timestamp in milliseconds.
+	Sql         string        // SQL string(may contain reserved char '?').
+	Args        []interface{} // Arguments for this sql.
+	Format      string        // Formatted sql which contains arguments in the sql.
+	Error       error         // Execution result.
+	Start       int64         // Start execution timestamp in milliseconds.
+	End         int64         // End execution timestamp in milliseconds.
+	DBGroupName string        // DBGroupName is which database call the sql.
 }
 
 // TableField is the struct for table field.

--- a/database/gdb/gdb_core.go
+++ b/database/gdb/gdb_core.go
@@ -109,12 +109,13 @@ func (c *Core) DoExec(link Link, sql string, args ...interface{}) (result sql.Re
 		}
 		mTime2 := gtime.TimestampMilli()
 		s := &Sql{
-			Sql:    sql,
-			Args:   args,
-			Format: FormatSqlWithArgs(sql, args),
-			Error:  err,
-			Start:  mTime1,
-			End:    mTime2,
+			Sql:         sql,
+			Args:        args,
+			Format:      FormatSqlWithArgs(sql, args),
+			Error:       err,
+			Start:       mTime1,
+			End:         mTime2,
+			DBGroupName: c.group,
 		}
 		c.writeSqlToLogger(s)
 	} else {

--- a/database/gdb/gdb_core.go
+++ b/database/gdb/gdb_core.go
@@ -11,10 +11,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/gogf/gf/internal/utils"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/gogf/gf/internal/utils"
 
 	"github.com/gogf/gf/container/gvar"
 	"github.com/gogf/gf/os/gtime"
@@ -64,12 +65,13 @@ func (c *Core) DoQuery(link Link, sql string, args ...interface{}) (rows *sql.Ro
 		rows, err = link.Query(sql, args...)
 		mTime2 := gtime.TimestampMilli()
 		s := &Sql{
-			Sql:    sql,
-			Args:   args,
-			Format: FormatSqlWithArgs(sql, args),
-			Error:  err,
-			Start:  mTime1,
-			End:    mTime2,
+			Sql:         sql,
+			Args:        args,
+			Format:      FormatSqlWithArgs(sql, args),
+			Error:       err,
+			Start:       mTime1,
+			End:         mTime2,
+			DBGroupName: c.group,
 		}
 		c.writeSqlToLogger(s)
 	} else {
@@ -781,7 +783,7 @@ func (c *Core) MarshalJSON() ([]byte, error) {
 // writeSqlToLogger outputs the sql object to logger.
 // It is enabled when configuration "debug" is true.
 func (c *Core) writeSqlToLogger(v *Sql) {
-	s := fmt.Sprintf("[%3d ms] %s", v.End-v.Start, v.Format)
+	s := fmt.Sprintf("[%s] [%3d ms] %s", v.DBGroupName, v.End-v.Start, v.Format)
 	if v.Error != nil {
 		s += "\nError: " + v.Error.Error()
 		c.logger.StackWithFilter(gPATH_FILTER_KEY).Error(s)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5274925/85943217-2b70cb00-b961-11ea-8f6d-089d7f929a7d.png)
