### PR TITLE
修复gini组件不能正确获取带“=”值的Bug

### DIFF
--- a/encoding/gini/gini.go
+++ b/encoding/gini/gini.go
@@ -65,7 +65,7 @@ func Decode(data []byte) (res map[string]interface{}, err error) {
 
 		if strings.Contains(lineStr, "=") && haveSection {
 			values := strings.Split(lineStr, "=")
-			fieldMap[strings.TrimSpace(values[0])] = strings.TrimSpace(strings.Join(values[1:], ""))
+			fieldMap[strings.TrimSpace(values[0])] = strings.TrimSpace(strings.Join(values[1:], "="))
 			res[section] = fieldMap
 		}
 	}

--- a/encoding/gini/gini_test.go
+++ b/encoding/gini/gini_test.go
@@ -22,6 +22,7 @@ aa=bb
 ip = 127.0.0.1
 port=9001
 enable=true
+command=/bin/echo "gf=GoFrame"
 
 	[DBINFO]
 	type=mysql
@@ -40,6 +41,7 @@ func TestDecode(t *testing.T) {
 		}
 		t.Assert(res["addr"].(map[string]interface{})["ip"], "127.0.0.1")
 		t.Assert(res["addr"].(map[string]interface{})["port"], "9001")
+		t.Assert(res["addr"].(map[string]interface{})["command"], `/bin/echo "gf=GoFrame"`)
 		t.Assert(res["DBINFO"].(map[string]interface{})["user"], "root")
 		t.Assert(res["DBINFO"].(map[string]interface{})["type"], "mysql")
 		t.Assert(res["键"].(map[string]interface{})["呵呵"], "值")


### PR DESCRIPTION
当ini的配置值中含有"="时候，不能正确解析。