### PR TITLE
fix timezone bug when persisting *gtime.Time to db #1714

### DIFF
--- a/database/gdb/gdb_z_init_test.go
+++ b/database/gdb/gdb_z_init_test.go
@@ -187,7 +187,7 @@ func createTableWithDb(db gdb.DB, table ...string) (name string) {
 	        passport    varchar(45) NULL,
 	        password    char(32) NULL,
 	        nickname    varchar(45) NULL,
-	        create_time timestamp NULL,
+	        create_time timestamp(6) NULL,
 	        PRIMARY KEY (id)
 	    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 	    `, name,

--- a/database/gdb/gdb_z_mysql_model_test.go
+++ b/database/gdb/gdb_z_mysql_model_test.go
@@ -3081,8 +3081,8 @@ func Test_TimeZoneInsert(t *testing.T) {
 		userEntity := &User{}
 		err := db.Model(tableName).Where("id", 1).Unscoped().Scan(&userEntity)
 		t.AssertNil(err)
-		t.Assert(userEntity.CreatedAt.String(), "2020-11-22 04:23:45")
-		t.Assert(userEntity.UpdatedAt.String(), "2020-11-22 05:23:45")
+		t.Assert(userEntity.CreatedAt.String(), "2020-11-22 12:23:45")
+		t.Assert(userEntity.UpdatedAt.String(), "2020-11-22 13:23:45")
 		t.Assert(gtime.NewFromTime(userEntity.DeletedAt).String(), "2020-11-22 06:23:45")
 	})
 }

--- a/os/gtime/gtime_time_wrapper.go
+++ b/os/gtime/gtime_time_wrapper.go
@@ -25,5 +25,5 @@ func (t wrapper) String() string {
 		// Only time.
 		return t.Format("15:04:05")
 	}
-	return t.Format("2006-01-02 15:04:05")
+	return t.Local().Format("2006-01-02 15:04:05.999999999")
 }

--- a/os/gtime/gtime_z_example_basic_test.go
+++ b/os/gtime/gtime_z_example_basic_test.go
@@ -101,7 +101,7 @@ func ExampleConvertZone() {
 	fmt.Println(res)
 
 	// Output:
-	// 2006-01-02 16:04:05
+	// 2006-01-02 15:04:05
 }
 
 func ExampleStrToTimeFormat() {

--- a/os/gtime/gtime_z_example_time_test.go
+++ b/os/gtime/gtime_z_example_time_test.go
@@ -19,7 +19,7 @@ import (
 // The optional parameter can be type of: time.Time/*time.Time, string or integer.
 func ExampleNew() {
 	curTime := "2018-08-08 08:08:08"
-	timer, _ := time.Parse("2006-01-02 15:04:05", curTime)
+	timer, _ := time.ParseInLocation("2006-01-02 15:04:05", curTime, time.Local)
 	t1 := gtime.New(&timer)
 	t2 := gtime.New(curTime)
 	t3 := gtime.New(curTime, "Y-m-d H:i:s")
@@ -51,7 +51,7 @@ func ExampleNow() {
 
 // NewFromTime creates and returns a Time object with given time.Time object.
 func ExampleNewFromTime() {
-	timer, _ := time.Parse("2006-01-02 15:04:05", "2018-08-08 08:08:08")
+	timer, _ := time.ParseInLocation("2006-01-02 15:04:05", "2018-08-08 08:08:08", time.Local)
 	nTime := gtime.NewFromTime(timer)
 
 	fmt.Println(nTime)
@@ -401,7 +401,7 @@ func ExampleTime_EndOfMinute() {
 	fmt.Println(gt1.EndOfMinute())
 
 	// Output:
-	// 2018-08-08 08:08:59
+	// 2018-08-08 08:08:59.999999999
 }
 
 func ExampleTime_EndOfHour() {
@@ -410,7 +410,7 @@ func ExampleTime_EndOfHour() {
 	fmt.Println(gt1.EndOfHour())
 
 	// Output:
-	// 2018-08-08 08:59:59
+	// 2018-08-08 08:59:59.999999999
 }
 
 func ExampleTime_EndOfDay() {
@@ -419,7 +419,7 @@ func ExampleTime_EndOfDay() {
 	fmt.Println(gt1.EndOfDay())
 
 	// Output:
-	// 2018-08-08 23:59:59
+	// 2018-08-08 23:59:59.999999999
 }
 
 func ExampleTime_EndOfWeek() {
@@ -428,7 +428,7 @@ func ExampleTime_EndOfWeek() {
 	fmt.Println(gt1.EndOfWeek())
 
 	// Output:
-	// 2018-08-11 23:59:59
+	// 2018-08-11 23:59:59.999999999
 }
 
 func ExampleTime_EndOfMonth() {
@@ -437,7 +437,7 @@ func ExampleTime_EndOfMonth() {
 	fmt.Println(gt1.EndOfMonth())
 
 	// Output:
-	// 2018-08-31 23:59:59
+	// 2018-08-31 23:59:59.999999999
 }
 
 func ExampleTime_EndOfQuarter() {
@@ -446,7 +446,7 @@ func ExampleTime_EndOfQuarter() {
 	fmt.Println(gt1.EndOfQuarter())
 
 	// Output:
-	// 2018-09-30 23:59:59
+	// 2018-09-30 23:59:59.999999999
 }
 
 func ExampleTime_EndOfHalf() {
@@ -455,7 +455,7 @@ func ExampleTime_EndOfHalf() {
 	fmt.Println(gt1.EndOfHalf())
 
 	// Output:
-	// 2018-12-31 23:59:59
+	// 2018-12-31 23:59:59.999999999
 }
 
 func ExampleTime_EndOfYear() {
@@ -464,7 +464,7 @@ func ExampleTime_EndOfYear() {
 	fmt.Println(gt1.EndOfYear())
 
 	// Output:
-	// 2018-12-31 23:59:59
+	// 2018-12-31 23:59:59.999999999
 }
 
 func ExampleTime_MarshalJSON() {

--- a/os/gtime/gtime_z_unit_time_test.go
+++ b/os/gtime/gtime_z_unit_time_test.go
@@ -157,7 +157,7 @@ func Test_Time_Millisecond(t *testing.T) {
 func Test_Time_String(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		timeTemp := gtime.Now()
-		t.Assert(timeTemp.String(), timeTemp.Time.Format("2006-01-02 15:04:05"))
+		t.Assert(timeTemp.String(), timeTemp.Time.Format("2006-01-02 15:04:05.999999"))
 	})
 }
 


### PR DESCRIPTION
`gtime_time_wrapper.go`
should
`return t.Local().Format("2006-01-02 15:04:05.999999999")`
instead of
`return t.Format("2006-01-02 15:04:05")`
