### PR TITLE
comment updates for gdb.Builder

### DIFF
--- a/contrib/drivers/mysql/mysql_feature_model_builder_test.go
+++ b/contrib/drivers/mysql/mysql_feature_model_builder_test.go
@@ -34,7 +34,7 @@ func Test_Model_Builder(t *testing.T) {
 	// Where And
 	gtest.C(t, func(t *gtest.T) {
 		m := db.Model(table)
-		b := m.Builder()
+		b := m.Safe().Builder()
 
 		all, err := m.Where(
 			b.Where("id", g.Slice{1, 2, 3}).WhereOr("id", g.Slice{4, 5, 6}),
@@ -50,7 +50,7 @@ func Test_Model_Builder(t *testing.T) {
 	// Where Or
 	gtest.C(t, func(t *gtest.T) {
 		m := db.Model(table)
-		b := m.Builder()
+		b := m.Safe().Builder()
 
 		all, err := m.WhereOr(
 			b.Where("id", g.Slice{1, 2, 3}).WhereOr("id", g.Slice{4, 5, 6}),

--- a/contrib/drivers/mysql/mysql_feature_model_builder_test.go
+++ b/contrib/drivers/mysql/mysql_feature_model_builder_test.go
@@ -34,7 +34,7 @@ func Test_Model_Builder(t *testing.T) {
 	// Where And
 	gtest.C(t, func(t *gtest.T) {
 		m := db.Model(table)
-		b := m.Safe().Builder()
+		b := m.Builder()
 
 		all, err := m.Where(
 			b.Where("id", g.Slice{1, 2, 3}).WhereOr("id", g.Slice{4, 5, 6}),
@@ -50,7 +50,7 @@ func Test_Model_Builder(t *testing.T) {
 	// Where Or
 	gtest.C(t, func(t *gtest.T) {
 		m := db.Model(table)
-		b := m.Safe().Builder()
+		b := m.Builder()
 
 		all, err := m.WhereOr(
 			b.Where("id", g.Slice{1, 2, 3}).WhereOr("id", g.Slice{4, 5, 6}),
@@ -127,16 +127,9 @@ func Test_Model_Builder(t *testing.T) {
 }
 
 func Test_Safe_Builder(t *testing.T) {
-	// test whether m.Builder is not chain safe
+	// test whether m.Builder() is chain safe
 	gtest.C(t, func(t *gtest.T) {
 		b := db.Model().Builder()
-		b.Where("id", 1)
-		_, args := b.Build()
-		t.Assert(args, g.Slice{1})
-	})
-	// test whether m.Safe().Builder() is chain safe
-	gtest.C(t, func(t *gtest.T) {
-		b := db.Model().Safe().Builder()
 		b.Where("id", 1)
 		_, args := b.Build()
 		t.AssertNil(args)

--- a/contrib/drivers/mysql/mysql_feature_model_builder_test.go
+++ b/contrib/drivers/mysql/mysql_feature_model_builder_test.go
@@ -125,3 +125,24 @@ func Test_Model_Builder(t *testing.T) {
 		t.Assert(args, []interface{}{1})
 	})
 }
+
+func Test_Safe_Builder(t *testing.T) {
+	// test whether m.Builder is not chain safe
+	gtest.C(t, func(t *gtest.T) {
+		b := db.Model().Builder()
+		b.Where("id", 1)
+		_, args := b.Build()
+		t.Assert(args, g.Slice{1})
+	})
+	// test whether m.Safe().Builder() is chain safe
+	gtest.C(t, func(t *gtest.T) {
+		b := db.Model().Safe().Builder()
+		b.Where("id", 1)
+		_, args := b.Build()
+		t.AssertNil(args)
+
+		b = b.Where("id", 1)
+		_, args = b.Build()
+		t.Assert(args, g.Slice{1})
+	})
+}

--- a/database/gdb/gdb_model_builder.go
+++ b/database/gdb/gdb_model_builder.go
@@ -25,7 +25,7 @@ type WhereHolder struct {
 	Prefix   string        // Field prefix, eg: "user.", "order.".
 }
 
-// Builder creates and returns a WhereBuilder.
+// Builder creates and returns a WhereBuilder. Please note that the builder is chain-safe.
 func (m *Model) Builder() *WhereBuilder {
 	b := &WhereBuilder{
 		model:       m,
@@ -34,12 +34,8 @@ func (m *Model) Builder() *WhereBuilder {
 	return b
 }
 
-// getBuilder creates and returns a cloned WhereBuilder of current WhereBuilder if `safe` is true,
-// or else it returns the current WhereBuilder.
+// getBuilder creates and returns a cloned WhereBuilder of current WhereBuilder
 func (b *WhereBuilder) getBuilder() *WhereBuilder {
-	if !b.model.safe {
-		return b
-	}
 	return b.Clone()
 }
 

--- a/database/gdb/gdb_model_builder.go
+++ b/database/gdb/gdb_model_builder.go
@@ -37,6 +37,9 @@ func (m *Model) Builder() *WhereBuilder {
 // getBuilder creates and returns a cloned WhereBuilder of current WhereBuilder if `safe` is true,
 // or else it returns the current WhereBuilder.
 func (b *WhereBuilder) getBuilder() *WhereBuilder {
+	if !b.model.safe {
+		return b
+	}
 	return b.Clone()
 }
 


### PR DESCRIPTION
getBuilder creates and returns a cloned WhereBuilder of current WhereBuilder if `safe` is true,
or else it returns the current WhereBuilder.
But it seems that getBuilder directly returns b.Clone()