### PR TITLE
fix: OpenAPI cannot correctly identify the file type under the canoni…

### DIFF
--- a/net/goai/goai.go
+++ b/net/goai/goai.go
@@ -43,6 +43,7 @@ const (
 	TypeBoolean    = `boolean`
 	TypeArray      = `array`
 	TypeString     = `string`
+	TypeFile       = `file`
 	TypeObject     = `object`
 	FormatInt32    = `int32`
 	FormatInt64    = `int64`
@@ -145,6 +146,8 @@ func (oai *OpenApiV3) golangTypeToOAIType(t reflect.Type) string {
 		switch t.String() {
 		case `time.Time`, `gtime.Time`:
 			return TypeString
+		case `ghttp.UploadFile`:
+			return TypeFile
 		}
 		return TypeObject
 

--- a/net/goai/goai_shema_ref.go
+++ b/net/goai/goai_shema_ref.go
@@ -76,7 +76,7 @@ func (oai *OpenApiV3) newSchemaRefWithGolangType(golangType reflect.Type, tagMap
 	}
 	schemaRef.Value = schema
 	switch oaiType {
-	case TypeString:
+	case TypeString, TypeFile:
 	// Nothing to do.
 	case TypeInteger:
 		if schemaRef.Value.Default != nil {


### PR DESCRIPTION
fix: https://github.com/gogf/gf/issues/2897

By adding the file type, ghttp.UploadFile can be correctly identified as the file type.