### PR TITLE
fix(fix bug , add nexttime feature): ServeFileDownload filename doubl…

### DIFF
--- a/net/ghttp/ghttp_response.go
+++ b/net/ghttp/ghttp_response.go
@@ -92,7 +92,7 @@ func (r *Response) ServeFileDownload(path string, name ...string) {
 	}
 	r.Header().Set("Content-Type", "application/force-download")
 	r.Header().Set("Accept-Ranges", "bytes")
-	r.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="%s"`, url.QueryEscape(downloadName)))
+	r.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename=%s`, url.QueryEscape(downloadName)))
 	r.Server.serveFile(r.Request, serveFile)
 }
 


### PR DESCRIPTION
…e quotes cause underscores before and after the final file