### PR TITLE
fix(gdb): panic when concurrent db config map read and write.

### DIFF
--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -432,6 +432,9 @@ func Instance(name ...string) (db DB, err error) {
 // The parameter `master` specifies whether retrieving a master node, or else a slave node
 // if master-slave configured.
 func getConfigNodeByGroup(group string, master bool) (*ConfigNode, error) {
+	configs.RLock()
+	defer configs.RUnlock()
+
 	if list, ok := configs.config[group]; ok {
 		// Separates master and slave configuration nodes array.
 		var (


### PR DESCRIPTION
see https://github.com/gogf/gf/issues/1996

修复了部分地方没有用 RW 锁导致的竞争 panic