### PR TITLE
fix: add a expiration clear callback function to gcache

### DIFF
--- a/os/gcache/gcache_adapter.go
+++ b/os/gcache/gcache_adapter.go
@@ -139,4 +139,8 @@ type Adapter interface {
 
 	// Close closes the cache if necessary.
 	Close(ctx context.Context) error
+
+	// SetOnExpiredClearCallBack set a callback function that used when clear the expired key and value.
+	// This callback function will execute after clear the expired key and value
+	SetOnExpiredClearCallBack(ctx context.Context, callback func(key interface{}, value *gvar.Var))
 }

--- a/os/gcache/gcache_adapter_redis.go
+++ b/os/gcache/gcache_adapter_redis.go
@@ -17,7 +17,8 @@ import (
 
 // AdapterRedis is the gcache adapter implements using Redis server.
 type AdapterRedis struct {
-	redis *gredis.Redis
+	redis          *gredis.Redis
+	onExpiredClear func(key interface{}, value *gvar.Var)
 }
 
 // NewAdapterRedis creates and returns a new memory cache object.
@@ -25,6 +26,12 @@ func NewAdapterRedis(redis *gredis.Redis) Adapter {
 	return &AdapterRedis{
 		redis: redis,
 	}
+}
+
+// SetOnExpiredClearCallBack set a callback function that used when clear the expired key and value.
+// This callback function will execute after clear the expired key and value
+func (c *AdapterRedis) SetOnExpiredClearCallBack(ctx context.Context, callback func(key interface{}, value *gvar.Var)) {
+	c.onExpiredClear = callback
 }
 
 // Set sets cache with `key`-`value` pair, which is expired after `duration`.

--- a/os/gcache/gcache_cache.go
+++ b/os/gcache/gcache_cache.go
@@ -31,7 +31,8 @@ func New(lruCap ...int) *Cache {
 	}
 	// Here may be a "timer leak" if adapter is manually changed from memory adapter.
 	// Do not worry about this, as adapter is less changed, and it does nothing if it's not used.
-	gtimer.AddSingleton(context.Background(), time.Second, memAdapter.(*AdapterMemory).syncEventAndClearExpired)
+	adapterMemory := memAdapter.(*AdapterMemory)
+	gtimer.AddSingleton(context.Background(), time.Second, adapterMemory.syncEventAndClearExpired)
 	return c
 }
 


### PR DESCRIPTION
The gcache needs set a callback function when the key and value in cache is expired to clear.

In some business scenarios, it use gcache in memory to cache some stateful values,  such as a client that keep a connection, 
the callback function is useful to close it and execute some clear operations when cached value is expired.

I add a method "SetOnExpiredClearCallBack(ctx context.Context, callback func(key interface{}, value *gvar.Var))" in Adapter interface and the implement AdapterMemory struct.

Can you merge it?

