### PR TITLE
fix openapi path security, issue #1792

### DIFF
--- a/protocol/goai/goai.go
+++ b/protocol/goai/goai.go
@@ -73,6 +73,7 @@ const (
 )
 
 const (
+	TagNameSecurity     = `security`
 	TagNamePath     = `path`
 	TagNameMethod   = `method`
 	TagNameMime     = `mime`

--- a/protocol/goai/goai_path.go
+++ b/protocol/goai/goai_path.go
@@ -142,6 +142,17 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 		}
 	}
 
+	// path security
+	// note: the security schema type only support http and apiKey;not support oauth2 and openIdConnect.
+	// multi schema separate with comma, e.g. `security: apiKey1,apiKey2`
+	TagNameSecurity := gmeta.Get(inputObject.Interface(), TagNameSecurity).String()
+	securities := gstr.SplitAndTrim(TagNameSecurity, ",")
+	seRequirements := SecurityRequirement{}
+	for _, sec := range securities {
+		seRequirements[sec] = []string{}
+	}
+	operation.Security = &SecurityRequirements{seRequirements}
+
 	// =================================================================================================================
 	// Request.
 	// =================================================================================================================


### PR DESCRIPTION
support openapi path security.
**note: the security schema type only support http and apiKey;not support oauth2 and openIdConnect.
multi schema separate with comma, e.g. `security: "apiKey1, apiKey2"`**

usage:
first: set global openapi definition SecurityScheme, befor server run.
```
func enhanceOpenAPIDoc(s *ghttp.Server) {
	openapi := s.GetOpenApi()
	
	openapi.Components = goai.Components{
		SecuritySchemes: goai.SecuritySchemes{
			"BearerAuth": goai.SecuritySchemeRef{
				Ref: "", 
				Value: &goai.SecurityScheme{
					Type:   "http",
					In:     "header",
					Name:   "Authorization",
					Scheme: "bearer",
				},
			},
		},
	}
}
```
second, set path security in every request struct with security tag in meta.
e.g.
```
type LogoutReq struct {
	g.Meta `summary:"用户退出" tags:"认证" security:"BearerAuth"`
	Uuid   string `json:"uuid" p:"uuid"  v:"required" in:"path" dc:"用户UUID"`
}
```

then, enjoy it.