### PR TITLE
improve trace span generating for package gctx and http tracing content for package ghttp

### DIFF
--- a/net/ghttp/ghttp_middleware_tracing.go
+++ b/net/ghttp/ghttp_middleware_tracing.go
@@ -59,12 +59,14 @@ func internalMiddlewareServerTracing(r *Request) {
 			trace.WithInstrumentationVersion(gf.VERSION),
 		)
 	)
+	carrierData := r.Header
+	carrierData.Add("url", r.URL.String())
 	ctx, span = tr.Start(
 		otel.GetTextMapPropagator().Extract(
 			ctx,
-			propagation.HeaderCarrier(r.Header),
+			propagation.HeaderCarrier(carrierData),
 		),
-		r.URL.String(),
+		r.URL.Path,
 		trace.WithSpanKind(trace.SpanKindServer),
 	)
 	defer span.End()

--- a/os/gctx/gctx.go
+++ b/os/gctx/gctx.go
@@ -57,9 +57,7 @@ func WithCtx(ctx context.Context) context.Context {
 	if CtxId(ctx) != "" {
 		return ctx
 	}
-	var span *gtrace.Span
-	ctx, span = gtrace.NewSpan(ctx, "gctx.WithCtx")
-	defer span.End()
+	ctx, _ = gtrace.NewSpan(ctx, "gctx.WithCtx")
 	return ctx
 }
 

--- a/os/gctx/gctx.go
+++ b/os/gctx/gctx.go
@@ -57,7 +57,9 @@ func WithCtx(ctx context.Context) context.Context {
 	if CtxId(ctx) != "" {
 		return ctx
 	}
-	ctx, _ = gtrace.NewSpan(ctx, "gctx.WithCtx")
+	var span *gtrace.Span
+	ctx, span = gtrace.NewSpan(ctx, "gctx.WithCtx")
+	defer span.End()
 	return ctx
 }
 


### PR DESCRIPTION
1、项目底层上流调用链上报了WithCtx，此处干扰视线，影响界面显示，没法正常直观得看到展示的调用层
2、调用链上报的operation 是url, 这样会导致openration遍地繁衍，杂乱无章，如果想看具体请求业务日志，应当去日志系统查看