### PR TITLE
Update gutil_dump.go

### DIFF
--- a/util/gutil/gutil_dump.go
+++ b/util/gutil/gutil_dump.go
@@ -110,9 +110,12 @@ func doDump(value interface{}, indent string, buffer *bytes.Buffer, option doDum
 	}
 	var (
 		reflectKind     = reflectValue.Kind()
-		reflectTypeName = reflectValue.Type().String()
+		reflectTypeName = "invalid"
 		newIndent       = indent + dumpIndent
 	)
+	if reflectValue.IsValid() {
+		reflectTypeName = reflectValue.Type().String()
+	}
 	reflectTypeName = strings.ReplaceAll(reflectTypeName, `[]uint8`, `[]byte`)
 	if !option.WithType {
 		reflectTypeName = ""


### PR DESCRIPTION
Solve the panic: reflect: call of reflect.Value.Type on zero Value [recovered] The reason for this is the circular reference itself