### PR TITLE
feat:add trace db.statement、host.name

### DIFF
--- a/database/gdb/gdb_core_tracing.go
+++ b/database/gdb/gdb_core_tracing.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gogf/gf/v2"
@@ -54,6 +55,7 @@ func (c *Core) addSqlToTracing(ctx context.Context, sql *Sql) {
 	labels = append(labels, gtrace.CommonLabels()...)
 	labels = append(labels,
 		attribute.String(tracingAttrDbType, c.db.GetConfig().Type),
+		attribute.String(string(semconv.DBStatementKey), sql.Format),
 	)
 	if c.db.GetConfig().Host != "" {
 		labels = append(labels, attribute.String(tracingAttrDbHost, c.db.GetConfig().Host))

--- a/net/gtrace/gtrace.go
+++ b/net/gtrace/gtrace.go
@@ -12,16 +12,17 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gogf/gf/v2/internal/command"
-	"github.com/gogf/gf/v2/util/gconv"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/gogf/gf/v2/container/gmap"
 	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/internal/command"
 	"github.com/gogf/gf/v2/net/gipv4"
+	"github.com/gogf/gf/v2/util/gconv"
 )
 
 const (
@@ -68,6 +69,7 @@ func CommonLabels() []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String(tracingCommonKeyIpHostname, hostname),
 		attribute.String(tracingCommonKeyIpIntranet, intranetIpStr),
+		semconv.HostNameKey.String(hostname),
 	}
 }
 


### PR DESCRIPTION
Tip: the statistics of SQL data are based on Tagkey db.statement and db.instance, for example: tracer.activeSpan () .setTag ("db.statement", "SELECT * FROM wuser_table"); see [the Span Tag specification of OpenTracing ](https://github.com/opentracing-contrib/opentracing-specification-zh/blob/master/semantic_conventions.md)