### PR TITLE
fix issue #2816

### DIFF
--- a/cmd/gf/internal/cmd/genctrl/genctrl_generate_sdk.go
+++ b/cmd/gf/internal/cmd/genctrl/genctrl_generate_sdk.go
@@ -116,7 +116,7 @@ func (c *apiSdkGenerator) doGenerateSdkIClient(
 	if !gstr.Contains(fileContent, interfaceFuncDefinition) {
 		isDirty = true
 		fileContent, err = gregex.ReplaceString(
-			`(type iClient interface {[\s\S]*?)}`,
+			`(type IClient interface {[\s\S]*?)}`,
 			fmt.Sprintf("$1\t%s\n}", interfaceFuncDefinition),
 			fileContent,
 		)

--- a/cmd/gf/internal/consts/consts_gen_ctrl_template_sdk.go
+++ b/cmd/gf/internal/consts/consts_gen_ctrl_template_sdk.go
@@ -84,6 +84,7 @@ func (i *implementer) {ImplementerName}() {Module}.I{ImplementerName} {
 	client.Client = client.Prefix(prefix)
 	return &implementer{ImplementerName}{client}
 }
+
 `
 
 const TemplateGenCtrlSdkImplementerFunc = `


### PR DESCRIPTION
Fix the issue that `api/sdk/sdk.iclient.go` generated by `gf gen ctrl -k api/sdk` miss some content.

Fixes #2816.