### PR TITLE
discuss: issue #3525 on pgsql, char `?` in sql arguments

### DIFF
--- a/contrib/drivers/pgsql/pgsql_do_filter.go
+++ b/contrib/drivers/pgsql/pgsql_do_filter.go
@@ -21,6 +21,10 @@ func (d *Driver) DoFilter(
 	var index int
 	// Convert placeholder char '?' to string "$x".
 	newSql, err = gregex.ReplaceStringFunc(`\?`, sql, func(s string) string {
+		if _, ok := args[index].(gdb.NoReplacement); ok {
+			args = append(args[:index], args[index+1:]...)
+			return s
+		}
 		index++
 		return fmt.Sprintf(`$%d`, index)
 	})

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -356,12 +356,13 @@ type Counter struct {
 }
 
 type (
-	Raw    string                   // Raw is a raw sql that will not be treated as argument but as a direct sql part.
-	Value  = *gvar.Var              // Value is the field value type.
-	Record map[string]Value         // Record is the row record of the table.
-	Result []Record                 // Result is the row record array.
-	Map    = map[string]interface{} // Map is alias of map[string]interface{}, which is the most common usage map type.
-	List   = []Map                  // List is type of map array.
+	Raw           string                   // Raw is a raw sql that will not be treated as argument but as a direct sql part.
+	Value         = *gvar.Var              // Value is the field value type.
+	Record        map[string]Value         // Record is the row record of the table.
+	Result        []Record                 // Result is the row record array.
+	Map           = map[string]interface{} // Map is alias of map[string]interface{}, which is the most common usage map type.
+	List          = []Map                  // List is type of map array.
+	NoReplacement bool
 )
 
 type CatchSQLManager struct {

--- a/database/gdb/gdb_core.go
+++ b/database/gdb/gdb_core.go
@@ -623,6 +623,11 @@ func (c *Core) DoUpdate(ctx context.Context, link Link, table string, data inter
 
 			default:
 				if s, ok := v.(Raw); ok {
+					placeholders := strings.Index(string(s), "?")
+					if placeholders != -1 {
+						// 插入一个空的
+						args = append([]any{(NoReplacement)(true)}, args...)
+					}
 					fields = append(fields, c.QuoteWord(k)+"="+gconv.String(s))
 				} else {
 					fields = append(fields, c.QuoteWord(k)+"=?")


### PR DESCRIPTION
解决的思路如下：
1. 检测到Raw类型的参数时，检测是否含有?号，如果有，在args中添加一个占位符类型的参数
          占位符类型 =  `type NoReplacement bool`
2. 在`pgsql_do_filter.go`文件里面的`(*Driver).DoFilter函数`做参数替换的时候，检测到问号的时候，根据index索引查找对应的args是不是刚才添加的占位符类型，如果是，就不替换，返回原字符串

只提供一种思路，可能使用了Raw类型的参数中有多个问号，或者问号前后也有问号之类的


# 不要合并