### PR TITLE
fix: invalid cache key using pointer address of variable for soft time fields

### DIFF
--- a/database/gdb/gdb_model_soft_time.go
+++ b/database/gdb/gdb_model_soft_time.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	
+
 	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/errors/gcode"
 	"github.com/gogf/gf/v2/errors/gerror"

--- a/database/gdb/gdb_model_soft_time.go
+++ b/database/gdb/gdb_model_soft_time.go
@@ -9,7 +9,8 @@ package gdb
 import (
 	"context"
 	"fmt"
-
+	"strings"
+	
 	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/errors/gcode"
 	"github.com/gogf/gf/v2/errors/gerror"
@@ -189,7 +190,7 @@ func (m *softTimeMaintainer) getSoftFieldNameAndType(
 	schema string, table string, checkFiledNames []string,
 ) (fieldName string, fieldType LocalType) {
 	var (
-		cacheKey      = fmt.Sprintf(`getSoftFieldNameAndType:%s#%s#%p`, schema, table, checkFiledNames)
+		cacheKey      = fmt.Sprintf(`getSoftFieldNameAndType:%s#%s#%s`, schema, table, strings.Join(checkFiledNames, "_"))
 		cacheDuration = gcache.DurationNoExpire
 		cacheFunc     = func(ctx context.Context) (value interface{}, err error) {
 			// Ignore the error from TableFields.


### PR DESCRIPTION
fix: The getSoftFieldName cache key name uses a random special certificate of the memory address causing infinite writing to the cache.
![128861712027061_ pic](https://github.com/gogf/gf/assets/42709773/22438e78-adbd-4986-a4eb-d49763b5aa95)
