### PR TITLE
fix: #3465 If the value of a string is null, the value of string is nil after the string is converted to []string

### DIFF
--- a/util/gconv/gconv_slice_str.go
+++ b/util/gconv/gconv_slice_str.go
@@ -60,11 +60,26 @@ func Strings(any interface{}) []string {
 	case []uint8:
 		if json.Valid(value) {
 			_ = json.UnmarshalUseNumber(value, &array)
-		} else {
+		}
+		if array == nil {
 			array = make([]string, len(value))
 			for k, v := range value {
 				array[k] = String(v)
 			}
+			return array
+		}
+	case string:
+		byteValue := []byte(value)
+		if json.Valid(byteValue) {
+			_ = json.UnmarshalUseNumber(byteValue, &array)
+		}
+		if array == nil {
+			if value == "" {
+				return []string{}
+			}
+			// Prevent strings from being null
+			// See Issue 3465 for details
+			return []string{value}
 		}
 	case []uint16:
 		array = make([]string, len(value))

--- a/util/gconv/gconv_z_unit_slice_test.go
+++ b/util/gconv/gconv_z_unit_slice_test.go
@@ -321,6 +321,12 @@ func Test_Strings(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.AssertEQ(gconv.Strings("123"), []string{"123"})
 	})
+	// https://github.com/gogf/gf/issues/3465
+	gtest.C(t, func(t *gtest.T) {
+		t.AssertEQ(gconv.Strings("null"), []string{"null"})
+		t.AssertEQ(gconv.Strings([]byte("null")), []string{"110", "117", "108", "108"})
+		t.AssertEQ(gconv.Strings("{\"name\":\"wln\"}"), []string{"{\"name\":\"wln\"}"})
+	})
 }
 
 func Test_Slice_Interfaces(t *testing.T) {


### PR DESCRIPTION
修复以下问题:</br>
    1.当字符串的值为null时，调用gconv.Strings("null") 会返回nil