### PR TITLE
fix: memory leak when gcache.NewAdapterMemory with lru

### DIFF
--- a/os/gcache/gcache_adapter_memory.go
+++ b/os/gcache/gcache_adapter_memory.go
@@ -67,6 +67,9 @@ func NewAdapterMemory(lruCap ...int) Adapter {
 		c.cap = lruCap[0]
 		c.lru = newMemCacheLru(c)
 	}
+	// Here may be a "timer leak" if adapter is manually changed from memory adapter.
+	// Do not worry about this, as adapter is less changed, and it does nothing if it's not used.
+	gtimer.AddSingleton(context.Background(), time.Second, c.syncEventAndClearExpired)
 	return c
 }
 

--- a/os/gcache/gcache_cache.go
+++ b/os/gcache/gcache_cache.go
@@ -8,9 +8,7 @@ package gcache
 
 import (
 	"context"
-	"time"
 
-	"github.com/gogf/gf/v2/os/gtimer"
 	"github.com/gogf/gf/v2/util/gconv"
 )
 
@@ -29,9 +27,6 @@ func New(lruCap ...int) *Cache {
 	c := &Cache{
 		localAdapter: memAdapter,
 	}
-	// Here may be a "timer leak" if adapter is manually changed from memory adapter.
-	// Do not worry about this, as adapter is less changed, and it does nothing if it's not used.
-	gtimer.AddSingleton(context.Background(), time.Second, memAdapter.(*AdapterMemory).syncEventAndClearExpired)
 	return c
 }
 


### PR DESCRIPTION
# Example

```go
package main

import (
	"context"
	"runtime"
	"time"

	"github.com/gogf/gf/v2/frame/g"
	"github.com/gogf/gf/v2/os/gcache"
)

func main() {
	ctx := context.Background()

	cache := gcache.NewAdapterMemory(1)
	cache.Set(ctx, "key", "value", 10*time.Minute)

	var m runtime.MemStats
	timer1 := time.NewTicker(time.Microsecond)
	timer2 := time.NewTicker(time.Second)
	var i int
	for {
		select {
		case <-timer1.C:
			i++
			cache.Get(ctx, "key")
		case <-timer2.C:
			runtime.ReadMemStats(&m)
			size, _ := cache.Size(ctx)
			g.Log().Infof(ctx, "memory usage: %dKB, gc num: %d, gcache size: %d, call times: %d", m.HeapInuse/1024, m.NumGC, size, i)
		}
	}
}                                                                                                                                               
```

# Output
![image](https://github.com/gogf/gf/assets/6872629/c34a992b-cea6-48cb-9522-25ce56f9906d)
