### PR TITLE
improve list tables for pgsql

### DIFF
--- a/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
+++ b/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
@@ -40,6 +40,7 @@ package internal
 
 import (
 	"context"
+
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/frame/g"
 )


### PR DESCRIPTION
## 变更内容

pgsql列出表名方法更新，不再返回partition子表名


## 示例

### 数据准备
```sql
drop table if exists test_partition;
CREATE TABLE test_partition (                                
    id int8
)                                
PARTITION BY HASH (id);                                
CREATE TABLE "test_partition_p0" PARTITION OF "public"."test_partition" FOR VALUES WITH(MODULUS 50, REMAINDER 0);
CREATE TABLE "test_partition_p1" PARTITION OF "public"."test_partition" FOR VALUES WITH(MODULUS 50, REMAINDER 1);
CREATE TABLE "test_partition_p2" PARTITION OF "public"."test_partition" FOR VALUES WITH(MODULUS 50, REMAINDER 2);
```

### 变更前查表名
```sql
SELECT TABLENAME FROM PG_TABLES WHERE SCHEMANAME = 'public' ORDER BY TABLENAME
```
返回结果
```
test_partition
test_partition_p0
test_partition_p1
test_partition_p2
```

### 变更后查表名
```sql
SELECT
    c.relname
FROM
    pg_class c
INNER JOIN pg_namespace n ON
    c.relnamespace = n.oid
WHERE
    n.nspname = 'public'
    AND c.relkind IN ('r', 'p')
    AND c.relpartbound IS NULL
    AND PG_TABLE_IS_VISIBLE(c.oid)
ORDER BY
    c.relname
```
返回结果
```
test_partition
```