### PR TITLE
fix: #3432 Add Access-Control-Expose-Headers: Content-Disposition header in ServeFileDownload

### DIFF
--- a/net/ghttp/ghttp_response.go
+++ b/net/ghttp/ghttp_response.go
@@ -90,6 +90,7 @@ func (r *Response) ServeFileDownload(path string, name ...string) {
 	r.Header().Set("Content-Type", "application/force-download")
 	r.Header().Set("Accept-Ranges", "bytes")
 	r.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename=%s`, url.QueryEscape(downloadName)))
+	r.Header().Set("Access-Control-Expose-Headers", "Content-Disposition")
 	r.Server.serveFile(r.Request, serveFile)
 }
 


### PR DESCRIPTION
Fix #3432 Add Access-Control-Expose-Headers: Content-Disposition header in ServeFileDownload