### PR TITLE
add GetCtx for gdb.TX

### DIFF
--- a/database/gdb/gdb_core_transaction.go
+++ b/database/gdb/gdb_core_transaction.go
@@ -182,6 +182,11 @@ func (tx *TX) transactionKeyForNestedPoint() string {
 	return tx.db.GetCore().QuoteWord(transactionPointerPrefix + gconv.String(tx.transactionCount))
 }
 
+// GetCtx returns the context for current transaction.
+func (tx *TX) GetCtx() context.Context {
+	return tx.ctx
+}
+
 // Ctx sets the context for current transaction.
 func (tx *TX) Ctx(ctx context.Context) *TX {
 	tx.ctx = ctx


### PR DESCRIPTION
### 场景
自定义gdb driver重写Transaction时，发现Transaction内部如果有注入context数据，在Transaction完成后就无法再拿到内部context数据。

通过gdb.TX增加获取context的方法，可以带出内部context


### 示例

```go
func (d *DriverPgsql) Transaction(ctx context.Context, f func(ctx context.Context, tx *gdb.TX) error) error {
    var internalCtx context.Context

    nf := func(ctx context.Context, tx *gdb.TX) error {
        err := f(ctx, tx)
        internalCtx = tx.GetCtx()
        return err
    }

    err := d.DriverPgsql.Transaction(ctx, nf)

    if err == nil {
        // use internalCtx
    }   
    
    return err
}   

```

@gqcn 这个有更合适的方法搞定么