### PR TITLE
fix(ghttp): fix access log info format

### DIFF
--- a/net/ghttp/ghttp_server_log.go
+++ b/net/ghttp/ghttp_server_log.go
@@ -42,7 +42,7 @@ func (s *Server) handleAccessLog(r *Request) {
 		l.SetLevelPrint(false)
 		return l
 	}).(*glog.Logger)
-	logger.Printf(r.Context(), content)
+	logger.Print(r.Context(), content)
 }
 
 // handleErrorLog handles the error logging for server.


### PR DESCRIPTION
param with chinese char format error
<img width="1320" alt="image" src="https://github.com/gogf/gf/assets/20634646/81a5b988-b52f-413e-9b94-a0def90a106a">
<img width="1512" alt="image" src="https://github.com/gogf/gf/assets/20634646/eb76fcc9-d8c3-4590-be31-81e991729b44">
