### PR TITLE
add `Quick`  mode for gtimer

### DIFF
--- a/os/gtimer/gtimer.go
+++ b/os/gtimer/gtimer.go
@@ -42,6 +42,7 @@ type Timer struct {
 // TimerOptions is the configuration object for Timer.
 type TimerOptions struct {
 	Interval time.Duration // Interval is the interval escaped of the timer.
+	Quick    bool          // Quick is used for quick timer, which means the timer will not wait for the first interval to be elapsed.
 }
 
 // internalPanic is the custom panic for internal usage.

--- a/os/gtimer/gtimer_timer.go
+++ b/os/gtimer/gtimer_timer.go
@@ -22,6 +22,9 @@ func New(options ...TimerOptions) *Timer {
 	}
 	if len(options) > 0 {
 		t.options = options[0]
+		if t.options.Interval == 0 {
+			t.options.Interval = defaultInterval
+		}
 	} else {
 		t.options = DefaultOptions()
 	}

--- a/os/gtimer/gtimer_timer.go
+++ b/os/gtimer/gtimer_timer.go
@@ -166,7 +166,8 @@ type createEntryInput struct {
 // createEntry creates and adds a timing job to the timer.
 func (t *Timer) createEntry(in createEntryInput) *Entry {
 	var (
-		infinite = false
+		infinite  = false
+		nextTicks int64
 	)
 	if in.Times <= 0 {
 		infinite = true
@@ -182,11 +183,12 @@ func (t *Timer) createEntry(in createEntryInput) *Entry {
 	if t.options.Quick {
 		// If the quick mode is enabled, which means it will be run right now.
 		// Don't need to wait for the first interval.
-		intervalTicksOfJob = 0
+		nextTicks = t.ticks.Val()
+	} else {
+		nextTicks = t.ticks.Val() + intervalTicksOfJob
 	}
 	var (
-		nextTicks = t.ticks.Val() + intervalTicksOfJob
-		entry     = &Entry{
+		entry = &Entry{
 			job:         in.Job,
 			ctx:         in.Ctx,
 			timer:       t,

--- a/os/gtimer/gtimer_timer.go
+++ b/os/gtimer/gtimer_timer.go
@@ -179,6 +179,11 @@ func (t *Timer) createEntry(in createEntryInput) *Entry {
 		// then sets it to one tick, which means it will be run in one interval.
 		intervalTicksOfJob = 1
 	}
+	if t.options.Quick {
+		// If the quick mode is enabled, which means it will be run right now.
+		// Don't need to wait for the first interval.
+		intervalTicksOfJob = 0
+	}
 	var (
 		nextTicks = t.ticks.Val() + intervalTicksOfJob
 		entry     = &Entry{

--- a/os/gtimer/gtimer_z_unit_entry_test.go
+++ b/os/gtimer/gtimer_z_unit_entry_test.go
@@ -60,6 +60,27 @@ func TestJob_Singleton(t *testing.T) {
 	})
 }
 
+func TestJob_SingletonQuick(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		timer := gtimer.New(gtimer.TimerOptions{
+			Quick: true,
+		})
+		array := garray.New(true)
+		job := timer.Add(ctx, 5*time.Second, func(ctx context.Context) {
+			array.Append(1)
+			time.Sleep(10 * time.Second)
+		})
+		t.Assert(job.IsSingleton(), false)
+		job.SetSingleton(true)
+		t.Assert(job.IsSingleton(), true)
+		time.Sleep(250 * time.Millisecond)
+		t.Assert(array.Len(), 1)
+
+		time.Sleep(250 * time.Millisecond)
+		t.Assert(array.Len(), 1)
+	})
+}
+
 func TestJob_SetTimes(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		timer := gtimer.New()

--- a/os/gtimer/gtimer_z_unit_timer_test.go
+++ b/os/gtimer/gtimer_z_unit_timer_test.go
@@ -103,6 +103,44 @@ func TestTimer_AddSingleton(t *testing.T) {
 	})
 }
 
+func TestTimer_AddSingletonWithQuick(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		timer := gtimer.New(gtimer.TimerOptions{
+			Interval: 100 * time.Millisecond,
+			Quick:    true,
+		})
+		array := garray.New(true)
+		timer.AddSingleton(ctx, 5*time.Second, func(ctx context.Context) {
+			array.Append(1)
+			time.Sleep(10 * time.Second)
+		})
+		time.Sleep(250 * time.Millisecond)
+		t.Assert(array.Len(), 1)
+
+		time.Sleep(500 * time.Millisecond)
+		t.Assert(array.Len(), 1)
+	})
+}
+
+func TestTimer_AddSingletonWithoutQuick(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		timer := gtimer.New(gtimer.TimerOptions{
+			Interval: 100 * time.Millisecond,
+			Quick:    false,
+		})
+		array := garray.New(true)
+		timer.AddSingleton(ctx, 5*time.Second, func(ctx context.Context) {
+			array.Append(1)
+			time.Sleep(10 * time.Second)
+		})
+		time.Sleep(250 * time.Millisecond)
+		t.Assert(array.Len(), 0)
+
+		time.Sleep(500 * time.Millisecond)
+		t.Assert(array.Len(), 0)
+	})
+}
+
 func TestTimer_AddOnce(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		timer := gtimer.New()


### PR DESCRIPTION
This commit adds a new `Quick` bool to the timer code, which can be used to set the timer to quickly run without waiting for the first interval to be elapsed. This can be useful in certain scenarios where time-sensitive operations need to be performed immediately. 

此提交向 gtimer 添加了一个新的“Quick”布尔值，可用于将计时器设置为添加任务后立即执行，而无需等待第一个间隔结束。 这在某些需要立即执行时间敏感操作的场景中很有用。

PS：现在假设我添加一个30分钟执行的任务，则需要30分钟后才能第一次执行！