### PR TITLE
feat: add an optional prefix key for gcache with redis

### DIFF
--- a/os/gcache/gcache_z_example_cache_test.go
+++ b/os/gcache/gcache_z_example_cache_test.go
@@ -687,7 +687,7 @@ func ExampleCache_SetAdapter() {
 		panic(err)
 	}
 	// Create redis cache adapter and set it to cache object.
-	cache.SetAdapter(gcache.NewAdapterRedis(redis))
+	cache.SetAdapter(gcache.NewAdapterRedis(redis, "gcacheTest:"))
 
 	// Set and Get using cache object.
 	err = cache.Set(ctx, cacheKey, cacheValue, time.Second)
@@ -720,7 +720,7 @@ func ExampleCache_GetAdapter() {
 	if err != nil {
 		panic(err)
 	}
-	cache.SetAdapter(gcache.NewAdapterRedis(redis))
+	cache.SetAdapter(gcache.NewAdapterRedis(redis, "gcacheTest:"))
 
 	// Set and Get using cache object.
 	err = cache.Set(ctx, cacheKey, cacheValue, time.Second)


### PR DESCRIPTION
需要注意的是，在诸如`Clear`、`Size`等在 Redis 中只提供了DB层面操作的函数逻辑上，当使用`prefix`时，将通过`Keys`筛选符合`prefix`的键名并执行相应操作。