### PR TITLE
bugfix : when using otel, calling gclient *Raw methods may result in null pointer exceptions

### DIFF
--- a/net/gclient/gclient_tracing_tracer.go
+++ b/net/gclient/gclient_tracing_tracer.go
@@ -73,9 +73,17 @@ func newClientTrace(ctx context.Context, span trace.Span, request *http.Request)
 func (ct *clientTracer) getConn(host string) {}
 
 func (ct *clientTracer) gotConn(info httptrace.GotConnInfo) {
+	remoteAddr := ""
+	if info.Conn.RemoteAddr() != nil {
+		remoteAddr = info.Conn.RemoteAddr().String()
+	}
+	localAddr := ""
+	if info.Conn.LocalAddr() != nil {
+		localAddr = info.Conn.LocalAddr().String()
+	}
 	ct.span.SetAttributes(
-		attribute.String(tracingAttrHttpAddressRemote, info.Conn.RemoteAddr().String()),
-		attribute.String(tracingAttrHttpAddressLocal, info.Conn.LocalAddr().String()),
+		attribute.String(tracingAttrHttpAddressRemote, remoteAddr),
+		attribute.String(tracingAttrHttpAddressLocal, localAddr),
 	)
 }
 


### PR DESCRIPTION
bugfix : when using otel, calling gclient *Raw methods may result in null pointer exceptions。
<img width="763" alt="image" src="https://github.com/gogf/gf/assets/4269408/b47c335f-2039-4fdd-a5c0-a7cca1097c32">
