### PR TITLE
gdb pgsql skip dropped fields

### DIFF
--- a/database/gdb/gdb_driver_pgsql.go
+++ b/database/gdb/gdb_driver_pgsql.go
@@ -158,7 +158,7 @@ FROM pg_attribute a
          left join pg_description b ON a.attrelid=b.objoid AND a.attnum = b.objsubid
          left join  pg_type t ON  a.atttypid = t.oid
          left join information_schema.columns ic on ic.column_name = a.attname and ic.table_name = c.relname
-WHERE c.relname = '%s' and a.attnum > 0
+WHERE c.relname = '%s' and a.attisdropped is false and a.attnum > 0
 ORDER BY a.attnum`,
 					strings.ToLower(table),
 				)


### PR DESCRIPTION
变更内容：
pgsql驱动TableFields方法，查询SQL增加attisdropped条件

变更原因：
pgsql在删除字段后，TableFields方法没加过滤条件，仍可获取到一个dropped字段名，导致之后的SQL全部执行失败

[attisdropped字段说明](https://www.postgresql.org/docs/14/catalog-pg-attribute.html)