### PR TITLE
database/gdb/gdb_model_soft_time: fix soft-time support fieldType:`LocalTypeUint64` in Insert/Update perations

### DIFF
--- a/database/gdb/gdb_model_soft_time.go
+++ b/database/gdb/gdb_model_soft_time.go
@@ -333,7 +333,7 @@ func (m *softTimeMaintainer) getConditionByFieldNameAndTypeForSoftDeleting(
 		switch fieldType {
 		case LocalTypeDate, LocalTypeDatetime:
 			return fmt.Sprintf(`%s IS NULL`, quotedFieldName)
-		case LocalTypeInt, LocalTypeUint, LocalTypeInt64, LocalTypeBool:
+		case LocalTypeInt, LocalTypeUint, LocalTypeInt64, LocalTypeUint64, LocalTypeBool:
 			return fmt.Sprintf(`%s=0`, quotedFieldName)
 		default:
 			intlog.Errorf(
@@ -372,7 +372,7 @@ func (m *softTimeMaintainer) GetValueByFieldTypeForCreateOrUpdate(
 		switch fieldType {
 		case LocalTypeDate, LocalTypeDatetime:
 			value = gtime.Now()
-		case LocalTypeInt, LocalTypeUint, LocalTypeInt64:
+		case LocalTypeInt, LocalTypeUint, LocalTypeInt64, LocalTypeUint64:
 			value = gtime.Timestamp()
 		case LocalTypeBool:
 			value = 1


### PR DESCRIPTION
当数据库（mysql）表结构定义类似：
```
CREATE TABLE `example`
(
    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT 'ID',
    `created_at`  bigint(20) unsigned NOT NULL DEFAULT 0 COMMENT 'created timestamp',
    `updated_at` bigint(20) unsigned NOT NULL DEFAULT 0 COMMENT 'latest updated timestamp',
    PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```
gf框架会将created_at与updated_at识别为soft-time可自动填充的字段，同时字段类型会被识别为：LocalTypeUint64。

但是在insert和update操作自动填充字段值的时候，不支持 LocalTypeUint64 类型的自动填充。

本PR补全了 LocalTypeUint64 类型的默认值填充逻辑。
