### PR TITLE
add gutil.SliceToMapWithColumnAsKey

### DIFF
--- a/util/gutil/gutil_slice.go
+++ b/util/gutil/gutil_slice.go
@@ -65,3 +65,29 @@ func SliceToMap(slice interface{}) map[string]interface{} {
 	}
 	return nil
 }
+
+// SliceToMapWithColumnAsKey converts slice type variable `slice` to `map[interface{}]interface{}`
+// The value of specified column use as the key for returned map.
+// Eg:
+// SliceToMapWithColumnAsKey([{"K1": "v1", "K2": 1}, {"K1": "v2", "K2": 2}], "K1") => {"v1": {"K1": "v1", "K2": 1}, "v2": {"K1": "v2", "K2": 2}}
+// SliceToMapWithColumnAsKey([{"K1": "v1", "K2": 1}, {"K1": "v2", "K2": 2}], "K2") => {1: {"K1": "v1", "K2": 1}, 2: {"K1": "v2", "K2": 2}}
+func SliceToMapWithColumnAsKey(slice interface{}, key interface{}) map[interface{}]interface{} {
+	var (
+		reflectValue = reflect.ValueOf(slice)
+		reflectKind  = reflectValue.Kind()
+	)
+	for reflectKind == reflect.Ptr {
+		reflectValue = reflectValue.Elem()
+		reflectKind = reflectValue.Kind()
+	}
+	data := make(map[interface{}]interface{})
+	switch reflectKind {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < reflectValue.Len(); i++ {
+			if k, ok := ItemValue(reflectValue.Index(i), key); ok {
+				data[k] = reflectValue.Index(i).Interface()
+			}
+		}
+	}
+	return data
+}

--- a/util/gutil/gutil_z_unit_slice_test.go
+++ b/util/gutil/gutil_z_unit_slice_test.go
@@ -35,3 +35,23 @@ func Test_SliceToMap(t *testing.T) {
 		t.Assert(m, nil)
 	})
 }
+
+func Test_SliceToMapWithColumnAsKey(t *testing.T) {
+	m1 := g.Map{"K1": "v1", "K2": 1}
+	m2 := g.Map{"K1": "v2", "K2": 2}
+	s := g.Slice{m1, m2}
+	gtest.C(t, func(t *gtest.T) {
+		m := gutil.SliceToMapWithColumnAsKey(s, "K1")
+		t.Assert(m, g.MapAnyAny{
+			"v1": m1,
+			"v2": m2,
+		})
+	})
+	gtest.C(t, func(t *gtest.T) {
+		m := gutil.SliceToMapWithColumnAsKey(s, "K2")
+		t.Assert(m, g.MapAnyAny{
+			1: m1,
+			2: m2,
+		})
+	})
+}


### PR DESCRIPTION
增加gutil.SliceToMapWithColumnAsKey方法

把struct slice或者map slice，指定一列的值作为key，生成一个map

例如
```go
package main

import (
	"github.com/gogf/gf/frame/g"
	"github.com/gogf/gf/util/gutil"
)

type data struct {
	ID   int
	Name string
}

func main() {
	d1 := &data{1, "a"}
	d2 := &data{2, "b"}
	d3 := &data{3, "c"}
	d := []*data{d1, d2, d3}

	res := gutil.SliceToMapWithColumnAsKey(d, "ID")
	g.Log().Debugf("res: %#v", res[1])
	g.Log().Debugf("res: %#v", res[1].(*data).Name)

	res2 := gutil.SliceToMapWithColumnAsKey(d, "Name")
	g.Log().Debugf("res2: %#v", res2["b"])
	g.Log().Debugf("res2: %#v", res2["b"].(*data).Name)

	m1 := g.Map{"id": 1, "name": "a"}
	m2 := g.Map{"id": 2, "name": "b"}
	m3 := g.Map{"id": 3, "name": "c"}
	m := []g.Map{m1, m2, m3}

	res3 := gutil.SliceToMapWithColumnAsKey(m, "id")
	g.Log().Debugf("res3: %#v", res3[1])
	g.Log().Debugf("res3: %#v", res3[1].(g.Map)["name"])
}
```

输出
```
2021-06-09 18:57:08.742 [DEBU] res: &main.data{ID:1, Name:"a"} 
2021-06-09 18:57:08.742 [DEBU] res: "a" 
2021-06-09 18:57:08.742 [DEBU] res2: &main.data{ID:2, Name:"b"} 
2021-06-09 18:57:08.742 [DEBU] res2: "b" 
2021-06-09 18:57:08.742 [DEBU] res3: map[string]interface {}{"id":1, "name":"a"} 
2021-06-09 18:57:08.742 [DEBU] res3: "a" 
```