### PR TITLE
fix (clickhouse) : 修复clickhouse 使用link链接时 TableFields 

### DIFF
--- a/contrib/drivers/clickhouse/clickhouse.go
+++ b/contrib/drivers/clickhouse/clickhouse.go
@@ -152,8 +152,8 @@ func (d *Driver) TableFields(
 			var (
 				columns       = "name,position,default_expression,comment,type,is_in_partition_key,is_in_sorting_key,is_in_primary_key,is_in_sampling_key"
 				getColumnsSql = fmt.Sprintf(
-					"select %s from `system`.columns c where database = '%s' and `table` = '%s'",
-					columns, d.GetConfig().Name, table,
+					"select %s from `system`.columns c where `table` = '%s'",
+					columns, table,
 				)
 			)
 			result, err = d.DoSelect(ctx, link, getColumnsSql)

--- a/contrib/drivers/clickhouse/clickhouse_test.go
+++ b/contrib/drivers/clickhouse/clickhouse_test.go
@@ -127,6 +127,16 @@ func clickhouseConfigDB() gdb.DB {
 	return connect
 }
 
+func clickhouseLink() gdb.DB {
+	connect, err := gdb.New(gdb.ConfigNode{
+		Link: "clickhouse://default@127.0.0.1:9000,127.0.0.1:9000/default?dial_timeout=200ms&max_execution_time=60",
+		Type: "clickhouse",
+	})
+	gtest.AssertNil(err)
+	gtest.AssertNE(connect, nil)
+	return connect
+}
+
 func createClickhouseTableVisits(connect gdb.DB) error {
 	_, err := connect.Exec(context.Background(), sqlVisitsDDL)
 	return err
@@ -204,7 +214,7 @@ func TestDriverClickhouse_TableFields_Use_Config(t *testing.T) {
 }
 
 func TestDriverClickhouse_TableFields_Use_Link(t *testing.T) {
-	connect := clickhouseConfigDB()
+	connect := clickhouseLink()
 	gtest.AssertNil(createClickhouseTableVisits(connect))
 	defer dropClickhouseTableVisits(connect)
 	field, err := connect.TableFields(context.Background(), "visits")


### PR DESCRIPTION
场景：`gf gen dao`

在gen dao时，只有`link` , `d.GetConfig().Name`始终为空。

