### PR TITLE
修复浮点型排序

### DIFF
--- a/util/gutil/gutil_comparator.go
+++ b/util/gutil/gutil_comparator.go
@@ -77,12 +77,28 @@ func ComparatorUint64(a, b interface{}) int {
 
 // ComparatorFloat32 provides a basic comparison on float32.
 func ComparatorFloat32(a, b interface{}) int {
-	return int(gconv.Float32(a) - gconv.Float32(b))
+	aFloat := gconv.Float64(a)
+	bFloat := gconv.Float64(b)
+	if aFloat == bFloat{
+		return 0
+	}
+	if aFloat > bFloat{
+		return 1
+	}
+	return -1
 }
 
 // ComparatorFloat64 provides a basic comparison on float64.
 func ComparatorFloat64(a, b interface{}) int {
-	return int(gconv.Float64(a) - gconv.Float64(b))
+	aFloat := gconv.Float64(a)
+	bFloat := gconv.Float64(b)
+	if aFloat == bFloat{
+		return 0
+	}
+	if aFloat > bFloat{
+		return 1
+	}
+	return -1
 }
 
 // ComparatorByte provides a basic comparison on byte.


### PR DESCRIPTION
原因：
返回值，强制转成 int 类型，会导致浮点型比较不准确，例如：0.33，转成 int 类型时，会变成 0