### PR TITLE
Fix the bug that ScanAndCount and AllAndCount report errors in sqlserver

### DIFF
--- a/contrib/drivers/mssql/mssql_z_model_test.go
+++ b/contrib/drivers/mssql/mssql_z_model_test.go
@@ -2548,3 +2548,40 @@ func Test_Model_WherePrefixLike(t *testing.T) {
 		t.Assert(r[0]["ID"], "3")
 	})
 }
+
+func Test_Model_AllAndCount(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, total, err := db.Model(table).Order("id").Limit(0, 3).AllAndCount(false)
+		t.Assert(err, nil)
+
+		t.Assert(len(result), 3)
+		t.Assert(total, TableSize)
+	})
+}
+
+func Test_Model_ScanAndCount(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime gtime.Time
+		}
+
+		users := make([]User, 0)
+		total := 0
+
+		err := db.Model(table).Order("id").Limit(0, 3).ScanAndCount(&users, &total, false)
+		t.Assert(err, nil)
+
+		t.Assert(len(users), 3)
+		t.Assert(total, TableSize)
+	})
+}

--- a/database/gdb/gdb_model_select.go
+++ b/database/gdb/gdb_model_select.go
@@ -768,8 +768,10 @@ func (m *Model) formatCondition(
 		}
 	}
 	// ORDER BY.
-	if m.orderBy != "" {
-		conditionExtra += " ORDER BY " + m.orderBy
+	if !isCountStatement { //The count statement of sqlserver cannot contain the order by statement
+		if m.orderBy != "" {
+			conditionExtra += " ORDER BY " + m.orderBy
+		}
 	}
 	// LIMIT.
 	if !isCountStatement {

--- a/database/gdb/gdb_model_select.go
+++ b/database/gdb/gdb_model_select.go
@@ -768,7 +768,7 @@ func (m *Model) formatCondition(
 		}
 	}
 	// ORDER BY.
-	if !isCountStatement { //The count statement of sqlserver cannot contain the order by statement
+	if !isCountStatement { // The count statement of sqlserver cannot contain the order by statement
 		if m.orderBy != "" {
 			conditionExtra += " ORDER BY " + m.orderBy
 		}


### PR DESCRIPTION
AllAndCount and ScanAndCount throw errors in SQL Server environment when there is an orderby statement。

sql server 2022 statement：
      drop table if exists demo
      create table demo(recid int identity(1,1),txt varchar(100),primary key(recid))
      insert into demo(txt)values('txt1'),('txt2'),('txt3')
      select * from demo

example code：
      import (
	      "fmt"
	      _ "github.com/gogf/gf/contrib/drivers/mssql/v2"
	      "github.com/gogf/gf/v2/database/gdb"
      )
      
      func main() {
	      db, err := gdb.New(gdb.ConfigNode{
		      Link: `mssql:sa:123456@tcp(192.168.1.200:1433)/demo`,
	      })
	      if err != nil {
		      panic(err)
	      }
      
	      count, i, err := db.Model("demo").Order("recid").Limit(0, 10).AllAndCount(false)
	      if err != nil {
		      fmt.Println(err)
		      return
	      }
	      fmt.Println(count, i)
      }


Error message：
   SELECT COUNT(1) FROM demo ORDER BY recid: mssql: Column "demo.recid" is invalid in the ORDER BY clause because it is not contained in either an aggregate function or the GROUP By clause.
