### PR TITLE
gf run output directory path for built binary file is "manifest/output" in default

### DIFF
--- a/cmd/gf/internal/cmd/cmd_run.go
+++ b/cmd/gf/internal/cmd/cmd_run.go
@@ -69,7 +69,7 @@ type (
 	cRunInput struct {
 		g.Meta `name:"run"`
 		File   string `name:"FILE"  arg:"true" brief:"{cRunFileBrief}" v:"required"`
-		Path   string `name:"path"  short:"p"  brief:"{cRunPathBrief}" d:"./"`
+		Path   string `name:"path"  short:"p"  brief:"{cRunPathBrief}" d:"./manifest/output"`
 		Extra  string `name:"extra" short:"e"  brief:"{cRunExtraBrief}"`
 	}
 	cRunOutput struct{}


### PR DESCRIPTION
```bash
gf run --help
USAGE
    gf run FILE [OPTION]

ARGUMENT
    FILE    building file path.

OPTION
    -p, --path    output directory path for built binary file. it's "manifest/output" in default
    -e, --extra   the same options as "go run"/"go build" except some options as follows defined
    -h, --help    more information about this command

EXAMPLE
    gf run main.go
    gf run main.go --args "server -p 8080"
    gf run main.go -mod=vendor

DESCRIPTION
    The "run" command is used for running go codes with hot-compiled-like feature,
    which compiles and runs the go codes asynchronously when codes change.
```

-p, --path    output directory path for built binary file. it's "manifest/output" in default