### PR TITLE
add g.Meta data defined in XxxRe[q|s] struct to handlerFuncInfo

### DIFF
--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -70,11 +70,13 @@ type (
 	// HandlerFunc is request handler function.
 	HandlerFunc = func(r *Request)
 
-	// handlerFuncInfo contains the HandlerFunc address and its reflection type.
+	// handlerFuncInfo contains the possible g.Meta information, HandlerFunc address and its reflection type.
 	handlerFuncInfo struct {
-		Func  HandlerFunc   // Handler function address.
-		Type  reflect.Type  // Reflect type information for current handler, which is used for extensions of the handler feature.
-		Value reflect.Value // Reflect value information for current handler, which is used for extensions of the handler feature.
+		Func    HandlerFunc       // Handler function address.
+		Type    reflect.Type      // Reflect type information for current handler, which is used for extensions of the handler feature.
+		Value   reflect.Value     // Reflect value information for current handler, which is used for extensions of the handler feature.
+		ReqMeta map[string]string // g.Meta defined in "XxxReq" struct, which would be nil if there is no "XxxReq" struct in the handler function or no g.Meta in "XxxReq" struct.
+		ResMeta map[string]string // g.Meta defined in "XxxRes" struct, which would be nil if there is no "XxxRes" struct in the handler function or no g.Meta in "XxxRes" struct.
 	}
 
 	// HandlerItem is the registered handler for route handling,

--- a/net/ghttp/ghttp_z_unit_feature_router_strict_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_router_strict_test.go
@@ -196,6 +196,63 @@ func Test_Router_Handler_Strict_Group_Bind(t *testing.T) {
 	})
 }
 
+type TestForHandlerWithObjectAndMeta5Req struct {
+	g.Meta `path:"/test-meta" method:"get"`
+	Code   int `p:"code"`
+}
+
+type TestForHandlerWithObjectAndMeta5Res struct {
+	g.Meta `200:"ok" 400:"bad request" 401:"unauthorized" 500:"internal server error"`
+}
+
+type ControllerForHandlerWithObjectAndMeta3 struct{}
+
+func (ControllerForHandlerWithObjectAndMeta3) Test1(ctx2 context.Context, req *TestForHandlerWithObjectAndMeta5Req) (res *TestForHandlerWithObjectAndMeta5Res, err error) {
+	return
+}
+
+func TestHandlerForReqResMeta(t *testing.T) {
+	type TestNoMetaReq struct{}
+	type TestNoMetaRes struct{}
+
+	s := g.Server(guid.S())
+
+	// directly response with metadata without executing handler.
+	s.BindMiddleware("/*", func(r *ghttp.Request) {
+		data := g.Map{
+			"reqMeta": r.GetServeHandler().Handler.Info.ReqMeta,
+			"resMeta": r.GetServeHandler().Handler.Info.ResMeta,
+		}
+
+		r.Response.WriteExit(data)
+	})
+
+	s.BindObject("/", new(ControllerForHandlerWithObjectAndMeta3))
+
+	// no g.Meta defined in "XxxReq" and "XxxRes"
+	s.BindHandler("/test-meta-empty", func(ctx context.Context, req TestNoMetaReq) (res TestNoMetaRes, err error) {
+		return
+	})
+
+	// no "XxxReq" and "XxxRes"
+	s.BindHandler("/test-meta-classical-handler", func(r *ghttp.Request) {
+		return
+	})
+
+	s.Start()
+	defer s.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+	gtest.C(t, func(t *gtest.T) {
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+
+		t.Assert(client.GetContent(ctx, "/test-meta"), `{"reqMeta":{"method":"get","path":"/test-meta"},"resMeta":{"200":"ok","400":"bad request","401":"unauthorized","500":"internal server error"}}`)
+		t.Assert(client.GetContent(ctx, "/test-meta-empty"), `{"reqMeta":null,"resMeta":null}`)
+		t.Assert(client.GetContent(ctx, "/test-meta-classical-handler"), `{"reqMeta":null,"resMeta":null}`)
+	})
+}
+
 func Test_Issue1708(t *testing.T) {
 	type Test struct {
 		Name string `json:"name"`


### PR DESCRIPTION
Obtain and record the metadata defined in "XxxReq" and "XxxRes" struct before the server starts, in order to access metadata easily for pre or post middleware.

Example:
```go

type FooReq struct {
	g.Meta `path:"/foo" method:"get" auth:"jwt" more:"..."`
	Code   int `json:"code"`
}

type FooRes struct {
	g.Meta `200:"ok" 400:"bad request" 401:"unauthorized" 500:"internal server error"`
	Code   int `json:"code"`
}

func PreMiddleware(r *ghttp.Request) {
	meta := r.GetServeHandler().Handler.Info.ReqMeta
	if meta != nil && meta["auth"] == "jwt" {
		// check jwt
	}

	r.Middleware.Next()
}

func PostMiddleware(r *ghttp.Request) {
	r.Middleware.Next()

	meta := r.GetServeHandler().Handler.Info.ResMeta
	message := ""

	code := r.Response.Status

	// set code according to different error

	if meta != nil {
		message = meta[strconv.Itoa(code)]
	}

	r.Response.Write(g.Map{
		"message": message,
		"payload": r.GetHandlerResponse(),
	})
}

func TestMeta(t *testing.T) {
	ctx := context.TODO()
	s := g.Server()

	s.BindMiddleware("/*", PreMiddleware, PostMiddleware)
	s.BindHandler("/foo", func(ctx context.Context, req *FooReq) (res *FooRes, err error) {
		return
	})

	s.Start()
	defer s.Shutdown()

	time.Sleep(100 * time.Millisecond)
	gtest.C(t, func(t *gtest.T) {
		client := g.Client()
		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))

		t.Assert(client.GetContent(ctx, "/foo"), `{"message":"ok","payload":null}`)
	})
}

```