### PR TITLE
fix: cmd/gf cmd_build.go use arg(2) like `./cmd/v1/main.go` as build file

### DIFF
--- a/cmd/gf/internal/cmd/cmd_build.go
+++ b/cmd/gf/internal/cmd/cmd_build.go
@@ -50,14 +50,14 @@ const (
 gf build main.go
 gf build main.go --ps public,template
 gf build main.go --cgo
-gf build main.go -m none 
+gf build main.go -m none
 gf build main.go -n my-app -a all -s all
 gf build main.go -n my-app -a amd64,386 -s linux -p .
 gf build main.go -n my-app -v 1.0 -a amd64,386 -s linux,windows,darwin -p ./docker/bin
 `
 	cBuildDc = `
-The "build" command is most commonly used command, which is designed as a powerful wrapper for 
-"go build" command for convenience cross-compiling usage. 
+The "build" command is most commonly used command, which is designed as a powerful wrapper for
+"go build" command for convenience cross-compiling usage.
 It provides much more features for building binary:
 1. Cross-Compiling for many platforms and architectures.
 2. Configuration file support for compiling.

--- a/cmd/gf/internal/cmd/cmd_build.go
+++ b/cmd/gf/internal/cmd/cmd_build.go
@@ -157,11 +157,14 @@ func (c cBuild) Index(ctx context.Context, in cBuildInput) (out *cBuildOutput, e
 	)
 	if file == "" {
 		file = parser.GetArg(2).String()
-		// Check and use the main.go file.
-		if gfile.Exists(cBuildDefaultFile) {
-			file = cBuildDefaultFile
-		} else {
-			mlog.Fatal("build file path is empty or main.go not found in current working directory")
+		// Check and use Arg(2) as the file path.
+		if !gfile.Exists(file) {
+			// Check and use the main.go file.
+			if gfile.Exists(cBuildDefaultFile) {
+				file = cBuildDefaultFile
+			} else {
+				mlog.Fatal("build file path is empty or main.go not found in current working directory")
+			}
 		}
 	}
 	if in.Name == "" {


### PR DESCRIPTION
问题描述：
`gf build -X "server/service/version.GitCommitID=5s8ed919"  cmd/v2/main.go` 
经多次测试只要添加 -X 参数就会出现这个问题。

指定编译文件时始终无法正常编译，想了解下到底要如何使用指定路径的编译。文档并未说明，也没有从文档中发现参数指定。

心想，设计者一定会尽量模拟 go build 的行为。所以看了下源码，
尝试指定 File 也不行
`gf build -X "server/service/version.GitCount=7" FILE=cmd/v2/main.go` 

发现了此参数逻辑不合适，所以立刻按照自己的理解修改，然后可以适应没有 `-X` 参数和 有 `-X` 参数的情况了，特此提交了这个 PR。