### PR TITLE
feat: add required mark support for OpenAPI Response

### DIFF
--- a/net/goai/goai.go
+++ b/net/goai/goai.go
@@ -106,7 +106,7 @@ func (oai *OpenApiV3) Add(in AddInput) error {
 	}
 	switch reflectValue.Kind() {
 	case reflect.Struct:
-		return oai.addSchema(in.Object)
+		return oai.addSchema(true, in.Object)
 
 	case reflect.Func:
 		return oai.addPath(addPathInput{

--- a/net/goai/goai_parameter_ref.go
+++ b/net/goai/goai_parameter_ref.go
@@ -78,7 +78,7 @@ func (oai *OpenApiV3) newParameterRefWithStructMethod(field gstructs.Field, path
 		return nil, gerror.NewCodef(gcode.CodeInvalidParameter, `invalid tag value "%s" for In`, parameter.In)
 	}
 	// Necessary schema or content.
-	schemaRef, err := oai.newSchemaRefWithGolangType(field.Type().Type, tagMap)
+	schemaRef, err := oai.newSchemaRefWithGolangType(field.Type().Type, tagMap, true)
 	if err != nil {
 		return nil, err
 	}

--- a/net/goai/goai_path.go
+++ b/net/goai/goai_path.go
@@ -129,7 +129,11 @@ func (oai *OpenApiV3) addPath(in addPathInput) error {
 		)
 	}
 
-	if err := oai.addSchema(inputObject.Interface(), outputObject.Interface()); err != nil {
+	if err := oai.addSchema(true, inputObject.Interface()); err != nil {
+		return err
+	}
+
+	if err := oai.addSchema(false, outputObject.Interface()); err != nil {
 		return err
 	}
 

--- a/net/goai/goai_requestbody.go
+++ b/net/goai/goai_requestbody.go
@@ -49,7 +49,7 @@ func (oai *OpenApiV3) getRequestSchemaRef(in getRequestSchemaRefInput) (*SchemaR
 	var (
 		dataFieldsPartsArray      = gstr.Split(in.RequestDataField, ".")
 		bizRequestStructSchemaRef = oai.Components.Schemas.Get(in.BusinessStructName)
-		schema, err               = oai.structToSchema(in.RequestObject)
+		schema, err               = oai.structToSchema(in.RequestObject, true)
 	)
 	if err != nil {
 		return nil, err

--- a/net/goai/goai_response_ref.go
+++ b/net/goai/goai_response_ref.go
@@ -45,7 +45,7 @@ func (oai *OpenApiV3) getResponseSchemaRef(in getResponseSchemaRefInput) (*Schem
 	var (
 		dataFieldsPartsArray       = gstr.Split(in.CommonResponseDataField, ".")
 		bizResponseStructSchemaRef = oai.Components.Schemas.Get(in.BusinessStructName)
-		schema, err                = oai.structToSchema(in.CommonResponseObject)
+		schema, err                = oai.structToSchema(in.CommonResponseObject, false)
 	)
 	if err != nil {
 		return nil, err

--- a/net/goai/goai_shema.go
+++ b/net/goai/goai_shema.go
@@ -219,6 +219,9 @@ func (oai *OpenApiV3) structToSchema(object interface{}, isReq bool) (*Schema, e
 				if ref.Value.Format[0:2] != "[]" && ref.Value.Format[0] != '*' {
 					schema.Required = append(schema.Required, key)
 				}
+			} else { // is struct or struct pointer
+				// todo if it is struct pointer, don't mark it as required
+				schema.Required = append(schema.Required, key)
 			}
 		}
 		if !isValidParameterName(key) {


### PR DESCRIPTION
添加对 OpenAPI 响应对象定义中各个字段是否 required 的支持。

Respone 中的 required 数组用于标记响应体中非 nullable 字段，而根据 Golang 特性，指针类型和切片类型是 nullable 的，所以可以根据类型标记所有响应体的 nullable 情况。