### PR TITLE
Replace the Swagger JS CDN source from jsdelivr to unpkg.com

### DIFF
--- a/net/ghttp/ghttp_server_swagger.go
+++ b/net/ghttp/ghttp_server_swagger.go
@@ -32,7 +32,7 @@ const (
 	</head>
 	<body>
 		<redoc spec-url="{SwaggerUIDocUrl}" show-object-schema-examples="true"></redoc>
-		<script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"> </script>
+		<script src="https://unpkg.com/redoc@latest/bundles/redoc.standalone.js"> </script>
 	</body>
 </html>
 `


### PR DESCRIPTION
The jsdelivr cdn certificate expired in the mainland, causing the website to hang. To fix it, the solution is to replace the CDN source to unpkg.com