### PR TITLE
fix issue in converting value to nil when calling IsNil return ture for gdb.Core

### DIFF
--- a/contrib/drivers/mysql/mysql_basic_test.go
+++ b/contrib/drivers/mysql/mysql_basic_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/gogf/gf/v2/container/gvar"
 	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/encoding/gjson"
 	"github.com/gogf/gf/v2/test/gtest"
 )
 
@@ -41,6 +43,47 @@ func Test_Func_ConvertDataForRecord(t *testing.T) {
 		t.AssertNil(err)
 		t.Assert(len(m), 1)
 		t.Assert(m["reset_password_token_at"], nil)
+	})
+
+	type TestNil struct {
+		JsonEmptyString *gjson.Json `orm:"json_empty_string"`
+		JsonNil         *gjson.Json `orm:"json_nil"`
+		JsonNull        *gjson.Json `orm:"json_null"`
+		VarEmptyString  *gvar.Var   `orm:"var_empty_string"`
+		VarNil          *gvar.Var   `orm:"var_nil"`
+	}
+	gtest.C(t, func(t *gtest.T) {
+		c := &gdb.Core{}
+		m, err := c.ConvertDataForRecord(nil, TestNil{
+			JsonEmptyString: gjson.New(""),
+			JsonNil:         gjson.New(nil),
+			JsonNull:        gjson.New(struct{}{}),
+			VarEmptyString:  gvar.New(""),
+			VarNil:          gvar.New(nil),
+		})
+
+		t.AssertNil(err)
+		t.Assert(len(m), 5)
+
+		valueEmptyString, exist := m["json_empty_string"]
+		t.Assert(exist, true)
+		t.Assert(valueEmptyString, nil)
+
+		valueNil, exist := m["json_nil"]
+		t.Assert(exist, true)
+		t.Assert(valueNil, nil)
+
+		valueNull, exist := m["json_null"]
+		t.Assert(exist, true)
+		t.Assert(valueNull, "null")
+
+		valueEmptyString, exist = m["var_empty_string"]
+		t.Assert(exist, true)
+		t.Assert(valueEmptyString, "")
+
+		valueNil, exist = m["var_nil"]
+		t.Assert(exist, true)
+		t.Assert(valueNil, nil)
 	})
 }
 

--- a/database/gdb/gdb_core_structure.go
+++ b/database/gdb/gdb_core_structure.go
@@ -106,8 +106,13 @@ func (c *Core) ConvertDataForRecordValue(ctx context.Context, value interface{})
 			// Nothing to do.
 
 		default:
-			// Use string conversion in default.
-			if s, ok := value.(iString); ok {
+			// If `value` implements interface iNil,
+			// check its IsNil() function, if got ture,
+			// which will insert/update the value to database as "null".
+			if v, ok := value.(iNil); ok && v.IsNil() {
+				convertedValue = nil
+			} else if s, ok := value.(iString); ok {
+				// Use string conversion in default.
 				convertedValue = s.String()
 			} else {
 				// Convert the value to JSON.

--- a/database/gdb/gdb_func.go
+++ b/database/gdb/gdb_func.go
@@ -44,6 +44,11 @@ type iInterfaces interface {
 	Interfaces() []interface{}
 }
 
+// iNil if the type assert api for IsNil.
+type iNil interface {
+	IsNil() bool
+}
+
 // iTableName is the interface for retrieving table name for struct.
 type iTableName interface {
 	TableName() string


### PR DESCRIPTION
```go
// iString is the type assert api for String.
type iString interface {
	String() string
}

// iNil if the type assert api for IsNil.
type iNil interface {
	IsNil() bool
}
```
check whether `value` implements the `iNil` interface, before `iString` interface.


fix issue in converting `gjson.New('')` and `gjson.New(nil)` to `nil`, related Issues: #2719