### PR TITLE
Modify the gproc.manager.KillAll function to prevent partial processes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,5 +26,6 @@ require (
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	golang.org/x/sys v0.10.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
+github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
 go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=

--- a/os/gproc/gproc.go
+++ b/os/gproc/gproc.go
@@ -10,6 +10,7 @@ package gproc
 import (
 	"os"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/gogf/gf/v2/os/genv"
@@ -116,4 +117,14 @@ func SearchBinaryPath(file string) string {
 		}
 	}
 	return ""
+}
+
+// ProcessExist Determining the existence of a process using its PID.
+func ProcessExist(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
 }

--- a/os/gproc/gproc.go
+++ b/os/gproc/gproc.go
@@ -119,12 +119,15 @@ func SearchBinaryPath(file string) string {
 	return ""
 }
 
-// ProcessExist Determining the existence of a process using its PID.
-func ProcessExist(pid int) bool {
+// GetProcessByPid Get process information based on PID, return nil when retrieval fails.
+func GetProcessByPid(pid int) *os.Process {
 	process, err := os.FindProcess(pid)
 	if err != nil {
-		return false
+		return nil
 	}
 	err = process.Signal(syscall.Signal(0))
-	return err == nil
+	if err != nil {
+		return nil
+	}
+	return process
 }

--- a/os/gproc/gproc_manager.go
+++ b/os/gproc/gproc_manager.go
@@ -86,29 +86,37 @@ func (m *Manager) WaitAll() {
 
 // KillAll kills all processes in current manager.
 func (m *Manager) KillAll() error {
+	processesToRemove := make([]int, 0)
 	for _, p := range m.Processes() {
 		if !ProcessExist(p.Pid()) {
-			m.RemoveProcess(p.Pid())
+			processesToRemove = append(processesToRemove, p.Pid())
 			continue
 		}
 		if err := p.Kill(); err != nil {
 			return err
 		}
 	}
+	for _, pid := range processesToRemove {
+		m.RemoveProcess(pid)
+	}
 	return nil
 }
 
 // SignalAll sends a signal `sig` to all processes in current manager.
 func (m *Manager) SignalAll(sig os.Signal) error {
+	processesToRemove := make([]int, 0)
 	for _, p := range m.Processes() {
 		if !ProcessExist(p.Pid()) {
-			m.RemoveProcess(p.Pid())
+			processesToRemove = append(processesToRemove, p.Pid())
 			continue
 		}
 		if err := p.Signal(sig); err != nil {
 			err = gerror.Wrapf(err, `send signal to process failed for pid "%d" with signal "%s"`, p.Process.Pid, sig)
 			return err
 		}
+	}
+	for _, pid := range processesToRemove {
+		m.RemoveProcess(pid)
 	}
 	return nil
 }

--- a/os/gproc/gproc_manager.go
+++ b/os/gproc/gproc_manager.go
@@ -89,7 +89,6 @@ func (m *Manager) WaitAll() {
 // Pid along with the corresponding error message.
 func (m *Manager) KillAll() map[int]error {
 	terminationFailed := make(map[int]error)
-
 	for _, p := range m.Processes() {
 		if err := p.Kill(); err != nil {
 			terminationFailed[p.Pid()] = err

--- a/os/gproc/gproc_manager.go
+++ b/os/gproc/gproc_manager.go
@@ -86,39 +86,28 @@ func (m *Manager) WaitAll() {
 
 // KillAll kills all processes in current manager.
 func (m *Manager) KillAll() error {
-	processesToRemove := make([]int, 0)
+	var err error
 	for _, p := range m.Processes() {
-		if !ProcessExist(p.Pid()) {
-			processesToRemove = append(processesToRemove, p.Pid())
-			continue
-		}
-		if err := p.Kill(); err != nil {
-			return err
+		if errTemp := p.Kill(); errTemp != nil {
+			if err == nil {
+				err = errTemp
+			}
 		}
 	}
-	for _, pid := range processesToRemove {
-		m.RemoveProcess(pid)
-	}
-	return nil
+	return err
 }
 
 // SignalAll sends a signal `sig` to all processes in current manager.
 func (m *Manager) SignalAll(sig os.Signal) error {
-	processesToRemove := make([]int, 0)
+	var err error
 	for _, p := range m.Processes() {
-		if !ProcessExist(p.Pid()) {
-			processesToRemove = append(processesToRemove, p.Pid())
-			continue
-		}
-		if err := p.Signal(sig); err != nil {
-			err = gerror.Wrapf(err, `send signal to process failed for pid "%d" with signal "%s"`, p.Process.Pid, sig)
-			return err
+		if errTemp := p.Signal(sig); errTemp != nil {
+			if err != nil {
+				err = gerror.Wrapf(err, `send signal to process failed for pid "%d" with signal "%s"`, p.Process.Pid, sig)
+			}
 		}
 	}
-	for _, pid := range processesToRemove {
-		m.RemoveProcess(pid)
-	}
-	return nil
+	return err
 }
 
 // Send sends data bytes to all processes in current manager.
@@ -128,7 +117,7 @@ func (m *Manager) Send(data []byte) {
 	}
 }
 
-// SendTo sneds data bytes to specified processe in current manager.
+// SendTo sends data bytes to specified processes in current manager.
 func (m *Manager) SendTo(pid int, data []byte) error {
 	return Send(pid, data)
 }

--- a/os/gproc/gproc_manager.go
+++ b/os/gproc/gproc_manager.go
@@ -84,14 +84,21 @@ func (m *Manager) WaitAll() {
 	}
 }
 
-// KillAll kills all processes in current manager.
-func (m *Manager) KillAll() error {
+// KillAll kills all processes in current manager.If killing
+// all processes succeeds, return nil; otherwise, return the
+// Pid along with the corresponding error message.
+func (m *Manager) KillAll() map[int]error {
+	terminationFailed := make(map[int]error)
+
 	for _, p := range m.Processes() {
 		if err := p.Kill(); err != nil {
-			return err
+			terminationFailed[p.Pid()] = err
 		}
 	}
-	return nil
+	if len(terminationFailed) == 0 {
+		return nil
+	}
+	return terminationFailed
 }
 
 // SignalAll sends a signal `sig` to all processes in current manager.


### PR DESCRIPTION
Modify the gproc.manager.KillAll function to prevent partial processes from not being terminated due to premature termination.