### PR TITLE
fix: ghttp server static path config

### DIFF
--- a/net/ghttp/ghttp_server_config_static.go
+++ b/net/ghttp/ghttp_server_config_static.go
@@ -20,8 +20,8 @@ import (
 
 // staticPathItem is the item struct for static path configuration.
 type staticPathItem struct {
-	prefix string // The router URI.
-	path   string // The static path.
+	Prefix string // The router URI.
+	Path   string // The static path.
 }
 
 // SetIndexFiles sets the index files for server.
@@ -96,8 +96,8 @@ func (s *Server) AddStaticPath(prefix string, path string) {
 		}
 	}
 	addItem := staticPathItem{
-		prefix: prefix,
-		path:   realPath,
+		Prefix: prefix,
+		Path:   realPath,
 	}
 	if len(s.config.StaticPaths) > 0 {
 		s.config.StaticPaths = append(s.config.StaticPaths, addItem)
@@ -112,13 +112,13 @@ func (s *Server) AddStaticPath(prefix string, path string) {
 			return r
 		})
 		for _, v := range s.config.StaticPaths {
-			array.Add(v.prefix)
+			array.Add(v.Prefix)
 		}
 		// Add the items to paths by previous sorted slice.
 		paths := make([]staticPathItem, 0)
 		for _, v := range array.Slice() {
 			for _, item := range s.config.StaticPaths {
-				if strings.EqualFold(gconv.String(v), item.prefix) {
+				if strings.EqualFold(gconv.String(v), item.Prefix) {
 					paths = append(paths, item)
 					break
 				}

--- a/net/ghttp/ghttp_server_handler.go
+++ b/net/ghttp/ghttp_server_handler.go
@@ -211,19 +211,19 @@ func (s *Server) searchStaticFile(uri string) *staticFile {
 	// Firstly search the StaticPaths mapping.
 	if len(s.config.StaticPaths) > 0 {
 		for _, item := range s.config.StaticPaths {
-			if len(uri) >= len(item.prefix) && strings.EqualFold(item.prefix, uri[0:len(item.prefix)]) {
+			if len(uri) >= len(item.Prefix) && strings.EqualFold(item.Prefix, uri[0:len(item.Prefix)]) {
 				// To avoid case like: /static/style -> /static/style.css
-				if len(uri) > len(item.prefix) && uri[len(item.prefix)] != '/' {
+				if len(uri) > len(item.Prefix) && uri[len(item.Prefix)] != '/' {
 					continue
 				}
-				file = gres.GetWithIndex(item.path+uri[len(item.prefix):], s.config.IndexFiles)
+				file = gres.GetWithIndex(item.Path+uri[len(item.Prefix):], s.config.IndexFiles)
 				if file != nil {
 					return &staticFile{
 						File:  file,
 						IsDir: file.FileInfo().IsDir(),
 					}
 				}
-				path, dir = gspath.Search(item.path, uri[len(item.prefix):], s.config.IndexFiles...)
+				path, dir = gspath.Search(item.Path, uri[len(item.Prefix):], s.config.IndexFiles...)
 				if path != "" {
 					return &staticFile{
 						Path:  path,


### PR DESCRIPTION
https://github.com/gogf/gf/issues/2333
静态文件服务的对象字段非公开导致无法通过配置文件进行配置