### PR TITLE
fixed inconsistent results when converting float64(NaN) to int/uint on multiple platforms

### DIFF
--- a/util/gconv/gconv_int.go
+++ b/util/gconv/gconv_int.go
@@ -7,6 +7,7 @@
 package gconv
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/gogf/gf/v2/encoding/gbinary"
@@ -126,6 +127,10 @@ func Int64(any interface{}) int64 {
 			return v
 		}
 		// Float64
-		return int64(Float64(value))
+		if valueInt64 := Float64(value); math.IsNaN(valueInt64) {
+			return 0
+		} else {
+			return int64(valueInt64)
+		}
 	}
 }

--- a/util/gconv/gconv_uint.go
+++ b/util/gconv/gconv_uint.go
@@ -7,6 +7,7 @@
 package gconv
 
 import (
+	"math"
 	"strconv"
 
 	"github.com/gogf/gf/v2/encoding/gbinary"
@@ -109,6 +110,10 @@ func Uint64(any interface{}) uint64 {
 			return v
 		}
 		// Float64
-		return uint64(Float64(value))
+		if valueFloat64 := Float64(value); math.IsNaN(valueFloat64) {
+			return 0
+		} else {
+			return uint64(Float64(value))
+		}
 	}
 }

--- a/util/gconv/gconv_z_unit_all_test.go
+++ b/util/gconv/gconv_z_unit_all_test.go
@@ -7,6 +7,7 @@
 package gconv_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -199,6 +200,7 @@ func Test_Int_All(t *testing.T) {
 		t.AssertEQ(gconv.Int(123.456), 123)
 		t.AssertEQ(gconv.Int(boolStruct{}), 0)
 		t.AssertEQ(gconv.Int(&boolStruct{}), 0)
+		t.AssertEQ(gconv.Int("NaN"), 0)
 	})
 }
 
@@ -233,6 +235,8 @@ func Test_Int8_All(t *testing.T) {
 		t.AssertEQ(gconv.Int8(123.456), int8(123))
 		t.AssertEQ(gconv.Int8(boolStruct{}), int8(0))
 		t.AssertEQ(gconv.Int8(&boolStruct{}), int8(0))
+		t.AssertEQ(gconv.Int8("NaN"), int8(0))
+
 	})
 }
 
@@ -267,6 +271,7 @@ func Test_Int16_All(t *testing.T) {
 		t.AssertEQ(gconv.Int16(123.456), int16(123))
 		t.AssertEQ(gconv.Int16(boolStruct{}), int16(0))
 		t.AssertEQ(gconv.Int16(&boolStruct{}), int16(0))
+		t.AssertEQ(gconv.Int16("NaN"), int16(0))
 	})
 }
 
@@ -301,6 +306,7 @@ func Test_Int32_All(t *testing.T) {
 		t.AssertEQ(gconv.Int32(123.456), int32(123))
 		t.AssertEQ(gconv.Int32(boolStruct{}), int32(0))
 		t.AssertEQ(gconv.Int32(&boolStruct{}), int32(0))
+		t.AssertEQ(gconv.Int32("NaN"), int32(0))
 	})
 }
 
@@ -355,6 +361,7 @@ func Test_Int64_All(t *testing.T) {
 		t.AssertEQ(gconv.Int64(123.456), int64(123))
 		t.AssertEQ(gconv.Int64(boolStruct{}), int64(0))
 		t.AssertEQ(gconv.Int64(&boolStruct{}), int64(0))
+		t.AssertEQ(gconv.Int64("NaN"), int64(0))
 	})
 }
 
@@ -390,6 +397,7 @@ func Test_Uint_All(t *testing.T) {
 		t.AssertEQ(gconv.Uint(123.456), uint(123))
 		t.AssertEQ(gconv.Uint(boolStruct{}), uint(0))
 		t.AssertEQ(gconv.Uint(&boolStruct{}), uint(0))
+		t.AssertEQ(gconv.Uint("NaN"), uint(0))
 	})
 }
 
@@ -425,6 +433,7 @@ func Test_Uint8_All(t *testing.T) {
 		t.AssertEQ(gconv.Uint8(123.456), uint8(123))
 		t.AssertEQ(gconv.Uint8(boolStruct{}), uint8(0))
 		t.AssertEQ(gconv.Uint8(&boolStruct{}), uint8(0))
+		t.AssertEQ(gconv.Uint8("NaN"), uint8(0))
 	})
 }
 
@@ -460,6 +469,7 @@ func Test_Uint16_All(t *testing.T) {
 		t.AssertEQ(gconv.Uint16(123.456), uint16(123))
 		t.AssertEQ(gconv.Uint16(boolStruct{}), uint16(0))
 		t.AssertEQ(gconv.Uint16(&boolStruct{}), uint16(0))
+		t.AssertEQ(gconv.Uint16("NaN"), uint16(0))
 	})
 }
 
@@ -495,6 +505,7 @@ func Test_Uint32_All(t *testing.T) {
 		t.AssertEQ(gconv.Uint32(123.456), uint32(123))
 		t.AssertEQ(gconv.Uint32(boolStruct{}), uint32(0))
 		t.AssertEQ(gconv.Uint32(&boolStruct{}), uint32(0))
+		t.AssertEQ(gconv.Uint32("NaN"), uint32(0))
 	})
 }
 
@@ -549,6 +560,7 @@ func Test_Uint64_All(t *testing.T) {
 		t.AssertEQ(gconv.Uint64(123.456), uint64(123))
 		t.AssertEQ(gconv.Uint64(boolStruct{}), uint64(0))
 		t.AssertEQ(gconv.Uint64(&boolStruct{}), uint64(0))
+		t.AssertEQ(gconv.Uint64("NaN"), uint64(0))
 	})
 }
 
@@ -583,6 +595,7 @@ func Test_Float32_All(t *testing.T) {
 		t.AssertEQ(gconv.Float32(123.456), float32(123.456))
 		t.AssertEQ(gconv.Float32(boolStruct{}), float32(0))
 		t.AssertEQ(gconv.Float32(&boolStruct{}), float32(0))
+		t.AssertEQ(gconv.Float32("NaN"), float32(math.NaN()))
 	})
 }
 
@@ -617,6 +630,7 @@ func Test_Float64_All(t *testing.T) {
 		t.AssertEQ(gconv.Float64(123.456), float64(123.456))
 		t.AssertEQ(gconv.Float64(boolStruct{}), float64(0))
 		t.AssertEQ(gconv.Float64(&boolStruct{}), float64(0))
+		t.AssertEQ(gconv.Float64("NaN"), float64(math.NaN()))
 	})
 }
 


### PR DESCRIPTION
Mainly include the following changes
- When using gconv.Int64/gconv.Uint64 , if the result is NaN, it will become 0
- When using gconv.Float64 / gconv.Float32 , if the result is NaN, it will not be modified

Fix the change only occurs when floating point to uint/int