### PR TITLE
Solve the problem of invalid modification of request parameters

### DIFF
--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -224,7 +224,7 @@ func (r *Request) GetError() error {
 	return r.error
 }
 
-// ReloadParam used for request parameter filtering.
+// ReloadParam used for request parameter modifying.
 func (r *Request) ReloadParam() {
 	r.parsedBody = false
 	r.parsedForm = false

--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -229,4 +229,5 @@ func (r *Request) ReloadParam() {
 	r.parsedBody = false
 	r.parsedForm = false
 	r.parsedQuery = false
+	r.bodyContent = nil
 }

--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -9,14 +9,15 @@ package ghttp
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/gogf/gf/internal/intlog"
 	"github.com/gogf/gf/os/gres"
 	"github.com/gogf/gf/os/gsession"
 	"github.com/gogf/gf/os/gview"
 	"github.com/gogf/gf/util/guid"
-	"net/http"
-	"strings"
-	"time"
 
 	"github.com/gogf/gf/os/gtime"
 	"github.com/gogf/gf/text/gregex"
@@ -221,4 +222,11 @@ func (r *Request) GetReferer() string {
 // It returns nil if there's no error.
 func (r *Request) GetError() error {
 	return r.error
+}
+
+// ReloadParam used for request parameter filtering.
+func (r *Request) ReloadParam() {
+	r.parsedBody = false
+	r.parsedForm = false
+	r.parsedQuery = false
 }

--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -224,7 +224,7 @@ func (r *Request) GetError() error {
 	return r.error
 }
 
-// ReloadParam used for request parameter modifying.
+// ReloadParam used for modifying request parameter.
 func (r *Request) ReloadParam() {
 	r.parsedBody = false
 	r.parsedForm = false


### PR DESCRIPTION
sometimes, we want to modify request parameters through middleware, but directly modifying `Request.Body` is invalid, so I add function `ReloadParam` for `ghttp_request.go` to clear parsed* mark.

```go
func MiddlewareExample(r *ghttp.Request) {
    // ... this is newParam
    r.Request.Body = ioutil.NopCloser(bytes.NewReader(newParam))
    r.ReloadParam()
    r.Middleware.Next()
}
```