### PR TITLE
fix: When repairing protobuf to generate controllers, if the project …

### DIFF
--- a/cmd/gf/internal/cmd/genpb/genpb_controller.go
+++ b/cmd/gf/internal/cmd/genpb/genpb_controller.go
@@ -9,6 +9,7 @@ package genpb
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 	"github.com/gogf/gf/v2/frame/g"
@@ -85,7 +86,7 @@ func (c CGenPb) parseControllers(filePath string) ([]generateCtrl, error) {
 		func(match []string) string {
 			ctrl := generateCtrl{
 				Name:    match[1],
-				Package: gfile.Basename(gfile.Dir(gfile.Dir(filePath))),
+				Package: strings.ReplaceAll(gfile.Basename(gfile.Dir(gfile.Dir(filePath))), "-", "_"),
 				Version: gfile.Basename(gfile.Dir(filePath)),
 				Methods: make([]generateCtrlMethod, 0),
 			}


### PR DESCRIPTION
中文：gf的项目名称带了-关键字，在 gprc 生成 controller 的时候，controller 的包名也是带 - 的，这个是不符合 go 的包名规范的，而对于项目来说，很多人会以 - 来命名项目，应该将项目名称中带 - 的，替换为 _ 下划线，这样就符合规范了
英文：The project name of gf has the - keyword. When gprc generates controller, the package name of controller also contains -. This does not conform to the package name specification of go. For the project For example, many people will name projects with -, you should replace - in the project name with _ underscore, so that it conforms to the specification