### PR TITLE
Enhance OrmTagForWithUnscoped

### DIFF
--- a/database/gdb/gdb_func.go
+++ b/database/gdb/gdb_func.go
@@ -58,12 +58,13 @@ type iTableName interface {
 }
 
 const (
-	OrmTagForStruct    = "orm"
-	OrmTagForTable     = "table"
-	OrmTagForWith      = "with"
-	OrmTagForWithWhere = "where"
-	OrmTagForWithOrder = "order"
-	OrmTagForDo        = "do"
+	OrmTagForStruct       = "orm"
+	OrmTagForTable        = "table"
+	OrmTagForWith         = "with"
+	OrmTagForWithWhere    = "where"
+	OrmTagForWithOrder    = "order"
+	OrmTagForWithUnscoped = "unscoped"
+	OrmTagForDo           = "do"
 )
 
 var (

--- a/database/gdb/gdb_model_with.go
+++ b/database/gdb/gdb_model_with.go
@@ -162,6 +162,9 @@ func (m *Model) doWithScanStruct(pointer interface{}) error {
 		if parsedTagOutput.Order != "" {
 			model = model.Order(parsedTagOutput.Order)
 		}
+		if parsedTagOutput.Unscoped == "true" {
+			model = model.Unscoped()
+		}
 		// With cache feature.
 		if m.cacheEnabled && m.cacheOption.Name == "" {
 			model = model.Cache(m.cacheOption)
@@ -277,6 +280,9 @@ func (m *Model) doWithScanStructs(pointer interface{}) error {
 		if parsedTagOutput.Order != "" {
 			model = model.Order(parsedTagOutput.Order)
 		}
+		if parsedTagOutput.Unscoped == "true" {
+			model = model.Unscoped()
+		}
 		// With cache feature.
 		if m.cacheEnabled && m.cacheOption.Name == "" {
 			model = model.Cache(m.cacheOption)
@@ -293,9 +299,10 @@ func (m *Model) doWithScanStructs(pointer interface{}) error {
 }
 
 type parseWithTagInFieldStructOutput struct {
-	With  string
-	Where string
-	Order string
+	With     string
+	Where    string
+	Order    string
+	Unscoped string
 }
 
 func (m *Model) parseWithTagInFieldStruct(field gstructs.Field) (output parseWithTagInFieldStructOutput) {
@@ -320,5 +327,6 @@ func (m *Model) parseWithTagInFieldStruct(field gstructs.Field) (output parseWit
 	output.With = data[OrmTagForWith]
 	output.Where = data[OrmTagForWithWhere]
 	output.Order = data[OrmTagForWithOrder]
+	output.Unscoped = data[OrmTagForWithUnscoped]
 	return
 }


### PR DESCRIPTION
Enhance OrmTagForWithUnscoped

Sometimes we need to actively associate "deleted" data instead of excluding it. For example, after deleting an employee, we hope that other data can be associated with the name of the deleted employee to avoid duplication of name data.