### PR TITLE
Protect RemoveValue from race condition

### DIFF
--- a/container/garray/garray_sorted_any.go
+++ b/container/garray/garray_sorted_any.go
@@ -207,9 +207,11 @@ func (a *SortedArray) doRemoveWithoutLock(index int) (value interface{}, found b
 // RemoveValue removes an item by value.
 // It returns true if value is found in the array, or else false if not found.
 func (a *SortedArray) RemoveValue(value interface{}) bool {
-	if i := a.Search(value); i != -1 {
-		a.Remove(i)
-		return true
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if i, r := a.binSearch(value, false); r == 0 {
+		_, res := a.doRemoveWithoutLock(i)
+		return res
 	}
 	return false
 }

--- a/container/garray/garray_sorted_int.go
+++ b/container/garray/garray_sorted_int.go
@@ -193,9 +193,11 @@ func (a *SortedIntArray) doRemoveWithoutLock(index int) (value int, found bool) 
 // RemoveValue removes an item by value.
 // It returns true if value is found in the array, or else false if not found.
 func (a *SortedIntArray) RemoveValue(value int) bool {
-	if i := a.Search(value); i != -1 {
-		_, found := a.Remove(i)
-		return found
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if i, r := a.binSearch(value, false); r == 0 {
+		_, res := a.doRemoveWithoutLock(i)
+		return res
 	}
 	return false
 }

--- a/container/garray/garray_sorted_str.go
+++ b/container/garray/garray_sorted_str.go
@@ -179,9 +179,11 @@ func (a *SortedStrArray) doRemoveWithoutLock(index int) (value string, found boo
 // RemoveValue removes an item by value.
 // It returns true if value is found in the array, or else false if not found.
 func (a *SortedStrArray) RemoveValue(value string) bool {
-	if i := a.Search(value); i != -1 {
-		a.Remove(i)
-		return true
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if i, r := a.binSearch(value, false); r == 0 {
+		_, res := a.doRemoveWithoutLock(i)
+		return res
 	}
 	return false
 }


### PR DESCRIPTION
When multiple gouroutines are trying to remove values from the same garray. After one routine calculate the index to remove, the other one could have removed the value before the calculated index, causing the index to shift and remove the wrong element. Making both the search and remove action atomic solve this problem.