### PR TITLE
fix:  fixed where process parameter parsing failed on Windows

### DIFF
--- a/os/gproc/gproc_shell.go
+++ b/os/gproc/gproc_shell.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/gogf/gf/v2/os/gfile"
-	"github.com/gogf/gf/v2/text/gstr"
 )
 
 // Shell executes command `cmd` synchronously with given input pipe `in` and output pipe `out`.
@@ -64,40 +63,41 @@ func ShellExec(ctx context.Context, cmd string, environment ...[]string) (result
 // Note that it just parses the `cmd` for "cmd.exe" binary in windows, but it is not necessary
 // parsing the `cmd` for other systems using "bash"/"sh" binary.
 func parseCommand(cmd string) (args []string) {
-	if runtime.GOOS != "windows" {
-		return []string{cmd}
-	}
-	// Just for "cmd.exe" in windows.
-	var argStr string
-	var firstChar, prevChar, lastChar1, lastChar2 byte
-	array := gstr.SplitAndTrim(cmd, " ")
-	for _, v := range array {
-		if len(argStr) > 0 {
-			argStr += " "
-		}
-		firstChar = v[0]
-		lastChar1 = v[len(v)-1]
-		lastChar2 = 0
-		if len(v) > 1 {
-			lastChar2 = v[len(v)-2]
-		}
-		if prevChar == 0 && (firstChar == '"' || firstChar == '\'') {
-			// It should remove the first quote char.
-			argStr += v[1:]
-			prevChar = firstChar
-		} else if prevChar != 0 && lastChar2 != '\\' && lastChar1 == prevChar {
-			// It should remove the last quote char.
-			argStr += v[:len(v)-1]
-			args = append(args, argStr)
-			argStr = ""
-			prevChar = 0
-		} else if len(argStr) > 0 {
-			argStr += v
-		} else {
-			args = append(args, v)
-		}
-	}
-	return
+	return []string{cmd}
+	//if runtime.GOOS != "windows" {
+	//	return []string{cmd}
+	//}
+	//// Just for "cmd.exe" in windows.
+	//var argStr string
+	//var firstChar, prevChar, lastChar1, lastChar2 byte
+	//array := gstr.SplitAndTrim(cmd, " ")
+	//for _, v := range array {
+	//	if len(argStr) > 0 {
+	//		argStr += " "
+	//	}
+	//	firstChar = v[0]
+	//	lastChar1 = v[len(v)-1]
+	//	lastChar2 = 0
+	//	if len(v) > 1 {
+	//		lastChar2 = v[len(v)-2]
+	//	}
+	//	if prevChar == 0 && (firstChar == '"' || firstChar == '\'') {
+	//		// It should remove the first quote char.
+	//		argStr += v[1:]
+	//		prevChar = firstChar
+	//	} else if prevChar != 0 && lastChar2 != '\\' && lastChar1 == prevChar {
+	//		// It should remove the last quote char.
+	//		argStr += v[:len(v)-1]
+	//		args = append(args, argStr)
+	//		argStr = ""
+	//		prevChar = 0
+	//	} else if len(argStr) > 0 {
+	//		argStr += v
+	//	} else {
+	//		args = append(args, v)
+	//	}
+	//}
+	//return
 }
 
 // getShell returns the shell command depending on current working operating system.


### PR DESCRIPTION
修复了在 Windows 上进程参数解析失败的问题，我直接用了原生参数传进去了，不做任何处理