### PR TITLE
fix: #3390 #3391 Fixed gconv.Struct parameter parsing error

### DIFF
--- a/os/gcmd/gcmd_command_object.go
+++ b/os/gcmd/gcmd_command_object.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gogf/gf/v2/encoding/gjson"
 	"github.com/gogf/gf/v2/errors/gcode"
 	"github.com/gogf/gf/v2/errors/gerror"
+
 	"github.com/gogf/gf/v2/internal/intlog"
 	"github.com/gogf/gf/v2/internal/reflection"
 	"github.com/gogf/gf/v2/internal/utils"
@@ -296,14 +297,18 @@ func newCommandFromMethod(
 			return nil, err
 		}
 		// Construct input parameters.
+
 		if len(data) > 0 {
 			intlog.PrintFunc(ctx, func() string {
 				return fmt.Sprintf(`input command data map: %s`, gjson.MustEncode(data))
 			})
+
 			if inputObject.Kind() == reflect.Ptr {
 				err = gconv.Scan(data, inputObject.Interface())
+
 			} else {
-				err = gconv.Struct(data, inputObject.Addr().Interface())
+				// add tags
+				err = gconv.StructTag(data, inputObject.Addr().Interface(), "short,name")
 			}
 			intlog.PrintFunc(ctx, func() string {
 				return fmt.Sprintf(`input object assigned data: %s`, gjson.MustEncode(inputObject.Interface()))

--- a/util/gconv/gconv_z_unit_custom_mapping_test.go
+++ b/util/gconv/gconv_z_unit_custom_mapping_test.go
@@ -1,0 +1,71 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gconv_test
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/gconv"
+)
+
+func Test_Struct_Custom_Mapping1_Attribute(t *testing.T) {
+	type TestData struct {
+		Name string
+		Age  string
+	}
+	type dataMapKey = string
+	type structFieldName = string
+	gtest.C(t, func(t *gtest.T) {
+		data := map[string]any{
+			"a":    "123",
+			"name": "456",
+		}
+		mapping := map[dataMapKey]structFieldName{
+			"a":    "Age",
+			"name": "Age",
+
+			"age": "Name",
+			"n":   "Name",
+		}
+
+		var input = &TestData{}
+		err := gconv.Struct(data, input, mapping)
+		t.AssertNil(err)
+		t.AssertEQ(input.Age, "123")
+		t.AssertNE(input.Name, "456")
+	})
+}
+
+func Test_Struct_Custom_Mapping2_Attribute(t *testing.T) {
+	type User struct {
+		Uid  int
+		Name string
+	}
+	gtest.C(t, func(t *gtest.T) {
+
+		var (
+			user   = new(User)
+			params = g.Map{
+				"uid": 1,
+				//"myname": "john",
+				"name": "smith",
+			}
+		)
+		err := gconv.Scan(params, user, g.MapStrStr{
+			"myname": "Name",
+		})
+
+		t.AssertNil(err)
+		t.Assert(user, &User{
+			Uid:  1,
+			Name: "smith",
+		})
+	})
+
+}


### PR DESCRIPTION
修复了gconv.Struct参数解析错误的bug，测试全部通过
======
<p>
我在gcmd解析参数的地方加了short和name的tag，以便正常解析。<br>

hi @gqcn 我注意到gconv.doStruct函数的参数貌似有重复的意思，`paramKeyToAttrMap` 和 `priorityTag`，<br>

这里的tag可以和前面的用户定义的映射规则合并到一起去，比方说以下代码<br>



orm tag是不是本身就是一种`paramKeyToAttrMap`呢,可以在传入tag的时候，解析每个字段的tag，<br>

然后`paramKeyToAttrMap`即可，不必要传两个参数<br>
</p>

```go
type User struct {
	Uid   int
	Name  string
	Pass1 string `orm:"password1"`
	Pass2 string `orm:"password2"`
}
user := new(User)
params1 := g.Map{
	"uid":       1,
	"Name":      "john",
	"password1": "123",
	"password2": "456",
}
gconv.Struct(params1, user)
```


