### PR TITLE
fix: multiple interfaces cause the original type to be inaccessible

### DIFF
--- a/util/gconv/gconv_convert.go
+++ b/util/gconv/gconv_convert.go
@@ -194,7 +194,7 @@ func doConvert(in doConvertInput) (convertedValue interface{}) {
 		}
 		return Time(in.FromValue)
 	case "*time.Time":
-		var v interface{}
+		var v time.Time
 		if len(in.Extra) > 0 {
 			v = Time(in.FromValue, String(in.Extra[0]))
 		} else {

--- a/util/gconv/gconv_z_unit_converter_test.go
+++ b/util/gconv/gconv_z_unit_converter_test.go
@@ -8,7 +8,9 @@ package gconv_test
 
 import (
 	"testing"
+	"time"
 
+	"github.com/gogf/gf/v2/os/gtime"
 	"github.com/gogf/gf/v2/test/gtest"
 	"github.com/gogf/gf/v2/util/gconv"
 )
@@ -41,6 +43,12 @@ func TestConverter_Struct(t *testing.T) {
 	type tDD struct {
 		ValTop string
 		ValTa  tB
+	}
+
+	type tEE struct {
+		Val1 time.Time  `json:"val1"`
+		Val2 *time.Time `json:"val2"`
+		Val3 *time.Time `json:"val3"`
 	}
 
 	gtest.C(t, func(t *gtest.T) {
@@ -173,6 +181,23 @@ func TestConverter_Struct(t *testing.T) {
 		t.Assert(dd.ValTop, "123")
 		t.Assert(dd.ValTa.Val1, 234)
 		t.Assert(dd.ValTa.Val2, "abc")
+	})
+
+	// fix: https://github.com/gogf/gf/issues/2665
+	gtest.C(t, func(t *gtest.T) {
+		aa := &tEE{}
+
+		var tmp = map[string]any{
+			"val1": "2023-04-15 19:10:00 +0800 CST",
+			"val2": "2023-04-15 19:10:00 +0800 CST",
+			"val3": "2006-01-02T15:04:05Z07:00",
+		}
+		err := gconv.Struct(tmp, aa)
+		t.AssertNil(err)
+		t.AssertNE(aa, nil)
+		t.Assert(aa.Val1.Local(), gtime.New("2023-04-15 19:10:00 +0800 CST").Local().Time)
+		t.Assert(aa.Val2.Local(), gtime.New("2023-04-15 19:10:00 +0800 CST").Local().Time)
+		t.Assert(aa.Val3.Local(), gtime.New("2006-01-02T15:04:05Z07:00").Local().Time)
 	})
 }
 


### PR DESCRIPTION
fix: https://github.com/gogf/gf/issues/2665

Since v is of `interface{}` type, when v is assigned a value, the type of v is `interface{}|time.Time`, the function return type is interface{}, and the value type at this time is `interface{}|*interface{}|time .Time`, this will result in the original type `time.Time` not being available outside.

