### PR TITLE
improve gdb.CheckValueForLocalType for pgsql

### DIFF
--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -24,6 +24,8 @@ const (
 	typeDatetime    = "datetime"
 	typeInt64Bytes  = "int64-bytes"
 	typeUint64Bytes = "uint64-bytes"
+	typeJson        = "json"
+	typeJsonb       = "jsonb"
 )
 
 func generateStructDefinition(ctx context.Context, in generateStructDefinitionInput) string {
@@ -84,7 +86,7 @@ func generateStructFieldDefinition(
 		typeName = "uint64"
 
 	// Special type handle.
-	case "json", "jsonb":
+	case typeJson, typeJsonb:
 		if in.GJsonSupport {
 			typeName = "*gjson.Json"
 		} else {

--- a/contrib/drivers/pgsql/pgsql.go
+++ b/contrib/drivers/pgsql/pgsql.go
@@ -125,19 +125,17 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 	typeName, _ := gregex.ReplaceString(`\(.+\)`, "", fieldType)
 	typeName = strings.ToLower(typeName)
 	switch typeName {
+	// For pgsql, int2 = smallint and int4 = integer.
+	case "int2", "int4":
+		return gconv.Int(gconv.String(fieldValue)), nil
+
 	// For pgsql, int8 = bigint.
 	case "int8":
-		if gstr.ContainsI(fieldType, "unsigned") {
-			return gconv.Uint64(gconv.String(fieldValue)), nil
-		}
 		return gconv.Int64(gconv.String(fieldValue)), nil
 
 	// Int32 slice.
 	case
-		"_int2":
-		if gstr.ContainsI(fieldType, "unsigned") {
-			gconv.Uints(gconv.String(fieldValue))
-		}
+		"_int2", "_int4":
 		return gconv.Ints(
 			gstr.ReplaceByMap(gconv.String(fieldValue),
 				map[string]string{
@@ -149,10 +147,7 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 
 	// Int64 slice.
 	case
-		"_int4", "_int8":
-		if gstr.ContainsI(fieldType, "unsigned") {
-			gconv.Uint64(gconv.String(fieldValue))
-		}
+		"_int8":
 		return gconv.Int64s(
 			gstr.ReplaceByMap(gconv.String(fieldValue),
 				map[string]string{

--- a/database/gdb/gdb_func_structure.go
+++ b/database/gdb/gdb_func_structure.go
@@ -23,6 +23,7 @@ const (
 	typeUint        = "uint"
 	typeInt64       = "int64"
 	typeUint64      = "uint64"
+	typeIntSlice    = "[]int"
 	typeInt64Slice  = "[]int64"
 	typeUint64Slice = "[]uint64"
 	typeInt64Bytes  = "int64-bytes"
@@ -31,6 +32,8 @@ const (
 	typeFloat64     = "float64"
 	typeBytes       = "[]byte"
 	typeBool        = "bool"
+	typeJson        = "json"
+	typeJsonb       = "jsonb"
 )
 
 // CheckValueForLocalType checks and returns corresponding type for given db type.
@@ -58,6 +61,8 @@ func CheckValueForLocalType(ctx context.Context, fieldType string, fieldValue in
 		return typeBytes, nil
 
 	case
+		"int2", // For pgsql, int2 = smallint.
+		"int4", // For pgsql, int4 = integer.
 		"int",
 		"tinyint",
 		"small_int",
@@ -70,13 +75,8 @@ func CheckValueForLocalType(ctx context.Context, fieldType string, fieldValue in
 		}
 		return typeInt, nil
 
-	case "_int4", "_int8":
-		if gstr.ContainsI(fieldType, "unsigned") {
-			return typeUint64Slice, nil
-		}
-		return typeInt64Slice, nil
-
 	case
+		"int8", // For pgsql, int8 = bigint.
 		"big_int",
 		"bigint",
 		"bigserial":
@@ -84,6 +84,12 @@ func CheckValueForLocalType(ctx context.Context, fieldType string, fieldValue in
 			return typeUint64, nil
 		}
 		return typeInt64, nil
+
+	case "_int2", "_int4":
+		return typeIntSlice, nil
+
+	case "_int8":
+		return typeInt64Slice, nil
 
 	case "real":
 		return typeFloat32, nil
@@ -123,6 +129,12 @@ func CheckValueForLocalType(ctx context.Context, fieldType string, fieldValue in
 		"timestamp",
 		"timestamptz":
 		return typeDatetime, nil
+
+	case "json":
+		return typeJson, nil
+
+	case "jsonb":
+		return typeJsonb, nil
 
 	default:
 		// Auto-detect field type, using key match.


### PR DESCRIPTION
修复当前版本生成entity时，int8和json类型字段都无法正确解析到本地类型的问题

另外数据库的int4类型是32位，调整了一下转换成了 int