### PR TITLE
fix precision lost of int64 for package gcfg

### DIFF
--- a/encoding/gjson/gjson_api_new_load.go
+++ b/encoding/gjson/gjson_api_new_load.go
@@ -210,7 +210,8 @@ func LoadContentType(dataType string, data interface{}, safe ...bool) (*Json, er
 		content = content[3:]
 	}
 	options := Options{
-		Type: dataType,
+		Type:      dataType,
+		StrNumber: true,
 	}
 	if len(safe) > 0 && safe[0] {
 		options.Safe = true

--- a/encoding/gjson/gjson_z_unit_feature_new_test.go
+++ b/encoding/gjson/gjson_z_unit_feature_new_test.go
@@ -110,3 +110,13 @@ func Test_NewWithOptions(t *testing.T) {
 		t.Assert(array, []uint64{9223372036854775807, 9223372036854775806})
 	})
 }
+
+func Test_LoadContentType(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		data := []byte("value = 79937385836643329")
+		j, err := gjson.LoadContentType("toml", data)
+		t.AssertNil(err)
+		value := j.Get("value").Int64()
+		t.Assert(value, 79937385836643329)
+	})
+}


### PR DESCRIPTION
修复配置文件中的int64丢失精度问题