### PR TITLE
fix: gredis maxActive config and duplicate connection bug

### DIFF
--- a/contrib/nosql/redis/redis.go
+++ b/contrib/nosql/redis/redis.go
@@ -47,6 +47,7 @@ func New(config *gredis.Config) *Redis {
 		Password:     config.Pass,
 		DB:           config.Db,
 		MaxRetries:   defaultMaxRetries,
+		PoolSize:     config.MaxActive,
 		MinIdleConns: config.MinIdle,
 		MaxConnAge:   config.MaxConnLifetime,
 		IdleTimeout:  config.IdleTimeout,

--- a/database/gredis/gredis.go
+++ b/database/gredis/gredis.go
@@ -58,7 +58,7 @@ func New(config ...*Config) (*Redis, error) {
 	}
 	redis := &Redis{
 		config:       config[0],
-		localAdapter: defaultAdapterFunc(config[0]),
+		localAdapter: usedAdapter,
 	}
 	return redis.initGroup(), nil
 }


### PR DESCRIPTION
- maxActive没生效
- redis adapter初始化了两次