### PR TITLE
feat: support custom listener

### DIFF
--- a/net/ghttp/ghttp_server.go
+++ b/net/ghttp/ghttp_server.go
@@ -262,12 +262,6 @@ func (s *Server) getListenAddress() string {
 	} else {
 		port = gconv.Int(array[0])
 	}
-	if s.config.Listeners != nil {
-		for _, v := range s.config.Listeners {
-			portArray := gstr.SplitAndTrim(v.Addr().String(), ":")
-			port = gconv.Int(portArray[len(portArray)-1])
-		}
-	}
 	return fmt.Sprintf(`http://%s:%d`, host, port)
 }
 

--- a/net/ghttp/ghttp_server.go
+++ b/net/ghttp/ghttp_server.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -503,14 +502,10 @@ func (s *Server) startServer(fdMap listenerFdMap) {
 					fd = gconv.Int(addrAndFd[1])
 				}
 			}
-			var ln net.Listener
-			if s.config.Listeners != nil {
-				ln = s.config.Listeners[v]
-			}
 			if fd > 0 {
-				s.servers = append(s.servers, s.newGracefulServer(itemFunc, ln, fd))
+				s.servers = append(s.servers, s.newGracefulServer(itemFunc, fd))
 			} else {
-				s.servers = append(s.servers, s.newGracefulServer(itemFunc, ln))
+				s.servers = append(s.servers, s.newGracefulServer(itemFunc))
 			}
 			s.servers[len(s.servers)-1].isHttps = true
 		}
@@ -542,14 +537,10 @@ func (s *Server) startServer(fdMap listenerFdMap) {
 				fd = gconv.Int(addrAndFd[1])
 			}
 		}
-		var ln net.Listener
-		if s.config.Listeners != nil {
-			ln = s.config.Listeners[v]
-		}
 		if fd > 0 {
-			s.servers = append(s.servers, s.newGracefulServer(itemFunc, ln, fd))
+			s.servers = append(s.servers, s.newGracefulServer(itemFunc, fd))
 		} else {
-			s.servers = append(s.servers, s.newGracefulServer(itemFunc, ln))
+			s.servers = append(s.servers, s.newGracefulServer(itemFunc))
 		}
 	}
 	// Start listening asynchronously.

--- a/net/ghttp/ghttp_server_config.go
+++ b/net/ghttp/ghttp_server_config.go
@@ -9,6 +9,7 @@ package ghttp
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -49,6 +50,9 @@ type ServerConfig struct {
 
 	// HTTPSAddr specifies the HTTPS addresses, multiple addresses joined using char ','.
 	HTTPSAddr string `json:"httpsAddr"`
+
+	// Listeners specifies custom listeners, size should match address provided
+	Listeners map[string]net.Listener `json:"listeners"`
 
 	// HTTPSCertPath specifies certification file path for HTTPS service.
 	HTTPSCertPath string `json:"httpsCertPath"`
@@ -406,6 +410,10 @@ func (s *Server) SetHTTPSPort(port ...int) {
 			s.config.HTTPSAddr += ":" + strconv.Itoa(v)
 		}
 	}
+}
+
+func (s *Server) SetListener(ln map[string]net.Listener) {
+	s.config.Listeners = ln
 }
 
 // EnableHTTPS enables HTTPS with given certification and key files for the server.

--- a/net/ghttp/ghttp_server_config.go
+++ b/net/ghttp/ghttp_server_config.go
@@ -420,11 +420,10 @@ func (s *Server) SetHTTPSPort(port ...int) {
 // SetListener set the custom listener for the server.
 // It will overwrite the address you specified before.
 func (s *Server) SetListener(l net.Listener) error {
-	addrArray := gstr.SplitAndTrim(l.Addr().String(), ":")
-	port, err := strconv.Atoi(addrArray[len(addrArray)-1])
-	if err != nil {
-		return err
+	if l == nil {
+		return gerror.NewCodef(gcode.CodeInvalidParameter, "listener is nil")
 	}
+	port := (l.Addr().(*net.TCPAddr)).Port
 	s.config.Address = fmt.Sprintf(":%d", port)
 	s.config.Listeners = map[int]net.Listener{port: l}
 	return nil
@@ -435,16 +434,12 @@ func (s *Server) SetListener(l net.Listener) error {
 // If the listener's port not match the port provided in map, the method will return error.
 func (s *Server) SetListeners(listeners map[int]net.Listener) error {
 	for k, v := range listeners {
-		addrArray := gstr.SplitAndTrim(v.Addr().String(), ":")
-		port, err := strconv.Atoi(addrArray[len(addrArray)-1])
-		if err != nil {
-			return err
-		}
-		if port != k {
+		portIndeed := (v.Addr().(*net.TCPAddr)).Port
+		if portIndeed != k {
 			return gerror.NewCodef(
 				gcode.CodeInvalidParameter,
-				"listener specified by port %d should listen at port %d, but got port: %d",
-				k, k, port,
+				"listener specified by port %d listen at port %d indeed",
+				k, portIndeed,
 			)
 		}
 	}

--- a/net/ghttp/ghttp_server_config.go
+++ b/net/ghttp/ghttp_server_config.go
@@ -420,13 +420,13 @@ func (s *Server) SetHTTPSPort(port ...int) {
 // SetListener set the custom listener for the server.
 func (s *Server) SetListener(listeners ...net.Listener) error {
 	if listeners == nil {
-		return gerror.NewCodef(gcode.CodeInvalidParameter, "listener can not be nil")
+		return gerror.NewCodef(gcode.CodeInvalidParameter, "SetListener failed: listener can not be nil")
 	}
 	if len(listeners) > 0 {
 		ports := make([]string, len(listeners))
 		for k, v := range listeners {
 			if v == nil {
-				return gerror.NewCodef(gcode.CodeInvalidParameter, "listener can not be nil")
+				return gerror.NewCodef(gcode.CodeInvalidParameter, "SetListener failed: listener can not be nil")
 			}
 			ports[k] = fmt.Sprintf(":%d", (v.Addr().(*net.TCPAddr)).Port)
 		}

--- a/net/ghttp/ghttp_server_graceful.go
+++ b/net/ghttp/ghttp_server_graceful.go
@@ -55,9 +55,9 @@ func (s *Server) newGracefulServer(address string, fd ...int) *gracefulServer {
 		addrPort, err := strconv.Atoi(addrArray[len(addrArray)-1])
 		if err == nil {
 			for _, v := range s.config.Listeners {
-				listenerPort := (v.Addr().(*net.TCPAddr)).Port
-				if listenerPort == addrPort {
+				if listenerPort := (v.Addr().(*net.TCPAddr)).Port; listenerPort == addrPort {
 					gs.rawListener = v
+					break
 				}
 			}
 		}

--- a/net/ghttp/ghttp_server_graceful.go
+++ b/net/ghttp/ghttp_server_graceful.go
@@ -52,9 +52,14 @@ func (s *Server) newGracefulServer(address string, fd ...int) *gracefulServer {
 	}
 	if s.config.Listeners != nil {
 		addrArray := gstr.SplitAndTrim(address, ":")
-		port, err := strconv.Atoi(addrArray[len(addrArray)-1])
+		addrPort, err := strconv.Atoi(addrArray[len(addrArray)-1])
 		if err == nil {
-			gs.rawListener = s.config.Listeners[port]
+			for _, v := range s.config.Listeners {
+				listenerPort := (v.Addr().(*net.TCPAddr)).Port
+				if listenerPort == addrPort {
+					gs.rawListener = v
+				}
+			}
 		}
 	}
 	return gs

--- a/net/ghttp/ghttp_z_unit_feature_config_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_config_test.go
@@ -8,6 +8,7 @@ package ghttp_test
 
 import (
 	"fmt"
+	"github.com/gogf/gf/v2/net/gtcp"
 	"net"
 	"testing"
 	"time"
@@ -24,12 +25,14 @@ import (
 
 func Test_ConfigFromMap(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
-		ln, err := net.Listen("tcp", ":8199")
+		p, _ := gtcp.GetFreePort()
+		addr := fmt.Sprintf(":%d", p)
+		ln, err := net.Listen("tcp", addr)
 		t.AssertNil(err)
-		listeners := map[int]net.Listener{8199: ln}
+		listeners := []net.Listener{ln}
 
 		m := g.Map{
-			"address":         ":8199",
+			"address":         addr,
 			"listeners":       listeners,
 			"readTimeout":     "60s",
 			"indexFiles":      g.Slice{"index.php", "main.php"},

--- a/net/ghttp/ghttp_z_unit_feature_config_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_config_test.go
@@ -8,6 +8,7 @@ package ghttp_test
 
 import (
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -23,8 +24,13 @@ import (
 
 func Test_ConfigFromMap(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
+		ln, err := net.Listen("tcp", ":8199")
+		t.AssertNil(err)
+		listeners := map[int]net.Listener{8199: ln}
+
 		m := g.Map{
 			"address":         ":8199",
+			"listeners":       listeners,
 			"readTimeout":     "60s",
 			"indexFiles":      g.Slice{"index.php", "main.php"},
 			"errorLogEnabled": true,
@@ -38,6 +44,7 @@ func Test_ConfigFromMap(t *testing.T) {
 		d1, _ := time.ParseDuration(gconv.String(m["readTimeout"]))
 		d2, _ := time.ParseDuration(gconv.String(m["cookieMaxAge"]))
 		t.Assert(config.Address, m["address"])
+		t.Assert(config.Listeners, listeners)
 		t.Assert(config.ReadTimeout, d1)
 		t.Assert(config.CookieMaxAge, d2)
 		t.Assert(config.IndexFiles, m["indexFiles"])

--- a/net/ghttp/ghttp_z_unit_feature_custom_listeners_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_custom_listeners_test.go
@@ -76,8 +76,8 @@ func Test_SetWrongCustomListeners(t *testing.T) {
 		s.SetAddr(":8199")
 		ln, err := net.Listen("tcp", ":8299")
 		t.AssertNil(err)
-		s.SetListeners(map[int]net.Listener{8199: ln})
-
+		err = s.SetListeners(map[int]net.Listener{8199: ln})
+		t.AssertNQ(err, nil)
 		s.Start()
 		defer s.Shutdown()
 

--- a/net/ghttp/ghttp_z_unit_feature_custom_listeners_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_custom_listeners_test.go
@@ -16,6 +16,29 @@ import (
 	"github.com/gogf/gf/v2/net/ghttp"
 )
 
+func Test_SetCustomListener(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		s := g.Server()
+		s.Group("/", func(group *ghttp.RouterGroup) {
+			group.GET("/test", func(r *ghttp.Request) {
+				r.Response.Write("test")
+			})
+		})
+		ln, err := net.Listen("tcp", ":8199")
+		t.AssertNil(err)
+		err = s.SetListener(ln)
+		t.AssertNil(err)
+
+		s.Start()
+		defer s.Shutdown()
+
+		time.Sleep(100 * time.Millisecond)
+		s.GetListenedPort()
+
+		t.AssertEQ(s.GetListenedPort(), 8199)
+	})
+}
+
 func Test_SetRightCustomListeners(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		s := g.Server()
@@ -27,7 +50,10 @@ func Test_SetRightCustomListeners(t *testing.T) {
 		s.SetAddr(":8199")
 		ln, err := net.Listen("tcp", ":8199")
 		t.AssertNil(err)
-		s.SetListeners(map[int]net.Listener{8199: ln})
+		err = s.SetListeners(map[int]net.Listener{8299: ln})
+		t.AssertNE(err, nil)
+		err = s.SetListeners(map[int]net.Listener{8199: ln})
+		t.AssertNil(err)
 
 		s.Start()
 		defer s.Shutdown()

--- a/net/ghttp/ghttp_z_unit_feature_custom_listeners_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_custom_listeners_test.go
@@ -1,0 +1,63 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package ghttp_test
+
+import (
+	"github.com/gogf/gf/v2/test/gtest"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/net/ghttp"
+)
+
+func Test_SetRightCustomListeners(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		s := g.Server()
+		s.Group("/", func(group *ghttp.RouterGroup) {
+			group.GET("/test", func(r *ghttp.Request) {
+				r.Response.Write("test")
+			})
+		})
+		s.SetAddr(":8199")
+		ln, err := net.Listen("tcp", ":8199")
+		t.AssertNil(err)
+		s.SetListeners(map[int]net.Listener{8199: ln})
+
+		s.Start()
+		defer s.Shutdown()
+
+		time.Sleep(100 * time.Millisecond)
+		s.GetListenedPort()
+
+		t.AssertEQ(s.GetListenedPort(), 8199)
+	})
+}
+
+func Test_SetWrongCustomListeners(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		s := g.Server()
+		s.Group("/", func(group *ghttp.RouterGroup) {
+			group.GET("/test", func(r *ghttp.Request) {
+				r.Response.Write("test")
+			})
+		})
+		s.SetAddr(":8199")
+		ln, err := net.Listen("tcp", ":8299")
+		t.AssertNil(err)
+		s.SetListeners(map[int]net.Listener{8199: ln})
+
+		s.Start()
+		defer s.Shutdown()
+
+		time.Sleep(100 * time.Millisecond)
+		s.GetListenedPort()
+
+		t.AssertEQ(s.GetListenedPort(), 8199)
+	})
+}


### PR DESCRIPTION
Add SetListener method for supporting custom listeners.

```go
// 设置单个listener
ln, err := net.Listen("tcp", ":8199")
if err != nil {
  log.Fatal(err)
}
....
s := g.Server()
s.SetListener(ln)
...
s.Run()
```

```go
// 设置多个listener
ln1, err := net.Listen("tcp", ":8199")
if err != nil {
  log.Fatal(err)
}
ln2, err := net.Listen("tcp", ":8299")
if err != nil {
  log.Fatal(err)
}
....
s := g.Server()
s.SetListener(ln1, ln2)
...
s.Run()
```

另外有相关的issue
https://github.com/gogf/gf/issues/1043