### PR TITLE
fix: when using association query, when the associated entity query i…

### DIFF
--- a/database/gdb/gdb_model_with.go
+++ b/database/gdb/gdb_model_with.go
@@ -71,6 +71,9 @@ func (m *Model) doWithScanStruct(pointer interface{}) error {
 		err                 error
 		allowedTypeStrArray = make([]string, 0)
 	)
+	if pointer == nil {
+		return nil
+	}
 	currentStructFieldMap, err := gstructs.FieldMap(gstructs.FieldMapInput{
 		Pointer:          pointer,
 		PriorityTagArray: nil,


### PR DESCRIPTION
fix: when using association query, when the associated entity query is empty, the associated field with zero value will still be used for recursive query.

Example:

```go
type OrderRes struct {
	gmeta.Meta `orm:"table:order"`
	Id         int64           `json:"id"`
	UserId     int64           `json:"user_id"`
	Subject    string          `json:"subject"`
	OrderNo    string          `json:"order_no"`

	PlaceOrder *PlaceOrder `json:"place_order,omitempty" orm:"with:order_id=id"`
	ActorOrder *ActorOrder `json:"actor_order,omitempty" orm:"with:order_id=id"`
}

type PlaceOrder struct {
	gmeta.Meta      `orm:"table:place_order"`
	Id              int64                `json:"-"`
	PlaceId         int64                `json:"place_id"`
	Status          api.PlaceOrderStatus `json:"status"`
	AppointmentTime gtime.Time           `json:"appointment_time"` 
	WriteOffTime    *gtime.Time          `json:"write_off_time,omitempty"`
	Place           *Place               `json:"place" orm:"with:id=place_id"`
}

type Place struct {
	gmeta.Meta    `orm:"table:place"`
	Id            int64   `json:"id"`
	Name          string  `json:"name"`
	MainImage     string  `json:"main_image"` 
}
```

if PlaceOrder return 0 rows, gdb will continue query Place by id = 0