### PR TITLE
fix(gutil): panic when field is []byte(BINARY in mysql)

### DIFF
--- a/util/gutil/gutil_list.go
+++ b/util/gutil/gutil_list.go
@@ -122,10 +122,15 @@ func ListItemValuesUnique(list interface{}, key string, subKey ...interface{}) [
 			m  = make(map[interface{}]struct{}, len(values))
 		)
 		for i := 0; i < len(values); {
-			if _, ok = m[values[i]]; ok {
+			value := values[i]
+			if t, ok := value.([]byte); ok {
+				// make byte slice comparable
+				value = string(t)
+			}
+			if _, ok = m[value]; ok {
 				values = SliceDelete(values, i)
 			} else {
-				m[values[i]] = struct{}{}
+				m[value] = struct{}{}
 				i++
 			}
 		}

--- a/util/gutil/gutil_z_unit_list_test.go
+++ b/util/gutil/gutil_z_unit_list_test.go
@@ -246,3 +246,17 @@ func Test_ListItemValuesUnique_Map_Array_SubKey(t *testing.T) {
 		t.Assert(gutil.ListItemValuesUnique(listMap, "scores", "PE"), g.Slice{})
 	})
 }
+
+func Test_ListItemValuesUnique_Binary_ID(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		listMap := g.List{
+			g.Map{"id": []byte{1}, "score": 100},
+			g.Map{"id": []byte{2}, "score": 100},
+			g.Map{"id": []byte{3}, "score": 100},
+			g.Map{"id": []byte{4}, "score": 100},
+			g.Map{"id": []byte{4}, "score": 100},
+		}
+		t.Assert(gutil.ListItemValuesUnique(listMap, "id"), g.Slice{[]byte{1}, []byte{2}, []byte{3}, []byte{4}})
+		t.Assert(gutil.ListItemValuesUnique(listMap, "score"), g.Slice{100})
+	})
+}


### PR DESCRIPTION
## Preview
在数据表定义时，我使用了 binary(32) 作为其主键，并使用 gf 生成了对应的 do 与 entity, 其主键类型为 []byte 。在数据关联查询过程中使用了 ListItemValuesUnique 导致了 panic。

Debug 发现当去重的 map 指定的 key 为 []byte 时，go 会认为其 not comparable 直接 panic，<del> 考虑到 []byte 与 string 强转的内存拷贝问题，这里使用了 unsafe 来转换 StringHeader 与 SliceHeader 并将结果的 string 作为 key 进行去重操作 </del> 这里将 []byte 强转为 comparable 的 string 来进行 set key 操作

## Testcase
```
func Test_ListItemValuesUnique_Binary_ID(t *testing.T) {
	gtest.C(t, func(t *gtest.T) {
		listMap := g.List{
			g.Map{"id": []byte{1}, "score": 100},
			g.Map{"id": []byte{2}, "score": 100},
			g.Map{"id": []byte{3}, "score": 100},
			g.Map{"id": []byte{4}, "score": 100},
			g.Map{"id": []byte{4}, "score": 100},
		}
		t.Assert(gutil.ListItemValuesUnique(listMap, "id"), g.Slice{[]byte{1}, []byte{2}, []byte{3}, []byte{4}})
		t.Assert(gutil.ListItemValuesUnique(listMap, "score"), g.Slice{100})
	})
}
```

### Before
```
=== RUN   Test_ListItemValuesUnique_Binary_ID
runtime error: hash of unhashable type []uint8
1.  github.com/gogf/gf/v2/util/gutil.ListItemValuesUnique
    /home/macoo/gf/util/gutil/gutil_list.go:126
2.  github.com/gogf/gf/v2/util/gutil_test.Test_ListItemValuesUnique_Binary_ID.func1
    /home/macoo/gf/util/gutil/gutil_z_unit_list_test.go:259
3.  github.com/gogf/gf/v2/util/gutil_test.Test_ListItemValuesUnique_Binary_ID
    /home/macoo/gf/util/gutil/gutil_z_unit_list_test.go:251
--- FAIL: Test_ListItemValuesUnique_Binary_ID (0.00s)
```

### After
```
=== RUN   Test_ListItemValuesUnique_Binary_ID
--- PASS: Test_ListItemValuesUnique_Binary_ID (0.00s)
PASS
```
