### PR TITLE
feat: Short form for canonical routing #3385

### DIFF
--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -174,6 +174,9 @@ var (
 	// methodsMap stores all supported HTTP method.
 	// It is used for quick HTTP method searching using map.
 	methodsMap = make(map[string]struct{})
+	// httpMethodList stores all supported HTTP method.
+	// It is used for quick HTTP method searching using slices.
+	httpMethodList []string
 
 	// serverMapping stores more than one server instances for current processes.
 	// The key is the name of the server, and the value is its instance.

--- a/net/ghttp/ghttp_server.go
+++ b/net/ghttp/ghttp_server.go
@@ -43,8 +43,11 @@ import (
 )
 
 func init() {
+
+	httpMethodList = strings.Split(supportedHttpMethods, ",")
+
 	// Initialize the method map.
-	for _, v := range strings.Split(supportedHttpMethods, ",") {
+	for _, v := range httpMethodList {
 		methodsMap[v] = struct{}{}
 	}
 }

--- a/net/ghttp/ghttp_z_unit_feature_router_strict_easy_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_router_strict_easy_test.go
@@ -1,0 +1,119 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package ghttp_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/net/ghttp"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/guid"
+)
+
+type Feature3385_testHelloReq struct {
+	g.Meta `GET:"/hello" `
+}
+
+type Feature3385_testDeleteReq struct {
+	g.Meta `path:"/delete" `
+}
+
+type Feature3385_testAddReq struct {
+	g.Meta `path:"/add" method:"put"`
+}
+
+type Feature3385_testPayReq struct {
+	g.Meta `POST:"/pay" method:"put"`
+}
+
+type Feature3385_testLoginReq struct {
+	g.Meta `path:"/login" method:"get,post"`
+}
+
+type Feature3385_testHelloRes struct {
+	Reply string
+}
+type Feature3385_testAddRes struct {
+	Reply string
+}
+type Feature3385_testDeleteRes struct {
+	Reply string
+}
+type Feature3385_testPayRes struct {
+	Reply string
+}
+type Feature3385_testLoginRes struct {
+	Reply string
+}
+
+type testControllerFeature3385 struct{}
+
+func (c *testControllerFeature3385) Hello(ctx context.Context, req *Feature3385_testHelloReq) (res *Feature3385_testHelloRes, err error) {
+	return &Feature3385_testHelloRes{"hello"}, nil
+}
+
+func (c *testControllerFeature3385) Delete(ctx context.Context, req *Feature3385_testDeleteReq) (res *Feature3385_testDeleteRes, err error) {
+	return &Feature3385_testDeleteRes{"delete"}, nil
+}
+func (c *testControllerFeature3385) Add(ctx context.Context, req *Feature3385_testAddReq) (res *Feature3385_testAddRes, err error) {
+	return &Feature3385_testAddRes{"add"}, nil
+}
+func (c *testControllerFeature3385) Pay(ctx context.Context, req *Feature3385_testPayReq) (res *Feature3385_testPayRes, err error) {
+	return &Feature3385_testPayRes{"pay"}, nil
+}
+func (c *testControllerFeature3385) Login(ctx context.Context, req *Feature3385_testLoginReq) (res *Feature3385_testLoginRes, err error) {
+	return &Feature3385_testLoginRes{"login"}, nil
+}
+
+func Test_Router_Handler_Strict_WithObject_MethodUri(t *testing.T) {
+	s := g.Server(guid.S())
+	s.SetPort(56007)
+	s.Group("/", func(group *ghttp.RouterGroup) {
+		group.Middleware(ghttp.MiddlewareHandlerResponse)
+		group.Bind(
+			&testControllerFeature3385{},
+		)
+	})
+
+	s.Start()
+
+	defer s.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+	// success
+	gtest.C(t, func(t *gtest.T) {
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+
+		t.Assert(client.PutContent(ctx, "/add"), `{"code":0,"message":"","data":{"Reply":"add"}}`)
+		// all
+		t.Assert(client.DeleteContent(ctx, "/delete"), `{"code":0,"message":"","data":{"Reply":"delete"}}`)
+		//
+		t.Assert(client.GetContent(ctx, "/hello"), `{"code":0,"message":"","data":{"Reply":"hello"}}`)
+		t.Assert(client.GetContent(ctx, "/login"), `{"code":0,"message":"","data":{"Reply":"login"}}`)
+		t.Assert(client.PostContent(ctx, "/login"), `{"code":0,"message":"","data":{"Reply":"login"}}`)
+		t.Assert(client.PostContent(ctx, "/pay"), `{"code":0,"message":"","data":{"Reply":"pay"}}`)
+
+		expect := `Not Found`
+		add := client.GetContent(ctx, "/add")
+
+		t.Assert(add, expect)
+		// all
+		t.Assert(client.DeleteContent(ctx, "/delete/1"), expect)
+		//
+		t.Assert(client.DeleteContent(ctx, "/hello"), expect)
+		t.Assert(client.PutContent(ctx, "/login"), expect)
+		t.Assert(client.DeleteContent(ctx, "/login"), expect)
+		t.Assert(client.GetContent(ctx, "/pay"), expect)
+
+	})
+
+}


### PR DESCRIPTION
严格路由的简写形式。
`path:"/admin/employee/login" method:"post" `   ==> `POST:"/admin/employee/login" `

90%的场景都是一个req结构体只有一个方法，使用这种写法更加便捷，代码实现也没有很复杂
目前我的实现思路是 当path存在时，简写形式不生效，只有当path不存在时，才会走简写形式的流程，并且会忽略method的tag
比如 `POST:"/admin/employee/login" method："get" `  这个规则下就是 method=post ，uri = /admin/employee/login，会忽略后面的method



