### PR TITLE
add timezone configuration for package gdb

### DIFF
--- a/database/gdb/gdb_core_config.go
+++ b/database/gdb/gdb_core_config.go
@@ -36,6 +36,7 @@ type ConfigNode struct {
 	DryRun               bool          `json:"dryRun"`               // (Optional) Dry run, which does SELECT but no INSERT/UPDATE/DELETE statements.
 	Weight               int           `json:"weight"`               // (Optional) Weight for load balance calculating, it's useless if there's just one node.
 	Charset              string        `json:"charset"`              // (Optional, "utf8mb4" in default) Custom charset when operating on database.
+	Timezone             string        `json:"timezone"`             // (Optional) Sets the time zone for displaying and interpreting time stamps.
 	LinkInfo             string        `json:"link"`                 // (Optional) Custom link information, when it is used, configuration Host/Port/User/Pass/Name are ignored.
 	MaxIdleConnCount     int           `json:"maxIdle"`              // (Optional) Max idle connection configuration for underlying connection pool.
 	MaxOpenConnCount     int           `json:"maxOpen"`              // (Optional) Max open connection configuration for underlying connection pool.

--- a/database/gdb/gdb_driver_mysql.go
+++ b/database/gdb/gdb_driver_mysql.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 
 	"github.com/gogf/gf/errors/gerror"
 	"github.com/gogf/gf/internal/intlog"
@@ -47,6 +48,9 @@ func (d *DriverMysql) Open(config *ConfigNode) (*sql.DB, error) {
 			"%s:%s@tcp(%s:%s)/%s?charset=%s",
 			config.User, config.Pass, config.Host, config.Port, config.Name, config.Charset,
 		)
+		if config.Timezone != "" {
+			source = fmt.Sprintf("%s&loc=%s", source, url.QueryEscape(config.Timezone))
+		}
 	}
 	intlog.Printf("Open: %s", source)
 	if db, err := sql.Open("mysql", source); err == nil {

--- a/database/gdb/gdb_driver_pgsql.go
+++ b/database/gdb/gdb_driver_pgsql.go
@@ -47,6 +47,9 @@ func (d *DriverPgsql) Open(config *ConfigNode) (*sql.DB, error) {
 			"user=%s password=%s host=%s port=%s dbname=%s sslmode=disable",
 			config.User, config.Pass, config.Host, config.Port, config.Name,
 		)
+		if config.Timezone != "" {
+			source = fmt.Sprintf("%s timezone=%s", source, config.Timezone)
+		}
 	}
 	intlog.Printf("Open: %s", source)
 	if db, err := sql.Open("postgres", source); err == nil {
@@ -135,9 +138,9 @@ func (d *DriverPgsql) TableFields(ctx context.Context, table string, schema ...s
 			result       Result
 			link, err    = d.SlaveLink(useSchema)
 			structureSql = fmt.Sprintf(`
-SELECT a.attname AS field, t.typname AS type FROM pg_class c, pg_attribute a 
+SELECT a.attname AS field, t.typname AS type FROM pg_class c, pg_attribute a
 LEFT OUTER JOIN pg_description b ON a.attrelid=b.objoid AND a.attnum = b.objsubid,pg_type t
-WHERE c.relname = '%s' and a.attnum > 0 and a.attrelid = c.oid and a.atttypid = t.oid 
+WHERE c.relname = '%s' and a.attnum > 0 and a.attrelid = c.oid and a.atttypid = t.oid
 ORDER BY a.attnum`,
 				strings.ToLower(table),
 			)


### PR DESCRIPTION
由于gdb在格式化SQL时，gtime.Time类型为Y-m-d H:i:s，不带时区，此时如果数据库时区和程序的不一致，就会导致存入的时间丢时区。

所以gdb配置增加了timezone，可以在连接数据库时指定时区，避免以上问题