### PR TITLE
database/gdb: fix #2119

### DIFF
--- a/os/gstructs/gstructs_type.go
+++ b/os/gstructs/gstructs_type.go
@@ -31,6 +31,7 @@ func getStructFields(structType reflect.Type) []string {
 			}
 			if field.Type.Kind() == reflect.Struct {
 				keys = append(keys, getStructFields(field.Type)...)
+				continue
 			}
 		}
 		keys = append(keys, field.Name)

--- a/os/gstructs/gstructs_z_unit_test.go
+++ b/os/gstructs/gstructs_z_unit_test.go
@@ -360,6 +360,41 @@ func TestType_FieldKeys(t *testing.T) {
 		t.AssertNil(err)
 		t.Assert(r.FieldKeys(), g.Slice{"Id", "Name"})
 	})
+
+	gtest.C(t, func(t *gtest.T) {
+		type A struct {
+			Age   int
+			Score float64
+		}
+		type B struct {
+			A
+			Id   int
+			Name string
+		}
+		r, err := gstructs.StructType(new(B))
+		t.AssertNil(err)
+		t.Assert(r.FieldKeys(), g.Slice{"Age", "Score", "Id", "Name"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		type Time struct {
+			CreatedAt string
+			UpdatedAt string
+		}
+		type A struct {
+			Age   int
+			Score float64
+		}
+		type B struct {
+			*A
+			Time
+			Id   int
+			Name string
+		}
+		r, err := gstructs.StructType(new(B))
+		t.AssertNil(err)
+		t.Assert(r.FieldKeys(), g.Slice{"Age", "Score", "CreatedAt", "UpdatedAt", "Id", "Name"})
+	})
 }
 
 func TestType_TagMap(t *testing.T) {


### PR DESCRIPTION
gstructs.Type.FieldKeys() 无法识别匿名结构体的字段，导致带有With的查询时，查询的字段不符合期望
