### PR TITLE
fix: glog - empty content should has placeholder

### DIFF
--- a/os/glog/glog_logger_handler.go
+++ b/os/glog/glog_logger_handler.go
@@ -126,7 +126,7 @@ func (in *HandlerInput) getDefaultBuffer(withColor bool) *bytes.Buffer {
 	for _, v := range in.Values {
 		valueContent = gconv.String(v)
 		if len(valueContent) == 0 {
-			continue
+			buffer.WriteString(" ")
 		}
 		if buffer.Len() > 0 {
 			if buffer.Bytes()[buffer.Len()-1] == '\n' {

--- a/os/glog/glog_logger_handler_json.go
+++ b/os/glog/glog_logger_handler_json.go
@@ -44,7 +44,7 @@ func HandlerJson(ctx context.Context, in *HandlerInput) {
 	for _, v := range in.Values {
 		valueContent = gconv.String(v)
 		if len(valueContent) == 0 {
-			continue
+			output.Content += " "
 		}
 		if len(output.Content) > 0 {
 			if output.Content[len(output.Content)-1] == '\n' {


### PR DESCRIPTION
When I pass values... to glog, if you totally ignore the empty values, I will be confused where is my params or if I made a  mistake ? Also, multi values may lead to out-of-order if no placeholder for empty values.