### PR TITLE
fix: "gf gen dao" utils.GetModPath Return empty string in windows

### DIFF
--- a/cmd/gf/internal/utility/utils/utils.go
+++ b/cmd/gf/internal/utility/utils/utils.go
@@ -118,7 +118,7 @@ func GetImportPath(filePath string) string {
 func GetModPath() string {
 	var (
 		oldDir    = gfile.Pwd()
-		newDir    = gfile.Dir(oldDir)
+		newDir    = oldDir
 		goModName = "go.mod"
 		goModPath string
 	)
@@ -127,11 +127,11 @@ func GetModPath() string {
 		if gfile.Exists(goModPath) {
 			return goModPath
 		}
-		oldDir = newDir
 		newDir = gfile.Dir(oldDir)
 		if newDir == oldDir {
 			break
 		}
+		oldDir = newDir
 	}
 	return ""
 }


### PR DESCRIPTION
In windows if you configure type: "decimal.Decimal", then execute "gf gen dao" will report "go.mod not found in current project". After some troubleshooting, I found that utils.GetModPath() returns an empty string.