### PR TITLE
fix gfsnotify recursive

### DIFF
--- a/os/gfsnotify/gfsnotify_watcher_loop.go
+++ b/os/gfsnotify/gfsnotify_watcher_loop.go
@@ -52,10 +52,11 @@ func (w *Watcher) getCallbacks(path string) (callbacks []*Callback) {
 	}
 	// Secondly searches its parent for callbacks.
 	dirPath := fileDir(path)
+	pathIsDir := fileIsDir(path)
 	if v := w.callbacks.Get(dirPath); v != nil {
 		for _, v := range v.(*glist.List).FrontAll() {
 			callback := v.(*Callback)
-			if callback.recursive {
+			if callback.recursive || !pathIsDir {
 				callbacks = append(callbacks, callback)
 			}
 		}


### PR DESCRIPTION
修复在递归监听为 `false` 时，监听文件夹将不起作用。

关闭递归监听时，监听的一级目录不应该直接跳过，这里通过判断如果传入的path不是文件目录时 不管是不是递归监听，应该都是允许执行回调函数的。