### PR TITLE
去除cancelFunc避免退出之前关闭mysqlConn导致数据获取不完整

### DIFF
--- a/database/gdb/gdb_core.go
+++ b/database/gdb/gdb_core.go
@@ -111,9 +111,7 @@ func (c *Core) DoQuery(link Link, sql string, args ...interface{}) (rows *sql.Ro
 	sql, args = c.db.HandleSqlBeforeCommit(link, sql, args)
 	ctx := c.db.GetCtx()
 	if c.GetConfig().QueryTimeout > 0 {
-		var cancelFunc context.CancelFunc
-		ctx, cancelFunc = context.WithTimeout(ctx, c.GetConfig().QueryTimeout)
-		defer cancelFunc()
+		ctx, _ = context.WithTimeout(ctx, c.GetConfig().QueryTimeout)
 	}
 
 	mTime1 := gtime.TimestampMilli()


### PR DESCRIPTION
该取消函数会导致设置QueryTimeout后通过gdb拿到的数据不完整。因为函数退出的时候关闭了rowsi的mysqlConn。