### PR TITLE
gcmd.Scan supports read line that contains whitespace

### DIFF
--- a/os/gcmd/gcmd_scan.go
+++ b/os/gcmd/gcmd_scan.go
@@ -17,18 +17,20 @@ import (
 
 // Scan prints <info> to stdout, reads and returns user input, which stops by '\n'.
 func Scan(info ...interface{}) string {
-	var s string
 	fmt.Print(info...)
-	reader := bufio.NewReader(os.Stdin)
-	s, _ = reader.ReadString('\n')
-	s = gstr.Trim(s)
-	return s
+	return readline()
 }
 
 // Scanf prints <info> to stdout with <format>, reads and returns user input, which stops by '\n'.
 func Scanf(format string, info ...interface{}) string {
-	var s string
 	fmt.Printf(format, info...)
-	fmt.Scanln(&s)
+	return readline()
+}
+
+func readline() string {
+	var s string
+	reader := bufio.NewReader(os.Stdin)
+	s, _ = reader.ReadString('\n')
+	s = gstr.Trim(s)
 	return s
 }

--- a/os/gcmd/gcmd_scan.go
+++ b/os/gcmd/gcmd_scan.go
@@ -7,13 +7,21 @@
 
 package gcmd
 
-import "fmt"
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/gogf/gf/text/gstr"
+)
 
 // Scan prints <info> to stdout, reads and returns user input, which stops by '\n'.
 func Scan(info ...interface{}) string {
 	var s string
 	fmt.Print(info...)
-	fmt.Scanln(&s)
+	reader := bufio.NewReader(os.Stdin)
+	s, _ = reader.ReadString('\n')
+	s = gstr.Trim(s)
 	return s
 }
 


### PR DESCRIPTION
变更内容：
gcmd.Scan支持包含空格的整行输入 #824 

另外看了下gcmd.Scanf目前有些问题，此用法并非Scanf本意
但如果在fmt.Scanf上封装仅多个prompt，觉得又很鸡肋，所以建议去掉这个方法以免与fmt.Scanf混淆， @gqcn 你看呢