### PR TITLE
fix: `gutil.IsSlice` judgment logic error

### DIFF
--- a/internal/utils/utils_is.go
+++ b/internal/utils/utils_is.go
@@ -57,6 +57,7 @@ func IsSlice(value interface{}) bool {
 	)
 	for reflectKind == reflect.Ptr {
 		reflectValue = reflectValue.Elem()
+		reflectKind = reflectValue.Kind()
 	}
 	switch reflectKind {
 	case reflect.Slice, reflect.Array:

--- a/internal/utils/utils_z_unit_is_test.go
+++ b/internal/utils/utils_z_unit_is_test.go
@@ -9,8 +9,10 @@ package utils_test
 import (
 	"testing"
 
+	"github.com/gogf/gf/v2/container/gvar"
 	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/internal/utils"
+	"github.com/gogf/gf/v2/os/gtime"
 	"github.com/gogf/gf/v2/test/gtest"
 )
 
@@ -123,6 +125,9 @@ func TestVar_IsSlice(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.Assert(utils.IsSlice(int8(1)), false)
 		t.Assert(utils.IsSlice(uint8(1)), false)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		t.Assert(utils.IsSlice(gvar.New(gtime.Now()).IsSlice()), false)
 	})
 }
 


### PR DESCRIPTION
fix: https://github.com/gogf/gf/issues/2855

In the code of `gutil.IsSlice`, only `reflectValue` has changed during the loop, and `reflectKind` has not changed