### PR TITLE
ghttp_request.go GetRemoteIp ipv6 fix

### DIFF
--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -216,7 +216,7 @@ func (r *Request) GetClientIp() string {
 func (r *Request) GetRemoteIp() string {
 	array, _ := gregex.MatchString(`(.+):(\d+)`, r.RemoteAddr)
 	if len(array) > 1 {
-		return array[1]
+		return strings.Trim(array[1], "[]")
 	}
 	return r.RemoteAddr
 }

--- a/net/ghttp/ghttp_z_unit_feature_ip_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_ip_test.go
@@ -32,10 +32,14 @@ func TestRequest_GetRemoteIp(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		client := g.Client()
-		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", p))
+		clientV4 := g.Client()
+		clientV4.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", p))
 
-		t.Assert(client.GetContent(ctx, "/"), "127.0.0.1")
+		clientV6 := g.Client()
+		clientV6.SetPrefix(fmt.Sprintf("http://[::1]:%d", p))
+
+		t.Assert(clientV4.GetContent(ctx, "/"), "127.0.0.1")
+		t.Assert(clientV6.GetContent(ctx, "/"), "::1")
 	})
 
 }


### PR DESCRIPTION
# Why is this pull request needed and what does it do

- IPv6 address only use square bracket when  in conjunction with other parts such as user:pass and :port.
- Literal IPv6 addresses with square bracket can't be parsed by Golang offical `net.ParseIP`,.As the name `GetRemoteIp ` ,we just want a parsable IP,not the literal form in URI.

- IPv6地址只有在与其他部分（如user:pass和:port）结合时才使用方括号。
- 带有方括号的IPv6地址不能被Golang官方的`net.ParseIP`解析。一个可解析的IPv6地址，不应该包含只URI中出现的，为了防止歧义使用的方括号。