### PR TITLE
fix issue #2677 the signal of client disconnect to server ignored

### DIFF
--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -84,6 +84,7 @@ func newRequest(s *Server, r *http.Request, w http.ResponseWriter) *Request {
 		Request:       r,
 		Response:      newResponse(s, w),
 		EnterTime:     gtime.TimestampMilli(),
+		context:       r.Context(),
 		originUrlPath: r.URL.Path,
 	}
 	request.Cookie = GetCookie(request)

--- a/net/ghttp/ghttp_request.go
+++ b/net/ghttp/ghttp_request.go
@@ -84,8 +84,8 @@ func newRequest(s *Server, r *http.Request, w http.ResponseWriter) *Request {
 		Request:       r,
 		Response:      newResponse(s, w),
 		EnterTime:     gtime.TimestampMilli(),
-		context:       r.Context(),
 		originUrlPath: r.URL.Path,
+		context:       r.Context(),
 	}
 	request.Cookie = GetCookie(request)
 	request.Session = s.sessionManager.New(


### PR DESCRIPTION
When constructing a new ghttp.Request, the context should be set as the underlying context of wrapped http.Request.