### PR TITLE
fix: #2938

### DIFF
--- a/example/httpserver/upload_file/main.go
+++ b/example/httpserver/upload_file/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/net/ghttp"
+)
+
+type UploadReq struct {
+	g.Meta `path:"/upload" method:"POST" tags:"Upload" mime:"multipart/form-data" summary:"上传文件"`
+	File   *ghttp.UploadFile `p:"file" type:"file" dc:"选择上传文件"`
+	Msg    string            `dc:"消息"`
+}
+type UploadRes struct {
+	FileName string `json:"fileName"`
+}
+
+type cUpload struct{}
+
+func (u cUpload) Upload(ctx context.Context, req *UploadReq) (*UploadRes, error) {
+	fmt.Println(req.Msg)
+	if req.File != nil {
+		return &UploadRes{
+			FileName: req.File.Filename,
+		}, nil
+	}
+	return nil, nil
+}
+
+func main() {
+	s := g.Server()
+	s.Group("/", func(group *ghttp.RouterGroup) {
+		group.Middleware(ghttp.MiddlewareHandlerResponse)
+		group.Bind(cUpload{})
+	})
+	s.SetClientMaxBodySize(600 * 1024 * 1024) // 600M
+	s.SetPort(8199)
+	s.SetAccessLogEnabled(true)
+	s.Run()
+}
+
+// curl --location 'http://127.0.0.1:8199/upload' \
+// --form 'file=@"/D:/下载/goframe-v2.5.pdf"' \
+// --form 'msg="666"'

--- a/example/httpserver/upload_file/main.go
+++ b/example/httpserver/upload_file/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/net/ghttp"
@@ -20,7 +19,6 @@ type UploadRes struct {
 type cUpload struct{}
 
 func (u cUpload) Upload(ctx context.Context, req *UploadReq) (*UploadRes, error) {
-	fmt.Println(req.Msg)
 	if req.File != nil {
 		return &UploadRes{
 			FileName: req.File.Filename,

--- a/net/ghttp/ghttp_request_param.go
+++ b/net/ghttp/ghttp_request_param.go
@@ -269,8 +269,6 @@ func (r *Request) parseForm() {
 		return
 	}
 	if contentType := r.Header.Get("Content-Type"); contentType != "" {
-		r.MakeBodyRepeatableRead(true)
-
 		var err error
 		if gstr.Contains(contentType, "multipart/") {
 			// multipart/form-data, multipart/mixed

--- a/net/ghttp/ghttp_z_unit_feature_config_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_config_test.go
@@ -8,6 +8,7 @@ package ghttp_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -154,8 +155,11 @@ func Test_ClientMaxBodySize_File(t *testing.T) {
 		t.Assert(gfile.PutBytes(path, data), nil)
 		defer gfile.Remove(path)
 		t.Assert(
-			gstr.Trim(c.PostContent(ctx, "/", "name=john&file=@file:"+path)),
-			"Read from request Body failed: http: request body too large",
+			true,
+			strings.Contains(
+				gstr.Trim(c.PostContent(ctx, "/", "name=john&file=@file:"+path)),
+				"http: request body too large",
+			),
 		)
 	})
 }


### PR DESCRIPTION
fix #2938
如果需要body支持复读，可以在前置中间件中使用`r.MakeBodyRepeatableRead(true)`
```go
s.Group("/", func(group *ghttp.RouterGroup) {
		group.Middleware(func(r *ghttp.Request) {
			fmt.Println("middleware")
			r.MakeBodyRepeatableRead(true)
			r.Middleware.Next()
		})
		group.Middleware(ghttp.MiddlewareHandlerResponse)
		group.Bind(cUpload{})
	})
```