### PR TITLE
add func gtimer.Entry.Reset()

### DIFF
--- a/os/gtimer/gtimer.go
+++ b/os/gtimer/gtimer.go
@@ -31,6 +31,7 @@ const (
 	STATUS_READY            = 0             // Job is ready for running.
 	STATUS_RUNNING          = 1             // Job is already running.
 	STATUS_STOPPED          = 2             // Job is stopped.
+	STATUS_RESET            = 3             // Job is reset.
 	STATUS_CLOSED           = -1            // Job is closed and waiting to be deleted.
 	gPANIC_EXIT             = "exit"        // Internal usage for custom job exit function with panic.
 	gDEFAULT_TIMES          = math.MaxInt32 // Default limit running times, a big number.

--- a/os/gtimer/gtimer_entry.go
+++ b/os/gtimer/gtimer_entry.go
@@ -106,6 +106,11 @@ func (entry *Entry) Stop() {
 	entry.status.Set(STATUS_STOPPED)
 }
 
+//Reset reset the job.
+func (entry *Entry) Reset() {
+	entry.status.Set(STATUS_RESET)
+}
+
 // Close closes the job, and then it will be removed from the timer.
 func (entry *Entry) Close() {
 	entry.status.Set(STATUS_CLOSED)
@@ -138,6 +143,8 @@ func (entry *Entry) check(nowTicks int64, nowMs int64) (runnable, addable bool) 
 		return false, true
 	case STATUS_CLOSED:
 		return false, false
+	case STATUS_RESET:
+		return false, true
 	}
 	// Firstly checks using the ticks, this may be low precision as one tick is a little bit long.
 	if diff := nowTicks - entry.create; diff > 0 && diff%entry.interval == 0 {

--- a/os/gtimer/gtimer_loop.go
+++ b/os/gtimer/gtimer_loop.go
@@ -74,6 +74,10 @@ func (w *wheel) proceed() {
 				}
 				// If rolls on the job.
 				if addable {
+					//If STATUS_RESET , reset to runnable state.
+					if entry.Status() == STATUS_RESET {
+						entry.SetStatus(STATUS_READY)
+					}
 					entry.wheel.timer.doAddEntryByParent(entry.rawIntervalMs, entry)
 				}
 			}

--- a/os/gtimer/gtimer_z_unit_1_test.go
+++ b/os/gtimer/gtimer_z_unit_1_test.go
@@ -76,6 +76,7 @@ func TestTimer_Start_Stop_Close(t *testing.T) {
 
 func TestTimer_Reset(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
+		timer := New()
 		array := garray.New(true)
 		glog.Printf("start time:%d", time.Now().Unix())
 		singleton := timer.AddSingleton(2*time.Second, func() {

--- a/os/gtimer/gtimer_z_unit_1_test.go
+++ b/os/gtimer/gtimer_z_unit_1_test.go
@@ -9,6 +9,7 @@
 package gtimer_test
 
 import (
+	"github.com/gogf/gf/os/glog"
 	"testing"
 	"time"
 
@@ -70,6 +71,19 @@ func TestTimer_Start_Stop_Close(t *testing.T) {
 		timer.Close()
 		time.Sleep(1000 * time.Millisecond)
 		t.Assert(array.Len(), 2)
+	})
+}
+
+func TestTimer_Reset(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		glog.Printf("start time:%d", time.Now().Unix())
+		singleton := timer.AddSingleton(2*time.Second, func() {
+			glog.Println(time.Now().Unix())
+		})
+		time.Sleep(5 * time.Second)
+		glog.Printf("reset time:%d", time.Now().Unix())
+		singleton.Reset()
+		select {}
 	})
 }
 

--- a/os/gtimer/gtimer_z_unit_1_test.go
+++ b/os/gtimer/gtimer_z_unit_1_test.go
@@ -76,14 +76,18 @@ func TestTimer_Start_Stop_Close(t *testing.T) {
 
 func TestTimer_Reset(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
+		array := garray.New(true)
 		glog.Printf("start time:%d", time.Now().Unix())
 		singleton := timer.AddSingleton(2*time.Second, func() {
-			glog.Println(time.Now().Unix())
+			timestamp := time.Now().Unix()
+			glog.Println(timestamp)
+			array.Append(timestamp)
 		})
 		time.Sleep(5 * time.Second)
 		glog.Printf("reset time:%d", time.Now().Unix())
 		singleton.Reset()
-		select {}
+		time.Sleep(10 * time.Second)
+		t.Assert(array.Len(), 6)
 	})
 }
 


### PR DESCRIPTION
Test Code:
~~~
glog.Printf("start time:%d", time.Now().Unix())
singleton := timer.AddSingleton(2*time.Second, func() {
	glog.Println(time.Now().Unix())
})
time.Sleep(5 * time.Second)
glog.Printf("reset time:%d", time.Now().Unix())
singleton.Reset()
select {}
~~~
Test results:
~~~
=== RUN   TestTimer_Reset
2020-07-29 10:29:36.129 start time:1595989776
2020-07-29 10:29:38.138 1595989778
2020-07-29 10:29:40.118 1595989780
2020-07-29 10:29:41.165 reset time:1595989781
2020-07-29 10:29:43.358 1595989783
2020-07-29 10:29:45.338 1595989785
2020-07-29 10:29:47.318 1595989787
2020-07-29 10:29:49.298 1595989789
~~~