### PR TITLE
add cluster mode and tls configuration support for package gredis

### DIFF
--- a/contrib/nosql/redis/redis.go
+++ b/contrib/nosql/redis/redis.go
@@ -9,6 +9,7 @@ package redis
 
 import (
 	"context"
+	"crypto/tls"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -67,7 +68,7 @@ func New(config *gredis.Config) *Redis {
 		redisSentinel := opts.Failover()
 		redisSentinel.ReplicaOnly = config.SlaveOnly
 		client = redis.NewFailoverClient(redisSentinel)
-	} else if len(opts.Addrs) > 1 {
+	} else if len(opts.Addrs) > 1 || config.Cluster {
 		client = redis.NewClusterClient(opts.Cluster())
 	} else {
 		client = redis.NewClient(opts.Simple())
@@ -134,5 +135,10 @@ func fillWithDefaultConfiguration(config *gredis.Config) {
 	}
 	if config.ReadTimeout == 0 {
 		config.ReadTimeout = -1
+	}
+	if config.TLSConfig == nil && config.TLS {
+		config.TLSConfig = &tls.Config{
+			InsecureSkipVerify: config.TLSSkipVerify,
+		}
 	}
 }

--- a/database/gredis/gredis_config.go
+++ b/database/gredis/gredis_config.go
@@ -39,6 +39,7 @@ type Config struct {
 	TLSSkipVerify   bool          `json:"tlsSkipVerify"`   // Disables server name verification when connecting over TLS.
 	TLSConfig       *tls.Config   `json:"-"`               // TLS Config to use. When set TLS will be negotiated.
 	SlaveOnly       bool          `json:"slaveOnly"`       // Route all commands to slave read-only nodes.
+	Cluster         bool          `json:"cluster"`         // Specifies whether cluster mode be used.
 }
 
 const (


### PR DESCRIPTION
1. tls及tlsSkipVerify配置不生效
2. 在使用aws这类单endpoint的集群时，会错误地判定为单节点服务。故添加cluster配置项用于强行指定为集群服务。