### PR TITLE
fix bug

### DIFF
--- a/contrib/registry/etcd/etcd_discovery.go
+++ b/contrib/registry/etcd/etcd_discovery.go
@@ -22,6 +22,9 @@ func (r *Registry) Search(ctx context.Context, in gsvc.SearchInput) ([]gsvc.Serv
 		in.Prefix = gsvc.NewServiceWithName(in.Name).GetPrefix()
 	}
 
+	if in.Version != "" {
+		in.Prefix = gstr.Replace(in.Prefix, "latest", in.Version, -1)
+	}
 	res, err := r.kv.Get(ctx, in.Prefix, etcd3.WithPrefix())
 	if err != nil {
 		return nil, err

--- a/contrib/registry/etcd/etcd_discovery.go
+++ b/contrib/registry/etcd/etcd_discovery.go
@@ -21,9 +21,10 @@ func (r *Registry) Search(ctx context.Context, in gsvc.SearchInput) ([]gsvc.Serv
 	if in.Prefix == "" && in.Name != "" {
 		in.Prefix = gsvc.NewServiceWithName(in.Name).GetPrefix()
 	}
-
 	if in.Version != "" {
-		in.Prefix = gstr.Replace(in.Prefix, "latest", in.Version, -1)
+		split := gstr.Split(in.Prefix, "/")
+		split[len(split)-1] = in.Version
+		in.Prefix = gstr.Join(split, "/")
 	}
 	res, err := r.kv.Get(ctx, in.Prefix, etcd3.WithPrefix())
 	if err != nil {

--- a/contrib/registry/etcd/etcd_z_test.go
+++ b/contrib/registry/etcd/etcd_z_test.go
@@ -24,6 +24,7 @@ func TestRegistry(t *testing.T) {
 	svc := &gsvc.LocalService{
 		Name:      guid.S(),
 		Endpoints: gsvc.NewEndpoints("127.0.0.1:8888"),
+		Version:   "test",
 		Metadata: map[string]interface{}{
 			"protocol": "https",
 		},
@@ -37,7 +38,8 @@ func TestRegistry(t *testing.T) {
 	// Search by name.
 	gtest.C(t, func(t *gtest.T) {
 		result, err := registry.Search(ctx, gsvc.SearchInput{
-			Name: svc.Name,
+			Name:    svc.Name,
+			Version: "test",
 		})
 		t.AssertNil(err)
 		t.Assert(len(result), 1)
@@ -57,7 +59,8 @@ func TestRegistry(t *testing.T) {
 	// Search by metadata.
 	gtest.C(t, func(t *gtest.T) {
 		result, err := registry.Search(ctx, gsvc.SearchInput{
-			Name: svc.GetName(),
+			Name:    svc.GetName(),
+			Version: "test",
 			Metadata: map[string]interface{}{
 				"protocol": "https",
 			},

--- a/contrib/registry/etcd/etcd_z_test.go
+++ b/contrib/registry/etcd/etcd_z_test.go
@@ -22,7 +22,7 @@ func TestRegistry(t *testing.T) {
 		registry = etcd.New(`127.0.0.1:2379`)
 	)
 	svc := &gsvc.LocalService{
-		Name:      guid.S(),
+		Name:      guid.S() + "latest",
 		Endpoints: gsvc.NewEndpoints("127.0.0.1:8888"),
 		Version:   "test",
 		Metadata: map[string]interface{}{


### PR DESCRIPTION
When registering a service with the parameter 'version', searching by name cannot find the service. It may need to replace the version field in in.Prefix with the user input 'version'