### PR TITLE
support chinese encoding dir name for unzip

### DIFF
--- a/encoding/gcompress/gcompress_z_unit_zip_test.go
+++ b/encoding/gcompress/gcompress_z_unit_zip_test.go
@@ -248,3 +248,15 @@ func Test_ZipPathContent(t *testing.T) {
 		)
 	})
 }
+
+func Test_Unzip(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			srcPath = gtest.DataPath("zip", "path3")
+		)
+		//fmt.Println(srcPath)
+		err := gcompress.UnZipFile(gfile.Join(srcPath, "1.zip"), srcPath)
+		t.AssertNil(err)
+	})
+
+}

--- a/encoding/gcompress/gcompress_zip.go
+++ b/encoding/gcompress/gcompress_zip.go
@@ -10,6 +10,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"github.com/gogf/gf/v2/encoding/gcharset"
 	"io"
 	"os"
 	"path/filepath"
@@ -174,6 +175,19 @@ func unZipFileWithReader(reader *zip.Reader, dstFolderPath string, zippedPrefix 
 	for _, file := range reader.File {
 		name = gstr.Replace(file.Name, `\`, `/`)
 		name = gstr.Trim(name, "/")
+		if file.NonUTF8 {
+			if nameWithUTF8, err := gcharset.ToUTF8("GBK", file.Name); err == nil {
+				name = nameWithUTF8
+			} else if nameWithUTF8, err = gcharset.ToUTF8("GB18030", file.Name); err == nil {
+				name = nameWithUTF8
+			} else if nameWithUTF8, err = gcharset.ToUTF8("GB2312", file.Name); err == nil {
+				name = nameWithUTF8
+			} else if nameWithUTF8, err = gcharset.ToUTF8("HZGB2312", file.Name); err == nil {
+				name = nameWithUTF8
+			} else if nameWithUTF8, err = gcharset.ToUTF8("Big5", file.Name); err == nil { //繁体中文 Big5编码
+				name = nameWithUTF8
+			}
+		}
 		if prefix != "" {
 			if !strings.HasPrefix(name, prefix) {
 				continue


### PR DESCRIPTION
fix: support chinese dir name in zipped file without utf8 encoding, such as gbk, gb18030, gb2312, hzgb2312, big5