### PR TITLE
Update gjson_api_new_load.go to make gjson work when sometimes the xml end with space or `\n`

### DIFF
--- a/encoding/gjson/gjson_api_new_load.go
+++ b/encoding/gjson/gjson_api_new_load.go
@@ -228,7 +228,7 @@ func IsValidDataType(dataType string) bool {
 func checkDataType(content []byte) string {
 	if json.Valid(content) {
 		return "json"
-	} else if gregex.IsMatch(`^<.+>[\S\s]+<.+>$`, content) {
+	} else if gregex.IsMatch(`^<.+>[\S\s]+<.+>\s*$`, content) {
 		return "xml"
 	} else if !gregex.IsMatch(`[\n\r]*[\s\t\w\-\."]+\s*=\s*"""[\s\S]+"""`, content) && !gregex.IsMatch(`[\n\r]*[\s\t\w\-\."]+\s*=\s*'''[\s\S]+'''`, content) &&
 		((gregex.IsMatch(`^[\n\r]*[\w\-\s\t]+\s*:\s*".+"`, content) || gregex.IsMatch(`^[\n\r]*[\w\-\s\t]+\s*:\s*\w+`, content)) ||


### PR DESCRIPTION
Make it work when the xml content has ` `,`\n`,`\r` or `\t` in the end. 

The json content can work well when the content not end with `}`, I think xml should not be too strict.