### PR TITLE
fix: disable map tag `summary` and `description` from the OpenAPI `Operation` to `PathItem`

### DIFF
--- a/net/goai/goai_path.go
+++ b/net/goai/goai_path.go
@@ -135,6 +135,8 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 	}
 
 	if len(inputMetaMap) > 0 {
+		// Path and Operation are not the same thing, so it is necessary to copy a Meta for Path from Operation and edit it.
+		// And you know, we set the Summary and Description for Operation, not for Path, so we need to remove them.
 		inputMetaMapForPath := gmap.NewStrStrMapFrom(inputMetaMap).Clone()
 		inputMetaMapForPath.Removes([]string{
 			gtag.SummaryShort,
@@ -147,6 +149,7 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 		if err := oai.tagMapToPath(inputMetaMapForPath.Map(), &path); err != nil {
 			return err
 		}
+
 		if err := oai.tagMapToOperation(inputMetaMap, &operation); err != nil {
 			return err
 		}

--- a/net/goai/goai_path.go
+++ b/net/goai/goai_path.go
@@ -7,6 +7,7 @@
 package goai
 
 import (
+	"github.com/gogf/gf/v2/container/gmap"
 	"net/http"
 	"reflect"
 
@@ -134,7 +135,16 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 	}
 
 	if len(inputMetaMap) > 0 {
-		if err := oai.tagMapToPath(inputMetaMap, &path); err != nil {
+		inputMetaMapForPath := gmap.NewStrStrMapFrom(inputMetaMap).Clone()
+		inputMetaMapForPath.Removes([]string{
+			gtag.SummaryShort,
+			gtag.SummaryShort2,
+			gtag.Summary,
+			gtag.DescriptionShort,
+			gtag.DescriptionShort2,
+			gtag.Description,
+		})
+		if err := oai.tagMapToPath(inputMetaMapForPath.Map(), &path); err != nil {
 			return err
 		}
 		if err := oai.tagMapToOperation(inputMetaMap, &operation); err != nil {

--- a/net/goai/goai_z_unit_test.go
+++ b/net/goai/goai_z_unit_test.go
@@ -671,7 +671,7 @@ func TestOpenApiV3_ShortTags(t *testing.T) {
 	}
 	type CreateResourceReq struct {
 		CommonReq
-		gmeta.Meta `path:"/CreateResourceReq" method:"POST" tags:"default" sm:"CreateResourceReq sum"`
+		gmeta.Meta `path:"/CreateResourceReq" method:"POST" tags:"default" sm:"CreateResourceReq sum" dc:"CreateResourceReq des"`
 		Name       string                  `dc:"实例名称"`
 		Product    string                  `dc:"业务类型"`
 		Region     string                  `v:"required" dc:"区域"`
@@ -709,7 +709,10 @@ func TestOpenApiV3_ShortTags(t *testing.T) {
 		// fmt.Println(oai.String())
 		// Schema asserts.
 		t.Assert(len(oai.Components.Schemas.Map()), 3)
-		t.Assert(oai.Paths[`/test1/{appId}`].Summary, `CreateResourceReq sum`)
+		t.Assert(oai.Paths[`/test1/{appId}`].Summary, ``)
+		t.Assert(oai.Paths[`/test1/{appId}`].Description, ``)
+		t.Assert(oai.Paths[`/test1/{appId}`].Put.Summary, `CreateResourceReq sum`)
+		t.Assert(oai.Paths[`/test1/{appId}`].Put.Description, `CreateResourceReq des`)
 		t.Assert(oai.Paths[`/test1/{appId}`].Put.Parameters[1].Value.Schema.Value.Description, `资源Id`)
 		t.Assert(oai.Components.Schemas.Get(`github.com.gogf.gf.v2.net.goai_test.CreateResourceReq`).Value.Properties.Get(`Name`).Value.Description, `实例名称`)
 	})


### PR DESCRIPTION
因为当前 tag 都是针对 Operation 对象设置的，不应该将 Operation 的 summary 和 description 直接添加到 PathItem 。

如存在`POST /user`的 summary 为`新增用户`，存在`DELETE /user`的 summary 为`删除用户`，两者为相反操作，其 PathItem 的 summary 应当留空而不是使用其中一个。

实际测试：

```golang
package main

import (
	"context"
	"fmt"

	"github.com/gogf/gf/v2/frame/g"
	"github.com/gogf/gf/v2/net/ghttp"
)

type HelloReq struct {
	g.Meta `path:"/hello" method:"get" sm:"sm" dc:"dc"`
	Name   string `v:"required" dc:"Your name"`
}
type HelloRes struct {
	Reply string `dc:"Reply content"`
}

type Hello struct{}

func (Hello) Say(ctx context.Context, req *HelloReq) (res *HelloRes, err error) {
	g.Log().Debugf(ctx, `receive say: %+v`, req)
	res = &HelloRes{
		Reply: fmt.Sprintf(`Hi %s`, req.Name),
	}
	return
}

func main() {
	s := g.Server()
	s.Use(ghttp.MiddlewareHandlerResponse)
	s.Group("/", func(group *ghttp.RouterGroup) {
		group.Bind(
			new(Hello),
		)
	})
	s.Run()
}
```

```diff
{
    "openapi": "3.0.0",
    "components": {
        "schemas": {
            "main.HelloReq": {
                "description": "dc",
                "properties": {
                    "Name": {
                        "description": "Your name",
                        "format": "string",
                        "properties": {},
                        "type": "string"
                    }
                },
                "required": [
                    "Name"
                ],
                "type": "object"
            },
            "main.HelloRes": {
                "properties": {
                    "Reply": {
                        "description": "Reply content",
                        "format": "string",
                        "properties": {},
                        "type": "string"
                    }
                },
                "type": "object"
            }
        }
    },
    "info": {
        "title": "",
        "version": ""
    },
    "paths": {
        "/hello": {
-           "description": "dc",
            "get": {
                "description": "dc",
                "parameters": [
                    {
                        "description": "Your name",
                        "in": "query",
                        "name": "Name",
                        "required": true,
                        "schema": {
                            "description": "Your name",
                            "format": "string",
                            "properties": {},
                            "type": "string"
                        }
                    }
                ],
                "responses": {
                    "200": {
                        "content": {
                            "application/json": {
                                "schema": {
                                    "$ref": "#/components/schemas/main.HelloRes"
                                }
                            }
                        },
                        "description": ""
                    }
                },
                "summary": "sm"
+           }
-           },
-           "summary": "sm"
        }
    }
}
```

----

各家支持解析 OpenAPI 的工具对于 PathItem 中的 summary 和 description 并不友好，所以理论上不太存在需要自定义这两个字段的需求。

如 Apifox 会把 summary 当成一个方法：

![a31f5de0d3a28d3488b27bb8b0881c4](https://github.com/gogf/gf/assets/21287731/be0999e9-a3a8-452c-90d3-d535f7235ace)
