### PR TITLE
support openapi path security

### DIFF
--- a/net/goai/goai.go
+++ b/net/goai/goai.go
@@ -73,6 +73,7 @@ const (
 )
 
 const (
+	TagNameSecurity     = `security`
 	TagNamePath     = `path`
 	TagNameMethod   = `method`
 	TagNameMime     = `mime`

--- a/net/goai/goai_path.go
+++ b/net/goai/goai_path.go
@@ -93,6 +93,7 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 			Responses:   map[string]ResponseRef{},
 			XExtensions: make(XExtensions),
 		}
+		seRequirement = SecurityRequirement{}
 	)
 	// Path check.
 	if in.Path == "" {
@@ -141,6 +142,16 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 			mime = inputMetaMap[TagNameConsumes]
 		}
 	}
+
+	// path security
+	// note: the security schema type only support http and apiKey;not support oauth2 and openIdConnect.
+	// multi schema separate with comma, e.g. `security: apiKey1,apiKey2`
+	TagNameSecurity := gmeta.Get(inputObject.Interface(), TagNameSecurity).String()
+	securities := gstr.SplitAndTrim(TagNameSecurity, ",")
+	for _, sec := range securities {
+		seRequirement[sec] = []string{}
+	}
+	operation.Security = &SecurityRequirements{seRequirement}
 
 	// =================================================================================================================
 	// Request.


### PR DESCRIPTION
support openapi path security.
**note: the security schema type only support http and apiKey;not support oauth2 and openIdConnect.
multi schema separate with comma, e.g. `security: "apiKey1, apiKey2"`**

usage:
first: set global openapi definition SecurityScheme, befor server run.
```
func enhanceOpenAPIDoc(s *ghttp.Server) {
	openapi := s.GetOpenApi()
	
	openapi.Components = goai.Components{
		SecuritySchemes: goai.SecuritySchemes{
			"BearerAuth": goai.SecuritySchemeRef{
				Ref: "", 
				Value: &goai.SecurityScheme{
					Type:   "http",
					In:     "header",
					Name:   "Authorization",
					Scheme: "bearer",
				},
			},
		},
	}
}
```
second, set path security in every request struct with security tag in meta.
e.g.
```
type LogoutReq struct {
	g.Meta `summary:"用户退出" tags:"认证" security:"BearerAuth"`
	Uuid   string `json:"uuid" p:"uuid"  v:"required" in:"path" dc:"用户UUID"`
}
```

then, enjoy it.