### PR TITLE
Polaris Server Offical image support

### DIFF
--- a/.github/workflows/gf.yml
+++ b/.github/workflows/gf.yml
@@ -92,7 +92,7 @@ jobs:
           - 9001:9001
 
       polaris:
-        image: houseme/polaris-server-with-config:latest
+        image: polarismesh/polaris-server-standalone:latest
         ports:
           - 8090:8090
           - 8091:8091


### PR DESCRIPTION
改为北极星 官方发布的docker镜像

https://github.com/polarismesh/polaris/pull/388