### PR TITLE
驼峰转换下划线时，不连续大写字母首位加下划线规范

### DIFF
--- a/text/gstr/gstr_case.go
+++ b/text/gstr/gstr_case.go
@@ -14,6 +14,7 @@
 //   | DelimitedScreamingCase(s, '.')    | ANY.KIND.OF.STRING |
 //   | CamelCase(s)                      | AnyKindOfString    |
 //   | CamelLowerCase(s)                 | anyKindOfString    |
+//   | SnakeFirstUpperCase(RGBCodeMd5)   | rgb_code_md5       |
 
 package gstr
 
@@ -25,6 +26,9 @@ import (
 var (
 	numberSequence    = regexp.MustCompile(`([a-zA-Z])(\d+)([a-zA-Z]?)`)
 	numberReplacement = []byte(`$1 $2 $3`)
+
+	firstCamelCaseStart = regexp.MustCompile(`([A-Z]+)([A-Z]?[_a-z\d]+)|$`)
+	firstCamelCaseEnd   = regexp.MustCompile(`([\w\W]*?)([_]?[A-Z]+)$`)
 )
 
 // CamelCase converts a string to CamelCase.
@@ -55,21 +59,20 @@ func SnakeScreamingCase(s string) string {
 
 // SnakeFirstUpperCase converts a string from RGBCodeMd5 to rgb_code_md5.
 // The length of word should not be too long
+// TODO for efficiency should change regexp to traversing string in future
 func SnakeFirstUpperCase(word string, underscore ...string) string {
 	replace := "_"
 	if len(underscore) > 0 {
 		replace = underscore[0]
 	}
 
-	r := regexp.MustCompile(`([\w\W]*?)([_]?[A-Z]+)$`)
-	m := r.FindAllStringSubmatch(word, 1)
+	m := firstCamelCaseEnd.FindAllStringSubmatch(word, 1)
 	if len(m) > 0 {
 		word = m[0][1] + replace + TrimLeft(ToLower(m[0][2]), replace)
 	}
 
-	r = regexp.MustCompile(`([A-Z]+)([A-Z]?[_a-z\d]+)|$`)
 	for {
-		m := r.FindAllStringSubmatch(word, 1)
+		m := firstCamelCaseStart.FindAllStringSubmatch(word, 1)
 		if len(m) > 0 && m[0][1] != "" {
 			w := strings.ToLower(m[0][1])
 			w = string(w[:len(w)-1]) + replace + string(w[len(w)-1])

--- a/text/gstr/gstr_case.go
+++ b/text/gstr/gstr_case.go
@@ -53,6 +53,36 @@ func SnakeScreamingCase(s string) string {
 	return DelimitedScreamingCase(s, '_', true)
 }
 
+// SnakeFirstUpperCase converts a string from RGBCodeMd5 to rgb_code_md5.
+// The length of word should not be too long
+func SnakeFirstUpperCase(word string, underscore ...string) string {
+	replace := "_"
+	if len(underscore) > 0 {
+		replace = underscore[0]
+	}
+
+	r := regexp.MustCompile(`([\w\W]*?)([_]?[A-Z]+)$`)
+	m := r.FindAllStringSubmatch(word, 1)
+	if len(m) > 0 {
+		word = m[0][1] + replace + TrimLeft(ToLower(m[0][2]), replace)
+	}
+
+	r = regexp.MustCompile(`([A-Z]+)([A-Z]?[_a-z\d]+)|$`)
+	for {
+		m := r.FindAllStringSubmatch(word, 1)
+		if len(m) > 0 && m[0][1] != "" {
+			w := strings.ToLower(m[0][1])
+			w = string(w[:len(w)-1]) + replace + string(w[len(w)-1])
+
+			word = strings.Replace(word, m[0][1], w, 1)
+		} else {
+			break
+		}
+	}
+
+	return TrimLeft(word, replace)
+}
+
 // KebabCase converts a string to kebab-case
 func KebabCase(s string) string {
 	return DelimitedCase(s, '-')

--- a/text/gstr/gstr_z_unit_case_test.go
+++ b/text/gstr/gstr_z_unit_case_test.go
@@ -170,3 +170,26 @@ func Test_DelimitedScreamingCase(t *testing.T) {
 		}
 	}
 }
+
+func TestSnakeFirstUpperCase(t *testing.T) {
+	cases := [][]string{
+		{"RGBCodeMd5", "rgb_code_md5"},
+		{"testCase", "test_case"},
+		{"Md5", "md5"},
+		{"userID", "user_id"},
+		{"RGB", "rgb"},
+		{"RGBCode", "rgb_code"},
+		{"_ID", "id"},
+		{"User_ID", "user_id"},
+		{"user_id", "user_id"},
+		{"md5", "md5"},
+	}
+	for _, i := range cases {
+		in := i[0]
+		out := i[1]
+		result := gstr.SnakeFirstUpperCase(in)
+		if result != out {
+			t.Error("'" + result + "' != '" + out + "'")
+		}
+	}
+}


### PR DESCRIPTION
为了实现数据库字段优雅映射为实体类，如`md5`应映射为 `Md5`, 新增一个`不连续大写字母首位加下划线`的方法。

Fix #795 

```
{"RGBCodeMd5", "rgb_code_md5"},
{"testCase", "test_case"},
{"Md5", "md5"},
{"userID", "user_id"},
{"RGB", "rgb"},
{"RGBCode", "rgb_code"},
{"_ID", "id"},
{"User_ID", "user_id"},
{"user_id", "user_id"},
{"md5", "md5"},
``