### PR TITLE
Fix gdb Order

### DIFF
--- a/database/gdb/gdb_model_order_group.go
+++ b/database/gdb/gdb_model_order_group.go
@@ -22,7 +22,7 @@ func (m *Model) Order(orderBy ...string) *Model {
 	if model.orderBy != "" {
 		model.orderBy += ","
 	}
-	model.orderBy = model.db.GetCore().QuoteString(strings.Join(orderBy, " "))
+	model.orderBy += model.db.GetCore().QuoteString(strings.Join(orderBy, " "))
 	return model
 }
 

--- a/database/gdb/gdb_z_mysql_model_test.go
+++ b/database/gdb/gdb_z_mysql_model_test.go
@@ -438,7 +438,7 @@ func Test_Model_Clone(t *testing.T) {
 	defer dropTable(table)
 
 	gtest.C(t, func(t *gtest.T) {
-		md := db.Model(table).Where("id IN(?)", g.Slice{1, 3})
+		md := db.Model(table).Safe(true).Where("id IN(?)", g.Slice{1, 3})
 		count, err := md.Count()
 		t.AssertNil(err)
 


### PR DESCRIPTION
```
if model.orderBy != "" {
    model.orderBy += ","
}
```
既然前边已经有了这样的判断，说明Order方法本意是允许多次调用`.OrderDesc("a").OrderDesc("b")`来生成类似于`order by a desc, b desc`这样的查询语句的，所以这里应该使用`+=`而不是`=`