### PR TITLE
Add the Protocol attribute to the Redis configuration

### DIFF
--- a/contrib/nosql/redis/redis.go
+++ b/contrib/nosql/redis/redis.go
@@ -61,6 +61,7 @@ func New(config *gredis.Config) *Redis {
 		WriteTimeout:    config.WriteTimeout,
 		MasterName:      config.MasterName,
 		TLSConfig:       config.TLSConfig,
+		Protocol:        config.Protocol,
 	}
 
 	var client redis.UniversalClient

--- a/database/gredis/gredis_config.go
+++ b/database/gredis/gredis_config.go
@@ -40,6 +40,7 @@ type Config struct {
 	TLSConfig       *tls.Config   `json:"-"`               // TLS Config to use. When set TLS will be negotiated.
 	SlaveOnly       bool          `json:"slaveOnly"`       // Route all commands to slave read-only nodes.
 	Cluster         bool          `json:"cluster"`         // Specifies whether cluster mode be used.
+	Protocol        int           `json:"protocol"`        // Specifies the RESP version (Protocol 2 or 3.)
 }
 
 const (
@@ -101,6 +102,9 @@ func ConfigFromMap(m map[string]interface{}) (config *Config, err error) {
 	}
 	if config.MaxConnLifetime < time.Second {
 		config.MaxConnLifetime = config.MaxConnLifetime * time.Second
+	}
+	if config.Protocol != 2 && config.Protocol != 3 {
+		config.Protocol = 3
 	}
 	return
 }


### PR DESCRIPTION
The go-redis v9 has added support for RESP3 and communicates with the redis server using RESP3 by default. However, many cloud server manufacturers’ redis cloud services do not yet support RESP3. Therefore, when using the v9 client to connect to a redis server that does not support RESP3, some redis commands may fail to process the return value from the server, such as ‘zset range’. In order to be compatible with the RESP2 protocol, it is necessary to add configuration for the RESP version.