### PR TITLE
fix configfile with UTF8-BOM issue

### DIFF
--- a/encoding/gjson/gjson_api_new_load.go
+++ b/encoding/gjson/gjson_api_new_load.go
@@ -10,8 +10,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gogf/gf/internal/json"
 	"reflect"
+
+	"github.com/gogf/gf/internal/json"
 
 	"github.com/gogf/gf/encoding/gini"
 	"github.com/gogf/gf/encoding/gtoml"
@@ -188,6 +189,12 @@ func LoadContent(data interface{}, safe ...bool) (*Json, error) {
 	if len(content) == 0 {
 		return New(nil, safe...), nil
 	}
+
+	//ignore UTF8-BOM
+	if content[0] == 0xEF && content[1] == 0xBB && content[2] == 0xBF {
+		content = content[3:]
+	}
+
 	return doLoadContent(checkDataType(content), content, safe...)
 
 }

--- a/os/gcfg/gcfg_z_unit_test.go
+++ b/os/gcfg/gcfg_z_unit_test.go
@@ -479,7 +479,7 @@ func TestCfg_Config(t *testing.T) {
 
 func TestCfg_With_UTF8_BOM(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
-		cfg := g.Cfg()
+		cfg := g.Cfg("test-cfg-with-utf8-bom")
 		t.Assert(cfg.SetPath("testdata"), nil)
 		cfg.SetFileName("cfg-with-utf8-bom.toml")
 		t.Assert(cfg.GetInt("test.testInt"), 1)

--- a/os/gcfg/gcfg_z_unit_test.go
+++ b/os/gcfg/gcfg_z_unit_test.go
@@ -9,10 +9,11 @@
 package gcfg_test
 
 import (
-	"github.com/gogf/gf/debug/gdebug"
-	"github.com/gogf/gf/os/gtime"
 	"os"
 	"testing"
+
+	"github.com/gogf/gf/debug/gdebug"
+	"github.com/gogf/gf/os/gtime"
 
 	"github.com/gogf/gf/encoding/gjson"
 	"github.com/gogf/gf/frame/g"
@@ -473,5 +474,15 @@ func TestCfg_Config(t *testing.T) {
 		gcfg.RemoveContent("config.yml")
 		gcfg.ClearContent()
 		t.Assert(gcfg.GetContent("name"), "")
+	})
+}
+
+func TestCfg_With_UTF8_BOM(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		cfg := g.Cfg()
+		t.Assert(cfg.SetPath("testdata"), nil)
+		cfg.SetFileName("cfg-with-utf8-bom.toml")
+		t.Assert(cfg.GetInt("test.testInt"), 1)
+		t.Assert(cfg.GetString("test.testStr"), "test")
 	})
 }

--- a/os/gcfg/testdata/cfg-with-utf8-bom.toml
+++ b/os/gcfg/testdata/cfg-with-utf8-bom.toml
@@ -1,0 +1,4 @@
+﻿
+[test]
+testInt=1
+testStr="test"


### PR DESCRIPTION
解决 #787

由于在Windows下修改配置文件导致配置文件带UTF8-BOM,产生异常错误的问题