### PR TITLE
增加一个 ListenAndServe 配置,将gf集成到已有的框架中

### DIFF
--- a/net/ghttp/ghttp_server.go
+++ b/net/ghttp/ghttp_server.go
@@ -343,6 +343,9 @@ func Wait() {
 
 // startServer starts the underlying server listening.
 func (s *Server) startServer(fdMap listenerFdMap) {
+	if !s.config.ListenAndServe {
+		return
+	}
 	var httpsEnabled bool
 	// HTTPS
 	if s.config.TLSConfig != nil || (s.config.HTTPSCertPath != "" && s.config.HTTPSKeyPath != "") {

--- a/net/ghttp/ghttp_server_config.go
+++ b/net/ghttp/ghttp_server_config.go
@@ -233,6 +233,8 @@ type ServerConfig struct {
 
 	// Graceful enables graceful reload feature for all servers of the process.
 	Graceful bool
+
+	ListenAndServe bool
 }
 
 // Deprecated. Use NewConfig instead.
@@ -278,6 +280,7 @@ func NewConfig() ServerConfig {
 		FormParsingMemory:   1024 * 1024,     // 1MB
 		Rewrites:            make(map[string]string),
 		Graceful:            false,
+		ListenAndServe:      true,
 	}
 }
 
@@ -467,4 +470,8 @@ func (s *Server) Handler() http.Handler {
 		return s
 	}
 	return s.config.Handler
+}
+
+func (s *Server) SetListenAndServe(enabled bool) {
+	s.config.ListenAndServe = enabled
 }


### PR DESCRIPTION
在我们项目有这样的一种情况,我们已经有了一个web框架了,希望将gf集成进去,但是不希望再启动一个gf的web服务,增加了ListenAndServe配置,当 `ListenAndServe=false`的时候,我们会把部分请求转发到gf的`ServeHTTP`方法中,目前是这样实现的.