### PR TITLE
gdb: overload DriverPgsql.ConvertDataForRecord to handle array structure

### DIFF
--- a/database/gdb/gdb_driver_pgsql.go
+++ b/database/gdb/gdb_driver_pgsql.go
@@ -230,8 +230,8 @@ func (d *DriverPgsql) convertDataForRecordValue(ctx context.Context, value inter
 		rvKind = rvValue.Kind()
 	}
 	switch rvKind {
-	case reflect.Slice, reflect.Array:
-	// only deal with slice or array now
+	case reflect.Slice:
+	// only deal with slice now
 	default:
 		return nil, false
 	}

--- a/database/gdb/gdb_z_pgsql_feature_model_struct_test.go
+++ b/database/gdb/gdb_z_pgsql_feature_model_struct_test.go
@@ -1,0 +1,27 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gdb_test
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/stretchr/testify/assert"
+)
+
+// fix https://github.com/gogf/gf/issues/1531
+func Test_Func_PG_ConvertDataForRecord(t *testing.T) {
+	d := new(gdb.DriverPgsql)
+	data := d.ConvertDataForRecord(ctx, g.Map{
+		"code":  "test",
+		"path":  []string{"c700a87b-e4d8-4aa1-aa18-38ebe107d0ae", "330cba76-8a69-4321-b783-199c53df64ae"},
+		"path2": []string{},
+	})
+	assert.Equal(t, gdb.Raw("ARRAY['c700a87b-e4d8-4aa1-aa18-38ebe107d0ae','330cba76-8a69-4321-b783-199c53df64ae']"), data["path"])
+	assert.Equal(t, gdb.Raw("ARRAY[]"), data["path2"])
+}

--- a/database/gdb/gdb_z_pgsql_feature_model_struct_test.go
+++ b/database/gdb/gdb_z_pgsql_feature_model_struct_test.go
@@ -11,17 +11,18 @@ import (
 
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/frame/g"
-	"github.com/stretchr/testify/assert"
+	"github.com/gogf/gf/v2/test/gtest"
 )
 
 // fix https://github.com/gogf/gf/issues/1531
 func Test_Func_PG_ConvertDataForRecord(t *testing.T) {
-	d := new(gdb.DriverPgsql)
-	data := d.ConvertDataForRecord(ctx, g.Map{
-		"code":  "test",
-		"path":  []string{"c700a87b-e4d8-4aa1-aa18-38ebe107d0ae", "330cba76-8a69-4321-b783-199c53df64ae"},
-		"path2": []string{},
+	gtest.C(t, func(t *gtest.T) {
+		d := new(gdb.DriverPgsql)
+		data := d.ConvertDataForRecord(ctx, g.Map{
+			"path":  []string{"c700a87b-e4d8-4aa1-aa18-38ebe107d0ae", "330cba76-8a69-4321-b783-199c53df64ae"},
+			"path2": []string{},
+		})
+		t.Assert(data["path"], gdb.Raw("ARRAY['c700a87b-e4d8-4aa1-aa18-38ebe107d0ae','330cba76-8a69-4321-b783-199c53df64ae']"))
+		t.Assert(data["path2"], gdb.Raw("ARRAY[]"))
 	})
-	assert.Equal(t, gdb.Raw("ARRAY['c700a87b-e4d8-4aa1-aa18-38ebe107d0ae','330cba76-8a69-4321-b783-199c53df64ae']"), data["path"])
-	assert.Equal(t, gdb.Raw("ARRAY[]"), data["path2"])
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #1531

Problem Summary:

The `DriverPgsql` using base-class's `ConvertDataForRecord` function to convert slice

### What is changed and how it works?

Add a `DriverPgsql.ConvertDataForRecord` to handle array type, and the other type still invoke `Core.ConvertDataForRecord`

