### PR TITLE
Fix the problem of missing decimal precision at a lower cost, and implement custom type mapping when implementing `gen dao`

### DIFF
--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -24,11 +24,10 @@ import (
 )
 
 const (
-	CGenDaoConfig  = `gfcli.gen.dao`
-	CGenDaoMapping = `gfcli.gen.mapping`
-	CGenDaoUsage   = `gf gen dao [OPTION]`
-	CGenDaoBrief   = `automatically generate go files for dao/do/entity`
-	CGenDaoEg      = `
+	CGenDaoConfig = `gfcli.gen.dao`
+	CGenDaoUsage  = `gf gen dao [OPTION]`
+	CGenDaoBrief  = `automatically generate go files for dao/do/entity`
+	CGenDaoEg     = `
 gf gen dao
 gf gen dao -l "mysql:root:12345678@tcp(127.0.0.1:3306)/test"
 gf gen dao -p ./model -g user-center -t user,user_detail,user_login

--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	CGenDaoConfig = `gfcli.gen.dao`
-	CGenDaoUsage  = `gf gen dao [OPTION]`
-	CGenDaoBrief  = `automatically generate go files for dao/do/entity`
-	CGenDaoEg     = `
+	CGenDaoConfig  = `gfcli.gen.dao`
+	CGenDaoMapping = `gfcli.gen.mapping`
+	CGenDaoUsage   = `gf gen dao [OPTION]`
+	CGenDaoBrief   = `automatically generate go files for dao/do/entity`
+	CGenDaoEg      = `
 gf gen dao
 gf gen dao -l "mysql:root:12345678@tcp(127.0.0.1:3306)/test"
 gf gen dao -p ./model -g user-center -t user,user_detail,user_login
@@ -145,33 +146,39 @@ func init() {
 }
 
 type (
-	CGenDao      struct{}
+	CGenDao     struct{}
+	CGenMapping struct {
+		Type   string `name:"type"`
+		Dest   string `name:"dest"`
+		Import string `name:"import"`
+	}
 	CGenDaoInput struct {
 		g.Meta             `name:"dao" config:"{CGenDaoConfig}" usage:"{CGenDaoUsage}" brief:"{CGenDaoBrief}" eg:"{CGenDaoEg}" ad:"{CGenDaoAd}"`
-		Path               string `name:"path"                short:"p"  brief:"{CGenDaoBriefPath}" d:"internal"`
-		Link               string `name:"link"                short:"l"  brief:"{CGenDaoBriefLink}"`
-		Tables             string `name:"tables"              short:"t"  brief:"{CGenDaoBriefTables}"`
-		TablesEx           string `name:"tablesEx"            short:"x"  brief:"{CGenDaoBriefTablesEx}"`
-		Group              string `name:"group"               short:"g"  brief:"{CGenDaoBriefGroup}" d:"default"`
-		Prefix             string `name:"prefix"              short:"f"  brief:"{CGenDaoBriefPrefix}"`
-		RemovePrefix       string `name:"removePrefix"        short:"r"  brief:"{CGenDaoBriefRemovePrefix}"`
-		JsonCase           string `name:"jsonCase"            short:"j"  brief:"{CGenDaoBriefJsonCase}" d:"CamelLower"`
-		ImportPrefix       string `name:"importPrefix"        short:"i"  brief:"{CGenDaoBriefImportPrefix}"`
-		DaoPath            string `name:"daoPath"             short:"d"  brief:"{CGenDaoBriefDaoPath}" d:"dao"`
-		DoPath             string `name:"doPath"              short:"o"  brief:"{CGenDaoBriefDoPath}" d:"model/do"`
-		EntityPath         string `name:"entityPath"          short:"e"  brief:"{CGenDaoBriefEntityPath}" d:"model/entity"`
-		TplDaoIndexPath    string `name:"tplDaoIndexPath"     short:"t1" brief:"{CGenDaoBriefTplDaoIndexPath}"`
-		TplDaoInternalPath string `name:"tplDaoInternalPath"  short:"t2" brief:"{CGenDaoBriefTplDaoInternalPath}"`
-		TplDaoDoPath       string `name:"tplDaoDoPath"        short:"t3" brief:"{CGenDaoBriefTplDaoDoPathPath}"`
-		TplDaoEntityPath   string `name:"tplDaoEntityPath"    short:"t4" brief:"{CGenDaoBriefTplDaoEntityPath}"`
-		StdTime            bool   `name:"stdTime"             short:"s"  brief:"{CGenDaoBriefStdTime}" orphan:"true"`
-		WithTime           bool   `name:"withTime"            short:"w"  brief:"{CGenDaoBriefWithTime}" orphan:"true"`
-		GJsonSupport       bool   `name:"gJsonSupport"        short:"n"  brief:"{CGenDaoBriefGJsonSupport}" orphan:"true"`
-		OverwriteDao       bool   `name:"overwriteDao"        short:"v"  brief:"{CGenDaoBriefOverwriteDao}" orphan:"true"`
-		DescriptionTag     bool   `name:"descriptionTag"      short:"c"  brief:"{CGenDaoBriefDescriptionTag}" orphan:"true"`
-		NoJsonTag          bool   `name:"noJsonTag"           short:"k"  brief:"{CGenDaoBriefNoJsonTag}" orphan:"true"`
-		NoModelComment     bool   `name:"noModelComment"      short:"m"  brief:"{CGenDaoBriefNoModelComment}" orphan:"true"`
-		Clear              bool   `name:"clear"               short:"a"  brief:"{CGenDaoBriefClear}" orphan:"true"`
+		Path               string         `name:"path"                short:"p"  brief:"{CGenDaoBriefPath}" d:"internal"`
+		Link               string         `name:"link"                short:"l"  brief:"{CGenDaoBriefLink}"`
+		Tables             string         `name:"tables"              short:"t"  brief:"{CGenDaoBriefTables}"`
+		TablesEx           string         `name:"tablesEx"            short:"x"  brief:"{CGenDaoBriefTablesEx}"`
+		Group              string         `name:"group"               short:"g"  brief:"{CGenDaoBriefGroup}" d:"default"`
+		Prefix             string         `name:"prefix"              short:"f"  brief:"{CGenDaoBriefPrefix}"`
+		RemovePrefix       string         `name:"removePrefix"        short:"r"  brief:"{CGenDaoBriefRemovePrefix}"`
+		JsonCase           string         `name:"jsonCase"            short:"j"  brief:"{CGenDaoBriefJsonCase}" d:"CamelLower"`
+		ImportPrefix       string         `name:"importPrefix"        short:"i"  brief:"{CGenDaoBriefImportPrefix}"`
+		DaoPath            string         `name:"daoPath"             short:"d"  brief:"{CGenDaoBriefDaoPath}" d:"dao"`
+		DoPath             string         `name:"doPath"              short:"o"  brief:"{CGenDaoBriefDoPath}" d:"model/do"`
+		EntityPath         string         `name:"entityPath"          short:"e"  brief:"{CGenDaoBriefEntityPath}" d:"model/entity"`
+		TplDaoIndexPath    string         `name:"tplDaoIndexPath"     short:"t1" brief:"{CGenDaoBriefTplDaoIndexPath}"`
+		TplDaoInternalPath string         `name:"tplDaoInternalPath"  short:"t2" brief:"{CGenDaoBriefTplDaoInternalPath}"`
+		TplDaoDoPath       string         `name:"tplDaoDoPath"        short:"t3" brief:"{CGenDaoBriefTplDaoDoPathPath}"`
+		TplDaoEntityPath   string         `name:"tplDaoEntityPath"    short:"t4" brief:"{CGenDaoBriefTplDaoEntityPath}"`
+		StdTime            bool           `name:"stdTime"             short:"s"  brief:"{CGenDaoBriefStdTime}" orphan:"true"`
+		WithTime           bool           `name:"withTime"            short:"w"  brief:"{CGenDaoBriefWithTime}" orphan:"true"`
+		GJsonSupport       bool           `name:"gJsonSupport"        short:"n"  brief:"{CGenDaoBriefGJsonSupport}" orphan:"true"`
+		OverwriteDao       bool           `name:"overwriteDao"        short:"v"  brief:"{CGenDaoBriefOverwriteDao}" orphan:"true"`
+		DescriptionTag     bool           `name:"descriptionTag"      short:"c"  brief:"{CGenDaoBriefDescriptionTag}" orphan:"true"`
+		NoJsonTag          bool           `name:"noJsonTag"           short:"k"  brief:"{CGenDaoBriefNoJsonTag}" orphan:"true"`
+		NoModelComment     bool           `name:"noModelComment"      short:"m"  brief:"{CGenDaoBriefNoModelComment}" orphan:"true"`
+		Clear              bool           `name:"clear"               short:"a"  brief:"{CGenDaoBriefClear}" orphan:"true"`
+		Mapping            []*CGenMapping `json:"mapping" name:"-"`
 	}
 	CGenDaoOutput struct{}
 
@@ -310,8 +317,18 @@ func doGenDaoForArray(ctx context.Context, index int, in CGenDaoInput) {
 func getImportPartContent(source string, isDo bool) string {
 	var (
 		packageImportsArray = garray.NewStrArray()
+		array               = gstr.SplitAndTrim(source, "#")
+		imports             = make(map[string]struct{})
 	)
-
+	for _, v := range array {
+		if gstr.HasPrefix(v, "import==") {
+			pack := gstr.TrimLeftStr(v, "import==")
+			imports[pack] = struct{}{}
+		}
+	}
+	for k := range imports {
+		packageImportsArray.Append(fmt.Sprintf(`"%s"`, k))
+	}
 	if isDo {
 		packageImportsArray.Append(`"github.com/gogf/gf/v2/frame/g"`)
 	}

--- a/database/gdb/gdb_core_structure.go
+++ b/database/gdb/gdb_core_structure.go
@@ -174,12 +174,11 @@ func (c *Core) CheckLocalTypeForField(ctx context.Context, fieldType string, fie
 	case
 		"float",
 		"double",
-		"decimal",
 		"money",
-		"numeric",
 		"smallmoney":
 		return LocalTypeFloat64, nil
-
+	case "decimal", "numeric":
+		return LocalTypeString, nil
 	case
 		"bit":
 		// It is suggested using bit(1) as boolean.


### PR DESCRIPTION
Issue：https://github.com/gogf/gf/issues/2685

change：
1. [Change the decimal and numeric type mapping to string](https://github.com/gogf/gf/commit/95cb81644f45b0dace21e3b99987f0571e6b8516)
2. [Support custom type mapping when gen dao generates entity](https://github.com/gogf/gf/commit/71d90878aed55a9babd3ca21677cac6a470eac97)

How To Use it:
Configration at hack/config.yaml Like:
```

# 工具相关配置
gfcli:
  # 工具编译配置
  build:
    name:     "focus"
    arch:     "amd64"
    system:   "linux,darwin,windows"
    mod:      ""
    cgo:      0

  # dao生成
  gen:
    dao:
      - link:            "sqlite::@file(manifest/document/sqlite/focus.db)"
        removePrefix:    "gf_"
        descriptionTag:  true
        noModelComment:  false
        mapping:
          - type: "decimal"    # 匹配的数据库类型
            dest: "decimal.Decimal"  # 自定义映射的类型
            import: "github.com/shopspring/decimal"  # （可选）自定义映射类型需要导入的包，如果是内置类型则不需要导入
```
then it will be:
```
package entity

import (
	"github.com/gogf/gf/v2/os/gtime"
	"github.com/shopspring/decimal"
)

// User is the golang structure for table user.
type User struct {
	Id        uint `json:"id"        description:""` //
	Value     decimal.Decimal `json:"value"        description:""` //  // #import==github.com/shopspring/decimal#
	Passport  string          `json:"passport"  description:""` //
	Password  string          `json:"password"  description:""` //
	Nickname  string          `json:"nickname"  description:""` //
	Avatar    string          `json:"avatar"    description:""` //
	Status    int             `json:"status"    description:""` //
	Gender    int             `json:"gender"    description:""` //
	CreatedAt *gtime.Time     `json:"createdAt" description:""` //
	UpdatedAt *gtime.Time     `json:"updatedAt" description:""` //
}
```

Modified code is minimal and should be easy to read