### PR TITLE
Openapi path security

### DIFF
--- a/net/goai/goai_path.go
+++ b/net/goai/goai_path.go
@@ -96,6 +96,7 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 			Responses:   map[string]ResponseRef{},
 			XExtensions: make(XExtensions),
 		}
+		seRequirement = SecurityRequirement{}
 	)
 	// Path check.
 	if in.Path == "" {
@@ -143,6 +144,18 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 		if mime = inputMetaMap[gtag.Mime]; mime == "" {
 			mime = inputMetaMap[gtag.Consumes]
 		}
+	}
+
+	// path security
+	// note: the security schema type only support http and apiKey;not support oauth2 and openIdConnect.
+	// multi schema separate with comma, e.g. `security: apiKey1,apiKey2`
+	TagNameSecurity := gmeta.Get(inputObject.Interface(), gtag.Security).String()
+	securities := gstr.SplitAndTrim(TagNameSecurity, ",")
+	for _, sec := range securities {
+		seRequirement[sec] = []string{}
+	}
+	if len(securities) > 0 {
+		operation.Security = &SecurityRequirements{seRequirement}
 	}
 
 	// =================================================================================================================

--- a/util/gtag/gtag.go
+++ b/util/gtag/gtag.go
@@ -44,4 +44,5 @@ const (
 	GConv             = "gconv"        // GConv defines the converting target name for specified struct field.
 	GConvShort        = "c"            // GConv defines the converting target name for specified struct field.
 	Json              = "json"         // Json tag is supported by stdlib.
+	Security          = "security"     // security schema.
 )


### PR DESCRIPTION
support openapi path security.
note: the security schema type only support http and apiKey;not support oauth2 and openIdConnect.
multi schema separate with comma, e.g. security: "apiKey1, apiKey2"

usage:
first: set global openapi definition SecurityScheme, befor server run.

func enhanceOpenAPIDoc(s *ghttp.Server) {
	openapi := s.GetOpenApi()
	
	openapi.Components = goai.Components{
		SecuritySchemes: goai.SecuritySchemes{
			"BearerAuth": goai.SecuritySchemeRef{
				Ref: "", 
				Value: &goai.SecurityScheme{
					Type:   "http",
					In:     "header",
					Name:   "Authorization",
					Scheme: "bearer",
				},
			},
		},
	}
}
second, set path security in every request struct with security tag in meta.
e.g.

type LogoutReq struct {
	g.Meta `summary:"用户退出" tags:"认证" security:"BearerAuth"`
	Uuid   string `json:"uuid" p:"uuid"  v:"required" in:"path" dc:"用户UUID"`
}
then, enjoy it.