### PR TITLE
add util: WrapF and WrapH to transform net/http handler to ghttp.HandlerFunc

### DIFF
--- a/net/ghttp/ghttp_server_util.go
+++ b/net/ghttp/ghttp_server_util.go
@@ -1,0 +1,23 @@
+// Copyright GoFrame Author(https://github.com/gogf/gf). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package ghttp
+
+import "net/http"
+
+// WrapF is a helper function for wrapping http.HandlerFunc and returns a ghttp middleware.
+func WrapF(f http.HandlerFunc) HandlerFunc {
+	return func(r *Request) {
+		f(r.Response.Writer, r.Request)
+	}
+}
+
+// WrapH is a helper function for wrapping http.Handler and returns a ghttp middleware.
+func WrapH(h http.Handler) HandlerFunc {
+	return func(r *Request) {
+		h.ServeHTTP(r.Response.Writer, r.Request)
+	}
+}

--- a/net/ghttp/ghttp_unit_server_util_test.go
+++ b/net/ghttp/ghttp_unit_server_util_test.go
@@ -1,0 +1,69 @@
+// Copyright 2018 gf Author(https://github.com/gogf/gf). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package ghttp_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/frame/g"
+	"github.com/gogf/gf/net/ghttp"
+	"github.com/gogf/gf/test/gtest"
+)
+
+type testWrapStdHTTPStruct struct {
+	T    *gtest.T
+	text string
+}
+
+func (t *testWrapStdHTTPStruct) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	t.T.Assert(req.Method, "POST")
+	t.T.Assert(req.URL.Path, "/api/wraph")
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprint(w, t.text)
+}
+func Test_Server_Wrap_Handler(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		p, _ := ports.PopRand()
+		s := g.Server(p)
+		str1 := "hello"
+		str2 := "hello again"
+		s.Group("/api", func(group *ghttp.RouterGroup) {
+			group.GET("/wrapf", ghttp.WrapF(func(w http.ResponseWriter, req *http.Request) {
+				t.Assert(req.Method, "GET")
+				t.Assert(req.URL.Path, "/api/wrapf")
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, str1)
+			}))
+
+			group.POST("/wraph", ghttp.WrapH(&testWrapStdHTTPStruct{t, str2}))
+		})
+
+		s.SetPort(p)
+		s.SetDumpRouterMap(false)
+		s.Start()
+		defer s.Shutdown()
+
+		time.Sleep(100 * time.Millisecond)
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d/api", p))
+
+		response, er1 := client.Get("/wrapf")
+		defer response.Close()
+		t.Assert(er1, nil)
+		t.Assert(response.StatusCode, http.StatusBadRequest)
+		t.Assert(response.ReadAllString(), str1)
+
+		response2, er2 := client.Post("/wraph")
+		defer response2.Close()
+		t.Assert(er2, nil)
+		t.Assert(response2.StatusCode, http.StatusInternalServerError)
+		t.Assert(response2.ReadAllString(), str2)
+	})
+}


### PR DESCRIPTION
将标准库的 HandlerFunc 和 Handler 转换为 ghttp.HandlerFunc，使得 ghttp 的 server 可以复用开源社区中标准库的中间件

参考 [gin 的实现](https://github.com/gin-gonic/gin/blob/master/utils.go#L38)

如复用标准库的cors

```go
import (
    "github.com/gogf/gf/net/ghttp"
    "github.com/rs/cors"
)

func main() {
    s := g.Server(p)
    c := cors.Default()
    server.Use(ghttp.WrapH(c))
    server.Use(ghttp.WrapF(c.HandlerFunc))
}
```