### PR TITLE
Implemented `stop`/`start`/`IsRunning` for grpool, it is now possible to suspend the grpool instead of recreating after shutdown

### DIFF
--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -18,6 +18,9 @@ func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsClosed() {
 		gtimer.Exit()
 	}
+	if !p.running.Val() {
+		return
+	}
 	if p.list.Size() > 0 && p.count.Val() == 0 {
 		var number = p.list.Size()
 		if p.limit > 0 {

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -43,6 +43,36 @@ func Test_Basic(t *testing.T) {
 	})
 }
 
+func Test_Basic2(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			pool  = grpool.New()
+			err   error
+			wg    = sync.WaitGroup{}
+			array = garray.NewArray(true)
+			size  = 100
+		)
+		pool.Stop() // Stop it before adding jobs.
+		wg.Add(size)
+		for i := 0; i < size; i++ {
+			err = pool.Add(ctx, func(ctx context.Context) {
+				array.Append(1)
+				wg.Done()
+			})
+			t.AssertNil(err)
+		}
+		time.Sleep(100 * time.Millisecond)
+		t.Assert(pool.Jobs(), size)
+		t.Assert(pool.Size(), 0)
+		pool.Start()
+		wg.Wait()
+		time.Sleep(100 * time.Millisecond)
+		t.Assert(array.Len(), size)
+		t.Assert(pool.Jobs(), 0)
+		t.Assert(pool.Size(), 0)
+	})
+}
+
 func Test_Limit1(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (


### PR DESCRIPTION
Implemented stop/start/IsRunning for grpool, it is now possible to suspend the grpool instead of recreating after shutdown

Because there may be a lot of data in the queue, it will be inconvenient to restart loading data after stopping