### PR TITLE
gvalid.aliasNameTagPriority consistent with gconv.StructTagPriority.

### DIFF
--- a/util/gvalid/gvalid.go
+++ b/util/gvalid/gvalid.go
@@ -183,8 +183,8 @@ var (
 		"no":    {},
 	}
 
-	structTagPriority    = []string{"gvalid", "valid", "v"} // structTagPriority specifies the validation tag priority array.
-	aliasNameTagPriority = []string{"param", "params", "p"} // aliasNameTagPriority specifies the alias tag priority array.
+	structTagPriority    = []string{"gvalid", "valid", "v"}                       // structTagPriority specifies the validation tag priority array.
+	aliasNameTagPriority = []string{"gconv", "param", "params", "c", "p", "json"} // aliasNameTagPriority specifies the alias tag priority array. Consistent with gconv.StructTagPriority.
 
 	// all internal error keys.
 	internalErrKeyMap = map[string]string{


### PR DESCRIPTION
This is a sample that causes an assertion error.

```go
package main

import (
	"github.com/gogf/gf/v2/frame/g"
	"github.com/gogf/gf/v2/os/gctx"
	"github.com/gogf/gf/v2/test/gtest"
)

func main() {
	type Req struct {
		Name string `json:"n" v:"required"`
	}

	ctx := gctx.New()
	req := Req{}
	data := g.MapStrStr{
		"n": "v1",
	}
	gtest.AssertNil(g.Validator().Data(&req).Assoc(data).Run(ctx))
}
```