### PR TITLE
fix: server access logs contain the protocol used between the server …

### DIFF
--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -224,8 +224,11 @@ func (r *Request) GetRemoteIp() string {
 
 // GetUrl returns current URL of this request.
 func (r *Request) GetUrl() string {
-	scheme := "http"
-	proto := r.Header.Get("X-Forwarded-Proto")
+	var (
+		scheme = "http"
+		proto  = r.Header.Get("X-Forwarded-Proto")
+	)
+
 	if r.TLS != nil || (proto != "" && strings.ToLower(proto) == "https") {
 		scheme = "https"
 	}

--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gogf/gf/v2/os/gtime"
 	"github.com/gogf/gf/v2/os/gview"
 	"github.com/gogf/gf/v2/text/gregex"
+	"github.com/gogf/gf/v2/text/gstr"
 	"github.com/gogf/gf/v2/util/guid"
 )
 
@@ -229,7 +230,7 @@ func (r *Request) GetUrl() string {
 		proto  = r.Header.Get("X-Forwarded-Proto")
 	)
 
-	if r.TLS != nil || (proto != "" && strings.ToLower(proto) == "https") {
+	if r.TLS != nil || gstr.Equal(proto, "https") {
 		scheme = "https"
 	}
 	return fmt.Sprintf(`%s://%s%s`, scheme, r.Host, r.URL.String())

--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -225,7 +225,8 @@ func (r *Request) GetRemoteIp() string {
 // GetUrl returns current URL of this request.
 func (r *Request) GetUrl() string {
 	scheme := "http"
-	if r.TLS != nil {
+	proto := r.Header.Get("X-Forwarded-Proto")
+	if r.TLS != nil || (proto != "" && strings.ToLower(proto) == "https") {
 		scheme = "https"
 	}
 	return fmt.Sprintf(`%s://%s%s`, scheme, r.Host, r.URL.String())

--- a/net/ghttp/ghttp_server_log.go
+++ b/net/ghttp/ghttp_server_log.go
@@ -18,8 +18,12 @@ func (s *Server) handleAccessLog(r *Request) {
 	if !s.IsAccessLogEnabled() {
 		return
 	}
-	scheme := "http"
-	if r.TLS != nil {
+	var (
+		scheme = "http"
+		proto  = r.Header.Get("X-Forwarded-Proto")
+	)
+
+	if r.TLS != nil || gstr.Equal(proto, "https") {
 		scheme = "https"
 	}
 	s.Logger().File(s.config.AccessLogPattern).

--- a/net/ghttp/ghttp_server_log.go
+++ b/net/ghttp/ghttp_server_log.go
@@ -47,9 +47,10 @@ func (s *Server) handleErrorLog(err error, r *Request) {
 		code          = gerror.Code(err)
 		scheme        = "http"
 		codeDetail    = code.Detail()
+		proto         = r.Header.Get("X-Forwarded-Proto")
 		codeDetailStr string
 	)
-	if r.TLS != nil {
+	if r.TLS != nil || gstr.Equal(proto, "https") {
 		scheme = "https"
 	}
 	if codeDetail != nil {

--- a/net/ghttp/ghttp_server_swagger.go
+++ b/net/ghttp/ghttp_server_swagger.go
@@ -7,6 +7,8 @@
 package ghttp
 
 import (
+	"fmt"
+
 	"github.com/gogf/gf/v2/text/gstr"
 )
 
@@ -45,7 +47,7 @@ func (s *Server) swaggerUI(r *Request) {
 	if r.StaticFile != nil && r.StaticFile.File != nil && r.StaticFile.IsDir {
 		content := gstr.ReplaceByMap(swaggerUITemplate, map[string]string{
 			swaggerUIDocURLPlaceHolder:  s.config.OpenApiPath,
-			swaggerUIDocNamePlaceHolder: gstr.TrimRight(r.GetUrl(), "/") + "/" + swaggerUIDocName,
+			swaggerUIDocNamePlaceHolder: gstr.TrimRight(fmt.Sprintf(`//%s%s`, r.Host, r.URL.String()), "/") + "/" + swaggerUIDocName,
 		})
 		r.Response.Write(content)
 		r.ExitAll()


### PR DESCRIPTION
…and the load balancer, but not the protocol used between the client and the load balancer

https://github.com/gogf/gf/issues/1655