### PR TITLE
fix tcp http demo error content-length

### DIFF
--- a/.example/net/gtcp/gtcp_conn.go
+++ b/.example/net/gtcp/gtcp_conn.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/gogf/gf/net/gtcp"
-	"strconv"
+	"github.com/gogf/gf/util/gconv"
 )
 
 func main() {
@@ -31,10 +31,7 @@ func main() {
 			// 获得页面内容长度
 			if contentLength == 0 && len(array) == 2 && bytes.EqualFold([]byte("Content-Length"), array[0]) {
 				// http 以\r\n换行，需要把\r也去掉
-				contentLength, err = strconv.Atoi(string(array[1][:len(array[1])-1]))
-				if err != nil {
-					fmt.Println(err)
-				}
+				contentLength = gconv.Int(string(array[1][:len(array[1])-1]))
 			}
 			header = append(header, data...)
 			header = append(header, '\n')

--- a/.example/net/gtcp/gtcp_conn.go
+++ b/.example/net/gtcp/gtcp_conn.go
@@ -32,9 +32,9 @@ func main() {
 			if contentLength == 0 && len(array) == 2 && bytes.EqualFold([]byte("Content-Length"), array[0]) {
 				// http 以\r\n换行，需要把\r也去掉
 				contentLength, err = strconv.Atoi(string(array[1][:len(array[1])-1]))
-                		if err != nil {
-                    			fmt.Println(err)
-                		}
+				if err != nil {
+					fmt.Println(err)
+				}
 			}
 			header = append(header, data...)
 			header = append(header, '\n')


### PR DESCRIPTION
原来的demo获取的content-length不正确，并且[]byte最后一位为\r，需要去除