### PR TITLE
optimize the handling of the `SIGUSR1` signal

### DIFF
--- a/net/ghttp/ghttp_server_admin_unix.go
+++ b/net/ghttp/ghttp_server_admin_unix.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 
 	"github.com/gogf/gf/v2/internal/intlog"
+	"github.com/gogf/gf/v2/os/glog"
 )
 
 // procSignalChan is the channel for listening to the signal.
@@ -54,6 +55,13 @@ func handleProcessSignal() {
 
 		// Restart the servers.
 		case syscall.SIGUSR1:
+			// If the graceful restart feature is not enabled,
+			// it does nothing except printing a warning log.
+			if !gracefulEnabled {
+				glog.Warning(ctx, "graceful reload feature is disabled")
+				continue
+			}
+
 			if err := restartWebServers(ctx, sig.String()); err != nil {
 				intlog.Errorf(ctx, `%+v`, err)
 			}


### PR DESCRIPTION
当用户没有开启优雅重启选项(`graceful: true`)时, gf不会创建pid和port的映射文件, 所以如果用户通过 `kill -SIGUSR1 pid` 来重启服务, 当产生子进程后, 父进程不会退出. 不过通过`http://localhost:8000/debug/admin/restart` api来重启, 不会有这个问题, 因为gf不会重启, 只会响应 `graceful reload feature is disabled` 提示用户.

这个pl就是解决此种场景下用户通过 `kill -SIGUSR1 pid`重启服务导致的问题, 优化后的效果:
如果没有开启优雅重启, 服务接收到`SIGUSR1`信号后, 不会重启, 只会打印警告日志: 
`2023-03-21 10:35:17.292 [WARN] graceful reload feature is disabled`