### PR TITLE
Zhl fix static file status

### DIFF
--- a/net/ghttp/ghttp_response_writer.go
+++ b/net/ghttp/ghttp_response_writer.go
@@ -16,10 +16,11 @@ import (
 
 // ResponseWriter is the custom writer for http response.
 type ResponseWriter struct {
-	Status   int                 // HTTP status.
-	writer   http.ResponseWriter // The underlying ResponseWriter.
-	buffer   *bytes.Buffer       // The output buffer.
-	hijacked bool                // Mark this request is hijacked or not.
+	Status      int                 // HTTP status.
+	writer      http.ResponseWriter // The underlying ResponseWriter.
+	buffer      *bytes.Buffer       // The output buffer.
+	hijacked    bool                // Mark this request is hijacked or not.
+	wroteHeader bool                // Is header wrote or not, avoiding error: superfluous/multiple response.WriteHeader call.
 }
 
 // RawWriter returns the underlying ResponseWriter.
@@ -54,7 +55,10 @@ func (w *ResponseWriter) Flush() {
 	if w.hijacked {
 		return
 	}
-	if w.Status != 0 && w.isHeaderWritten() {
+
+	if w.Status != 0 && !w.wroteHeader {
+		// if w.Status != 0 && !w.isHeaderWritten() {
+		w.wroteHeader = true
 		w.writer.WriteHeader(w.Status)
 	}
 	// Default status text output.

--- a/net/ghttp/ghttp_response_writer.go
+++ b/net/ghttp/ghttp_response_writer.go
@@ -54,7 +54,7 @@ func (w *ResponseWriter) Flush() {
 	if w.hijacked {
 		return
 	}
-	if w.Status != 0 && !w.isHeaderWritten() {
+	if w.Status != 0 && w.isHeaderWritten() {
 		w.writer.WriteHeader(w.Status)
 	}
 	// Default status text output.

--- a/net/ghttp/ghttp_server_handler.go
+++ b/net/ghttp/ghttp_server_handler.go
@@ -276,6 +276,7 @@ func (s *Server) serveFile(r *Request, f *staticFile, allowIndex ...bool) {
 			}
 		} else {
 			info := f.File.FileInfo()
+			r.Response.wroteHeader = true
 			http.ServeContent(r.Response.Writer.RawWriter(), r.Request, info.Name(), info.ModTime(), f.File)
 		}
 		return
@@ -300,6 +301,7 @@ func (s *Server) serveFile(r *Request, f *staticFile, allowIndex ...bool) {
 			r.Response.WriteStatus(http.StatusForbidden)
 		}
 	} else {
+		r.Response.wroteHeader = true
 		http.ServeContent(r.Response.Writer.RawWriter(), r.Request, info.Name(), info.ModTime(), file)
 	}
 }

--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -264,3 +264,24 @@ func Test_Issue2172(t *testing.T) {
 		t.Assert(c.PostContent(ctx, "/demo", dataReq), `{"code":0,"message":"","data":{"Content":"{\"asd\":1}"}}`)
 	})
 }
+
+// https://github.com/gogf/gf/issues/2334
+func Test_Issue2334(t *testing.T) {
+	s := g.Server(guid.S())
+	s.SetServerRoot(gtest.DataPath("static1"))
+	s.SetPort(8888)
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
+	time.Sleep(1000 * time.Millisecond)
+	fmt.Println("开始")
+	gtest.C(t, func(t *gtest.T) {
+		c := g.Client()
+		c.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+		t.Assert(c.GetContent(ctx, "/index.html"), "index")
+
+		c.SetHeader("If-Modified-Since", "Mon, 12 Dec 2022 05:53:35 GMT")
+		request, _ := c.Get(ctx, "/index.html")
+		t.Assert(request.StatusCode, 304)
+	})
+}

--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -279,7 +279,7 @@ func Test_Issue2334(t *testing.T) {
 		c := g.Client()
 		c.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
 		t.Assert(c.GetContent(ctx, "/index.html"), "index")
-
+		c = g.Client()
 		c.SetHeader("If-Modified-Since", "Mon, 12 Dec 2022 05:53:35 GMT")
 		request, _ := c.Get(ctx, "/index.html")
 		t.Assert(request.StatusCode, 304)

--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/gogf/gf/v2/util/guid"
 )
 
+var ctx = context.TODO()
+
 // https://github.com/gogf/gf/issues/1609
 func Test_Issue1609(t *testing.T) {
 	s := g.Server(guid.S())
@@ -274,14 +276,16 @@ func Test_Issue2334(t *testing.T) {
 	s.Start()
 	defer s.Shutdown()
 	time.Sleep(1000 * time.Millisecond)
-	fmt.Println("开始")
 	gtest.C(t, func(t *gtest.T) {
 		c := g.Client()
 		c.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
-		t.Assert(c.GetContent(ctx, "/index.html"), "index")
-		c = g.Client()
-		c.SetHeader("If-Modified-Since", "Mon, 12 Dec 2022 05:53:35 GMT")
 		request, _ := c.Get(ctx, "/index.html")
-		t.Assert(request.StatusCode, 304)
+		t.Assert(request.ReadAllString(), "index")
+
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+		client.SetHeader("If-Modified-Since", request.Header["Last-Modified"][0])
+		r, _ := client.Get(ctx, "/index.html")
+		t.Assert(r.StatusCode, 304)
 	})
 }

--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/gogf/gf/v2/util/guid"
 )
 
-var ctx = context.TODO()
-
 // https://github.com/gogf/gf/issues/1609
 func Test_Issue1609(t *testing.T) {
 	s := g.Server(guid.S())
@@ -284,7 +282,11 @@ func Test_Issue2334(t *testing.T) {
 
 		client := g.Client()
 		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
-		client.SetHeader("If-Modified-Since", request.Header["Last-Modified"][0])
+		lastModified := ""
+		if _, ok := request.Header["Last-Modified"]; ok {
+			lastModified = request.Header["Last-Modified"][0]
+		}
+		client.SetHeader("If-Modified-Since", lastModified)
 		r, _ := client.Get(ctx, "/index.html")
 		t.Assert(r.StatusCode, 304)
 	})


### PR DESCRIPTION
Solve the problem of error when accessing static files with cache time.
Error message:
2022-11-29 19:40:11.090 [ERRO] http: superfluous response.WriteHeader call from github.com/gogf/gf/v2/net/ghttp.(*ResponseWriter).Flush (ghttp_response_writer.go:58)
Stack:

Verification method:
curl 'http://127.0.0.1:8000/' -H 'If-Modified-Since: Thu, 08 Dec 2022 03:13:55 GMT' --compressed