### PR TITLE
fix fixed An error occurred when only one file was uploaded in batches and add unit testing(#2092)

### DIFF
--- a/net/ghttp/ghttp_request_param_request.go
+++ b/net/ghttp/ghttp_request_param_request.go
@@ -114,7 +114,7 @@ func (r *Request) GetRequestMap(kvMap ...map[string]interface{}) map[string]inte
 	if r.MultipartForm != nil {
 		for name := range r.MultipartForm.File {
 			if uploadFiles := r.GetUploadFiles(name); len(uploadFiles) == 1 {
-				m[name] = uploadFiles[0]
+				m[name] = *uploadFiles[0]
 			} else {
 				m[name] = uploadFiles
 			}

--- a/net/ghttp/ghttp_z_unit_feature_request_file_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_request_file_test.go
@@ -274,3 +274,101 @@ func Test_Params_File_MarshalJSON(t *testing.T) {
 		t.Assert(strings.Contains(content, "file1.txt"), true)
 	})
 }
+
+// Select only one file when batch uploading
+func Test_Params_Strict_Route_File_Batch_Up_One(t *testing.T) {
+	type Req struct {
+		gmeta.Meta `method:"post" mime:"multipart/form-data"`
+		Files      ghttp.UploadFiles `type:"file"`
+	}
+	type Res struct{}
+
+	dstDirPath := gfile.Temp(gtime.TimestampNanoStr())
+	s := g.Server(guid.S())
+	s.BindHandler("/upload/batch", func(ctx context.Context, req *Req) (res *Res, err error) {
+		var (
+			r     = g.RequestFromCtx(ctx)
+			files = req.Files
+		)
+		if len(files) == 0 {
+			r.Response.WriteExit("upload file cannot be empty")
+		}
+		names, err := files.Save(dstDirPath)
+		if err != nil {
+			r.Response.WriteExit(err)
+		}
+		r.Response.WriteExit(gstr.Join(names, ","))
+		return
+	})
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
+	time.Sleep(100 * time.Millisecond)
+	// normal name
+	gtest.C(t, func(t *gtest.T) {
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+
+		srcPath := gtest.DataPath("upload", "file1.txt")
+		dstPath := gfile.Join(dstDirPath, "file1.txt")
+		content := client.PostContent(ctx, "/upload/batch", g.Map{
+			"files": "@file:" + srcPath,
+		})
+		t.AssertNE(content, "")
+		t.AssertNE(content, "upload file cannot be empty")
+		t.AssertNE(content, "upload failed")
+		t.Assert(content, "file1.txt")
+		t.Assert(gfile.GetContents(dstPath), gfile.GetContents(srcPath))
+	})
+}
+
+// Select multiple files during batch upload
+func Test_Params_Strict_Route_File_Batch_Up_Multiple(t *testing.T) {
+	type Req struct {
+		gmeta.Meta `method:"post" mime:"multipart/form-data"`
+		Files      ghttp.UploadFiles `type:"file"`
+	}
+	type Res struct{}
+
+	dstDirPath := gfile.Temp(gtime.TimestampNanoStr())
+	s := g.Server(guid.S())
+	s.BindHandler("/upload/batch", func(ctx context.Context, req *Req) (res *Res, err error) {
+		var (
+			r     = g.RequestFromCtx(ctx)
+			files = req.Files
+		)
+		if len(files) == 0 {
+			r.Response.WriteExit("upload file cannot be empty")
+		}
+		names, err := files.Save(dstDirPath)
+		if err != nil {
+			r.Response.WriteExit(err)
+		}
+		r.Response.WriteExit(gstr.Join(names, ","))
+		return
+	})
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
+	time.Sleep(100 * time.Millisecond)
+	// normal name
+	gtest.C(t, func(t *gtest.T) {
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+
+		srcPath1 := gtest.DataPath("upload", "file1.txt")
+		srcPath2 := gtest.DataPath("upload", "file2.txt")
+		dstPath1 := gfile.Join(dstDirPath, "file1.txt")
+		dstPath2 := gfile.Join(dstDirPath, "file2.txt")
+		content := client.PostContent(ctx, "/upload/batch",
+			"files=@file:"+srcPath1+
+				"&files=@file:"+srcPath2,
+		)
+		t.AssertNE(content, "")
+		t.AssertNE(content, "upload file cannot be empty")
+		t.AssertNE(content, "upload failed")
+		t.Assert(content, "file1.txt,file2.txt")
+		t.Assert(gfile.GetContents(dstPath1), gfile.GetContents(srcPath1))
+		t.Assert(gfile.GetContents(dstPath2), gfile.GetContents(srcPath2))
+	})
+}


### PR DESCRIPTION
修复规范路由下批量上传时，若只上传一个文件出现错误：`reflect.Value.Convert: value of type *ghttp.UploadFile cannot be converted to type ghttp.UploadFile`
修复前单测：
![image](https://user-images.githubusercontent.com/5909445/207491094-7b53f48d-cfd5-48e0-8ec7-c78f7494a4c2.png)
修复后：
![image](https://user-images.githubusercontent.com/5909445/207491168-ef8780ad-d325-49c6-baa8-6dc890ea0775.png)
