### PR TITLE
bug/log-file-rotate: fix big file even with rotate-by-size and rotate…

### DIFF
--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -229,7 +229,6 @@ func (l *Logger) printToFile(now time.Time, buffer *bytes.Buffer) {
 	gmlock.Lock(memoryLockKey)
 	defer gmlock.Unlock(memoryLockKey)
 	file := l.getFilePointer(logFilePath)
-	defer file.Close()
 	// Rotation file size checks.
 	if l.config.RotateSize > 0 {
 		stat, err := file.Stat()
@@ -239,12 +238,13 @@ func (l *Logger) printToFile(now time.Time, buffer *bytes.Buffer) {
 		if stat.Size() > l.config.RotateSize {
 			l.rotateFileBySize(now)
 			file = l.getFilePointer(logFilePath)
-			defer file.Close()
 		}
 	}
 	if _, err := file.Write(buffer.Bytes()); err != nil {
+		defer file.Close()
 		panic(err)
 	}
+	defer file.Close()
 }
 
 // getFilePointer retrieves and returns a file pointer from file pool.


### PR DESCRIPTION
solving following problem
```bash
[logger]
    ...
    [logger.data_logger]
        RotateSize           = "16M"
        RotateBackupLimit    = 4
        RotateBackupExpire   = "1m"
        RotateCheckInterval  = "1m"
        Path = "/tmp/log/LogVerify"
        Level = "NOTI"
        Stdout = false
```
```go
var DataLogger = g.Log("data_logger").File("data.{Ymd}.log")

for {
	utils.DataLogger.Notice("log rotate test...")
}
```

![image](https://user-images.githubusercontent.com/5053620/87796997-b7995280-c87c-11ea-9f77-329cc037b418.png)
![image](https://user-images.githubusercontent.com/5053620/87797011-bd8f3380-c87c-11ea-8414-0ca16be0588b.png)

the file: data.20200717.20200717222703632677.log won't expired and the size is the total size.
