### PR TITLE
refactor: add default client instance for contrib/sdk/httpclient

### DIFF
--- a/contrib/sdk/httpclient/httpclient.go
+++ b/contrib/sdk/httpclient/httpclient.go
@@ -32,8 +32,12 @@ type Client struct {
 
 // New creates and returns a http client for SDK.
 func New(config Config) *Client {
+	client := config.Client
+	if client == nil {
+		client = gclient.New()
+	}
 	return &Client{
-		Client: config.Client,
+		Client: client,
 		config: config,
 	}
 }


### PR DESCRIPTION
用户在使用`sdk/httpclient`的时候可能忽略或忘记定制http客户端, 此时应该为其提供一个默认的http客户端实例(`gclient.New()`), 否则程序将会异常退出.