### PR TITLE
net/ghttp: conditional printing access log to stdout

### DIFF
--- a/net/ghttp/ghttp_server_config.go
+++ b/net/ghttp/ghttp_server_config.go
@@ -205,15 +205,17 @@ type ServerConfig struct {
 	// Logging.
 	// ======================================================================================================
 
-	Logger           *glog.Logger `json:"logger"`           // Logger specifies the logger for server.
-	LogPath          string       `json:"logPath"`          // LogPath specifies the directory for storing logging files.
-	LogLevel         string       `json:"logLevel"`         // LogLevel specifies the logging level for logger.
-	LogStdout        bool         `json:"logStdout"`        // LogStdout specifies whether printing logging content to stdout.
-	ErrorStack       bool         `json:"errorStack"`       // ErrorStack specifies whether logging stack information when error.
-	ErrorLogEnabled  bool         `json:"errorLogEnabled"`  // ErrorLogEnabled enables error logging content to files.
-	ErrorLogPattern  string       `json:"errorLogPattern"`  // ErrorLogPattern specifies the error log file pattern like: error-{Ymd}.log
-	AccessLogEnabled bool         `json:"accessLogEnabled"` // AccessLogEnabled enables access logging content to files.
-	AccessLogPattern string       `json:"accessLogPattern"` // AccessLogPattern specifies the error log file pattern like: access-{Ymd}.log
+	Logger                   *glog.Logger `json:"logger"`                   // Logger specifies the logger for server.
+	LogPath                  string       `json:"logPath"`                  // LogPath specifies the directory for storing logging files.
+	LogLevel                 string       `json:"logLevel"`                 // LogLevel specifies the logging level for logger.
+	LogStdout                bool         `json:"logStdout"`                // LogStdout specifies whether printing logging content to stdout.
+	ErrorStack               bool         `json:"errorStack"`               // ErrorStack specifies whether logging stack information when error.
+	ErrorLogEnabled          bool         `json:"errorLogEnabled"`          // ErrorLogEnabled enables error logging content to files.
+	ErrorLogPattern          string       `json:"errorLogPattern"`          // ErrorLogPattern specifies the error log file pattern like: error-{Ymd}.log
+	AccessLogEnabled         bool         `json:"accessLogEnabled"`         // AccessLogEnabled enables access logging content to files.
+	AccessLogPattern         string       `json:"accessLogPattern"`         // AccessLogPattern specifies the error log file pattern like: access-{Ymd}.log
+	AccessLogStdoutDisabled  bool         `json:"accessLogStdoutDisabled"`  // AccessLogStdoutDisabled specifies whether not printing access logging content to stdout if AccessLogStdoutDisabled is true.
+	AccessLogConditionUnless string       `json:"accessLogConditionUnless"` // AccessLogConditionUnless specifies condition which is meant not to printing access logging
 
 	// ======================================================================================================
 	// PProf.

--- a/net/ghttp/ghttp_server_config_cookie.go
+++ b/net/ghttp/ghttp_server_config_cookie.go
@@ -62,3 +62,7 @@ func (s *Server) GetCookieSecure() bool {
 func (s *Server) GetCookieHttpOnly() bool {
 	return s.config.CookieHttpOnly
 }
+
+func (s *Server) GetAccessLogUnlessCondition() string {
+	return s.config.AccessLogConditionUnless
+}

--- a/net/ghttp/ghttp_server_log.go
+++ b/net/ghttp/ghttp_server_log.go
@@ -20,6 +20,11 @@ func (s *Server) handleAccessLog(r *Request) {
 	if !s.IsAccessLogEnabled() {
 		return
 	}
+
+	if s.config.AccessLogConditionUnless != "" && r.GetCtxVar(s.config.AccessLogConditionUnless).String() != "" {
+		return
+	}
+
 	var (
 		scheme            = r.GetSchema()
 		loggerInstanceKey = fmt.Sprintf(`Acccess Logger Of Server:%s`, s.instance)
@@ -33,7 +38,7 @@ func (s *Server) handleAccessLog(r *Request) {
 	logger := instance.GetOrSetFuncLock(loggerInstanceKey, func() interface{} {
 		l := s.Logger().Clone()
 		l.SetFile(s.config.AccessLogPattern)
-		l.SetStdoutPrint(s.config.LogStdout)
+		l.SetStdoutPrint(s.config.LogStdout && !s.config.AccessLogStdoutDisabled)
 		l.SetLevelPrint(false)
 		return l
 	}).(*glog.Logger)


### PR DESCRIPTION
Added AccessLogStdoutDisabled toggle to disable access content logging into stdout and supported conditional access log to exclude endpoints such as /health, /metrics etc.