### PR TITLE
add update counter method for package gdb.

### DIFF
--- a/database/gdb/gdb_z_init_test.go
+++ b/database/gdb/gdb_z_init_test.go
@@ -119,6 +119,7 @@ func createTableWithDb(db gdb.DB, table ...string) (name string) {
 		   password char(32) NOT NULL,
 		   nickname varchar(45) NOT NULL,
 		   create_time timestamp NOT NULL,
+           login_times bigint NOT NULL,
 		   PRIMARY KEY (id)
 		) ;`, name,
 		)); err != nil {
@@ -132,6 +133,7 @@ func createTableWithDb(db gdb.DB, table ...string) (name string) {
 		   password char(32) NOT NULL,
 		   nickname varchar(45) NOT NULL,
 		   create_time timestamp NOT NULL,
+           login_times bigint NOT NULL,
 		   PRIMARY KEY (id)
 		) ;`, name,
 		)); err != nil {
@@ -146,6 +148,7 @@ func createTableWithDb(db gdb.DB, table ...string) (name string) {
 		PASSWORD CHAR(32) NOT NULL,
 		NICKNAME VARCHAR(45) NOT NULL,
 		CREATE_TIME datetime NOT NULL,
+        LOGIN_TIMES numeric(10,0) NOT NULL,
 		PRIMARY KEY (ID))`,
 			name, name,
 		)); err != nil {
@@ -159,6 +162,7 @@ func createTableWithDb(db gdb.DB, table ...string) (name string) {
 		PASSWORD CHAR(32) NOT NULL,
 		NICKNAME VARCHAR(45) NOT NULL,
 		CREATE_TIME varchar(45) NOT NULL,
+        LOGIN_TIMES NUMBER(10) NOT NULL,
 		PRIMARY KEY (ID))
 		`, name,
 		)); err != nil {
@@ -172,6 +176,7 @@ func createTableWithDb(db gdb.DB, table ...string) (name string) {
 	        password    char(32) NULL,
 	        nickname    varchar(45) NULL,
 	        create_time timestamp NULL,
+ 		    login_times int(10) NOT NULL,
 	        PRIMARY KEY (id)
 	    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 	    `, name,
@@ -193,6 +198,7 @@ func createInitTableWithDb(db gdb.DB, table ...string) (name string) {
 			"password":    fmt.Sprintf(`pass_%d`, i),
 			"nickname":    fmt.Sprintf(`name_%d`, i),
 			"create_time": gtime.NewFromStr("2018-10-24 10:00:00").String(),
+			"login_times": 0,
 		})
 	}
 

--- a/database/gdb/gdb_z_mysql_method_test.go
+++ b/database/gdb/gdb_z_mysql_method_test.go
@@ -375,6 +375,34 @@ func Test_DB_Update(t *testing.T) {
 	})
 }
 
+// update counter test
+func Test_DB_UpdateCounter(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	gtest.C(t, func(t *gtest.T) {
+		counter := &gdb.UpdateCounter{
+			Field: "login_times",
+			Value: 1,
+		}
+		updateData := g.Map{
+			"login_times": counter,
+			"password":    "987654321",
+		}
+		result, err := db.Update(table, updateData, "id=3")
+		t.Assert(err, nil)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		one, err := db.Table(table).Where("id", 3).One()
+		t.Assert(err, nil)
+		t.Assert(one["id"].Int(), 3)
+		t.Assert(one["passport"].String(), "user_3")
+		t.Assert(one["password"].String(), "987654321")
+		t.Assert(one["nickname"].String(), "name_3")
+		t.Assert(one["login_times"].String(), "1")
+	})
+}
+
 func Test_DB_GetAll(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)


### PR DESCRIPTION
Update quantity directly when updating data
在更新数据时直接更新数量
```
counter := &gdb.UpdateCounter{
	Field: "login_num",
	Value: 1,
}
update := g.Map{
	"login_num":  counter,
	"updated_at": gtime.Now().Unix(),
}
g.DB().Table("zs_admin").Data(update).Where("id=1").Update()
```
result:
```
2020-08-28 10:51:54.186 [DEBU] [  4 ms] [default] SHOW FULL COLUMNS FROM `zs_admin`
2020-08-28 10:51:54.261 [DEBU] [ 73 ms] [default] UPDATE `zs_admin` SET `login_num`=`login_num`+1,`updated_at`=1598583114 WHERE id=1

```