### PR TITLE
gfcli: fix imports parse and update gofmt

### DIFF
--- a/cmd/gf/internal/utility/utils/utils.go
+++ b/cmd/gf/internal/utility/utils/utils.go
@@ -8,10 +8,30 @@ import (
 	"golang.org/x/tools/imports"
 )
 
-// GoFmt formats the source file.
+// GoFmt formats the source file and adds or removes import statements as necessary.
 func GoFmt(path string) {
-	if err := doGoFmt(path, true); err != nil {
-		mlog.Fatalf(`error format "%s" go files: %v`, path, err)
+	replaceFunc := func(path, content string) string {
+		res, err := imports.Process(path, []byte(content), nil)
+		if err != nil {
+			mlog.Printf(`error format "%s" go files: %v`, path, err)
+			return content
+		}
+		return string(res)
+	}
+
+	var err error
+	if gfile.IsFile(path) {
+		// File format.
+		if gfile.ExtName(path) != "go" {
+			return
+		}
+		err = gfile.ReplaceFileFunc(replaceFunc, path)
+	} else {
+		// Folder format.
+		err = gfile.ReplaceDirFunc(replaceFunc, path, "*.go", true)
+	}
+	if err != nil {
+		mlog.Printf(`error format "%s" go files: %v`, path, err)
 	}
 }
 
@@ -21,34 +41,4 @@ func IsFileDoNotEdit(filePath string) bool {
 		return true
 	}
 	return gstr.Contains(gfile.GetContents(filePath), consts.DoNotEditKey)
-}
-
-// doGoFmt format go file and adds or removes import statements as necessary.
-func doGoFmt(path string, formatOnly ...bool) error {
-	var genOpt *imports.Options
-	if len(formatOnly) > 0 {
-		genOpt = &imports.Options{
-			Comments:   true,
-			TabIndent:  true,
-			TabWidth:   8,
-			FormatOnly: true,
-		}
-	}
-	replaceFunc := func(path, content string) string {
-		res, err := imports.Process(path, []byte(content), genOpt)
-		if err != nil {
-			mlog.Printf(`pretty go file "%s" failed: %v`, path, err)
-			return content
-		}
-		return string(res)
-	}
-	// File format.
-	if gfile.IsFile(path) {
-		if gfile.ExtName(path) != "go" {
-			return nil
-		}
-		return gfile.ReplaceFileFunc(replaceFunc, path)
-	}
-	// Folder format.
-	return gfile.ReplaceDirFunc(replaceFunc, path, "*.go", true)
 }


### PR DESCRIPTION
* 解决2个问题：
1：service 引入包的解析使用正则的情况下，遇到下面的写法时会无法正确解析到
``` go
import "xxx"
import (
   a "xxx"
   _ "xxxx"
)
```
2: 现在格式化go文件的方法只有 gofmt 这一个了，原先是 gofmt 和 goimports 两个，dofmt 的第二个参数是用来区分这两个功能的，所以现在直接统一了，gofmt 的职责就是用来同时做格式化代码并且纠正包的引入的。 

* 共有2处修改：
1： 重写 service 引入包的解析，从正则替换成 go 原生的解析方法。这里面我去除了对于 `_` 这个的包的引入，个人认为这个在logic应该是多余的
2: dofmt 移到 GoFmt 的方法内，让其职责变成同时 格式化代码和纠正包引入