### PR TITLE
fix convertFieldValueToLocalValue: pgsql int8 to local int64

### DIFF
--- a/database/gdb/gdb_core_structure.go
+++ b/database/gdb/gdb_core_structure.go
@@ -59,6 +59,7 @@ func (c *Core) convertFieldValueToLocalValue(fieldValue interface{}, fieldType s
 		"big_int",
 		"bigint",
 		"bigserial":
+		"int8"
 		if gstr.ContainsI(fieldType, "unsigned") {
 			gconv.Uint64(gconv.String(fieldValue))
 		}

--- a/database/gdb/gdb_core_structure.go
+++ b/database/gdb/gdb_core_structure.go
@@ -58,8 +58,8 @@ func (c *Core) convertFieldValueToLocalValue(fieldValue interface{}, fieldType s
 	case
 		"big_int",
 		"bigint",
-		"bigserial":
-		"int8"
+		"bigserial",
+		"int8":
 		if gstr.ContainsI(fieldType, "unsigned") {
 			gconv.Uint64(gconv.String(fieldValue))
 		}


### PR DESCRIPTION
pgsql 的bigint和bigserial都存储为int8类型，故将pgsql的int8字段类型转为go的int64类型，以使pgsql和mysql转换规则一致，方便互迁 @gqcn 