### PR TITLE
database/gdb： 更新/插入操作时，表字段数量为0，直接返回error

### DIFF
--- a/database/gdb/gdb_core_structure.go
+++ b/database/gdb/gdb_core_structure.go
@@ -381,6 +381,9 @@ func (c *Core) mappingAndFilterData(ctx context.Context, schema, table string, d
 	if err != nil {
 		return nil, err
 	}
+	if len(fieldsMap) == 0 {
+		return nil, gerror.Newf("The number of fields in the table %s is 0", table)
+	}
 	fieldsKeyMap := make(map[string]interface{}, len(fieldsMap))
 	for k := range fieldsMap {
 		fieldsKeyMap[k] = nil


### PR DESCRIPTION
当 更新/插入操作时，表字段数量为0，直接返回error，不在后续操作