### PR TITLE
formatMonthDaySuffixMap() misjudged suffix

### DIFF
--- a/os/gtime/gtime_format.go
+++ b/os/gtime/gtime_format.go
@@ -266,11 +266,11 @@ func formatToRegexPattern(format string) string {
 // formatMonthDaySuffixMap returns the short english word for current day.
 func formatMonthDaySuffixMap(day string) string {
 	switch day {
-	case "01":
+	case "01", "21", "31":
 		return "st"
-	case "02":
+	case "02", "22":
 		return "nd"
-	case "03":
+	case "03", "23":
 		return "rd"
 	default:
 		return "th"


### PR DESCRIPTION
when day is 21，abbreviated as 21st，suffix is st ,is not th
when day is 22，abbreviated as 22nd，suffix is nd ,is not th
when day is 23，abbreviated as 23rd，suffix is rd ,is not th
when day is 31，abbreviated as 31st，suffix is st ,is not th