### PR TITLE
[feature] add table excluding regex find support and add table shading support.

### DIFF
--- a/cmd/gf/internal/cmd/cmd_gen_dao.go
+++ b/cmd/gf/internal/cmd/cmd_gen_dao.go
@@ -89,7 +89,7 @@ generated json tag case for model struct, cases are as follows:
 | KebabScreaming  | ANY-KIND-OF-STRING |
 `
 	cGenDaoBriefTableSeparator = `
-tableSeparator is used to join table names and table suffix, It's empty in "_"
+tableSeparator is used to join table names and table suffix, It's empty in '_'
 `
 	tplVarTableName               = `{TplTableName}`
 	tplVarTableNameCamelCase      = `{TplTableNameCamelCase}`

--- a/cmd/gf/internal/cmd/cmd_gen_dao.go
+++ b/cmd/gf/internal/cmd/cmd_gen_dao.go
@@ -89,8 +89,7 @@ generated json tag case for model struct, cases are as follows:
 | KebabScreaming  | ANY-KIND-OF-STRING |
 `
 	cGenDaoBriefTableSeparator = `
-tableSeparator is used to join table names and table suffix,
-it's not necessary and the default value is "default"
+tableSeparator is used to join table names and table suffix, It's empty in "_"
 `
 	tplVarTableName               = `{TplTableName}`
 	tplVarTableNameCamelCase      = `{TplTableNameCamelCase}`

--- a/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
+++ b/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
@@ -9,8 +9,6 @@ package dao
 
 import (
 	"{TplImportPrefix}/internal"
-	"time"
-	"strconv"
 )
 
 // internal{TplTableNameCamelCase}Dao is internal type for wrapping internal DAO implements.
@@ -44,6 +42,8 @@ import (
 	"context"
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/frame/g"
+	"time"
+	"strconv"
 )
 
 // {TplTableNameCamelCase}Dao is the data access object for table {TplTableName}.

--- a/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
+++ b/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
@@ -97,7 +97,7 @@ func (dao *{TplTableNameCamelCase}Dao) Suffix(suffix string) *{TplTableNameCamel
 }
 // Mod is a modular sub table help function
 func (dao *{TplTableNameCamelCase}Dao) Mod(i int64, mod int64) *{TplTableNameCamelCase}Dao {
-	dao.Suffix(strconv.Itoa(i % mod))
+	dao.Suffix(strconv.Itoa(int(i % mod)))
 	return dao
 }
 // Month is a help function that divides tables by month

--- a/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
+++ b/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
@@ -9,6 +9,7 @@ package dao
 
 import (
 	"{TplImportPrefix}/internal"
+	"time"
 )
 
 // internal{TplTableNameCamelCase}Dao is internal type for wrapping internal DAO implements.

--- a/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
+++ b/cmd/gf/internal/consts/consts_gen_dao_template_dao.go
@@ -10,6 +10,7 @@ package dao
 import (
 	"{TplImportPrefix}/internal"
 	"time"
+	"strconv"
 )
 
 // internal{TplTableNameCamelCase}Dao is internal type for wrapping internal DAO implements.
@@ -96,7 +97,7 @@ func (dao *{TplTableNameCamelCase}Dao) Suffix(suffix string) *{TplTableNameCamel
 }
 // Mod is a modular sub table help function
 func (dao *{TplTableNameCamelCase}Dao) Mod(i int64, mod int64) *{TplTableNameCamelCase}Dao {
-	dao.Suffix(string(i % mod))
+	dao.Suffix(strconv.Itoa(i % mod))
 	return dao
 }
 // Month is a help function that divides tables by month


### PR DESCRIPTION
[feature] add table shading support.
[feature] add table excluding regex find support.
可以解决以下情况：
`table_a`      0-127 mod 分表
`table_a_1`
`table_a_2`
`table_a_...`
如果一个库里面有多个使用128张分表的功能如果按照现有的`dao`逻辑将全部生成，这样会导致项目文件大大增加编译时间也将增加，非常不优雅。
现在可以使用`excluding`功能排除不想要的表，原始的`excluding`功能是支持,号分割多个条件的增加`regex`之后依然支持多个条件
例：
```shell
gen dao -l "mysql:root:123456@tcp(xxx:8066)/dbbh_website" -p /tmp/dbbh_website -g dbbh_website -x "_[0-9]*$",week_start_\,game_list$
```
只生成母表将会导致一个问题就是
所有生成出来的表都是一个表，`NewXXX`的时候`table`名字是写死的这就会导致无法分表，并且所有的查询都走到了母表。
鉴于上述问题增加了`Suffix`函数，可以在查询的时候`Inline`动态修改表后缀
例：
```go
res := dbbh_website.OrgTryPlayUserGameList.Columns()
ctx := context.Background()
fmt.Println(strconv.Itoa(1 % 32))
err := dbbh_website.OrgTryPlayUserGameList.Suffix("4").Ctx(ctx).Where(g.Map{
dbbh_website.OrgTryPlayUserGameList.Columns().Gindex: 979015,
}).Scan(&res)
```
还增加了常用函数：
`Mod`，`Month`，`Year`