### PR TITLE
fix issue: Windows Platform did not handle process signal

### DIFF
--- a/net/ghttp/ghttp_server_admin_windows.go
+++ b/net/ghttp/ghttp_server_admin_windows.go
@@ -9,7 +9,17 @@
 
 package ghttp
 
-// registerSignalHandler does nothing on window platform.
-func handleProcessSignal() {
+import (
+	"github.com/gogf/gf/v2/os/gproc"
+	"os"
+)
 
+// handleProcessSignal handles all signals from system in blocking way.
+func handleProcessSignal() {
+	var ctx = context.TODO()
+	gproc.AddSigHandlerShutdown(func(sig os.Signal) {
+		shutdownWebServersGracefully(ctx, sig)
+	})
+
+	gproc.Listen()
 }


### PR DESCRIPTION
Add handleProcessSignal logic for windows platform which will AddSigHandlerShutdown and Listen process signal.