### PR TITLE
database/gdb:  fixed hasTable and getSoftFieldNameAndType use memory cache

### DIFF
--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -150,6 +150,7 @@ type DB interface {
 	// ===========================================================================
 
 	GetCache() *gcache.Cache            // See Core.GetCache.
+	GetMemCache() *gcache.Cache         // See Core.GetMemCache.
 	SetDebug(debug bool)                // See Core.SetDebug.
 	GetDebug() bool                     // See Core.GetDebug.
 	GetSchema() string                  // See Core.GetSchema.
@@ -264,6 +265,7 @@ type Core struct {
 	schema        string          // Custom schema for this object.
 	debug         *gtype.Bool     // Enable debug mode for the database, which can be changed in runtime.
 	cache         *gcache.Cache   // Cache manager, SQL result cache only.
+	memCache      *gcache.Cache   // Cache manager, inner memory cache use
 	links         *gmap.Map       // links caches all created links by node.
 	logger        glog.ILogger    // Logger for logging functionality.
 	config        *ConfigNode     // Current config node.
@@ -587,12 +589,13 @@ func newDBByConfigNode(node *ConfigNode, group string) (db DB, err error) {
 		node = parseConfigNodeLink(node)
 	}
 	c := &Core{
-		group:  group,
-		debug:  gtype.NewBool(),
-		cache:  gcache.New(),
-		links:  gmap.New(true),
-		logger: glog.New(),
-		config: node,
+		group:    group,
+		debug:    gtype.NewBool(),
+		cache:    gcache.New(),
+		memCache: gcache.New(),
+		links:    gmap.New(true),
+		logger:   glog.New(),
+		config:   node,
 		dynamicConfig: dynamicConfig{
 			MaxIdleConnCount: node.MaxIdleConnCount,
 			MaxOpenConnCount: node.MaxOpenConnCount,

--- a/database/gdb/gdb_core.go
+++ b/database/gdb/gdb_core.go
@@ -106,6 +106,10 @@ func (c *Core) Close(ctx context.Context) (err error) {
 	if err = c.cache.Close(ctx); err != nil {
 		return err
 	}
+	if err = c.memCache.Close(ctx); err != nil {
+		return err
+	}
+
 	c.links.LockFunc(func(m map[any]any) {
 		for k, v := range m {
 			if db, ok := v.(*sql.DB); ok {
@@ -743,7 +747,7 @@ func (c *Core) GetTablesWithCache() ([]string, error) {
 		ctx      = c.db.GetCtx()
 		cacheKey = fmt.Sprintf(`Tables: %s`, c.db.GetGroup())
 	)
-	result, err := c.GetCache().GetOrSetFuncLock(
+	result, err := c.GetMemCache().GetOrSetFuncLock(
 		ctx, cacheKey, func(ctx context.Context) (interface{}, error) {
 			tableList, err := c.db.Tables(ctx)
 			if err != nil {

--- a/database/gdb/gdb_core_config.go
+++ b/database/gdb/gdb_core_config.go
@@ -237,6 +237,11 @@ func (c *Core) GetCache() *gcache.Cache {
 	return c.cache
 }
 
+// GetMemCache returns the internal cache object.
+func (c *Core) GetMemCache() *gcache.Cache {
+	return c.memCache
+}
+
 // GetGroup returns the group string configured.
 func (c *Core) GetGroup() string {
 	return c.group

--- a/database/gdb/gdb_core_utility.go
+++ b/database/gdb/gdb_core_utility.go
@@ -174,12 +174,20 @@ func (c *Core) ClearTableFieldsAll(ctx context.Context) (err error) {
 
 // ClearCache removes cached sql result of certain table.
 func (c *Core) ClearCache(ctx context.Context, table string) (err error) {
-	return c.db.GetCache().Clear(ctx)
+	if err := c.db.GetCache().Clear(ctx); err != nil {
+		return err
+	}
+
+	return c.db.GetMemCache().Clear(ctx)
 }
 
 // ClearCacheAll removes all cached sql result from cache
 func (c *Core) ClearCacheAll(ctx context.Context) (err error) {
-	return c.db.GetCache().Clear(ctx)
+	if err := c.db.GetCache().Clear(ctx); err != nil {
+		return err
+	}
+
+	return c.db.GetMemCache().Clear(ctx)
 }
 
 func (c *Core) makeSelectCacheKey(name, schema, table, sql string, args ...interface{}) string {

--- a/database/gdb/gdb_model_soft_time.go
+++ b/database/gdb/gdb_model_soft_time.go
@@ -215,7 +215,7 @@ func (m *softTimeMaintainer) getSoftFieldNameAndType(
 			return
 		}
 	)
-	result, err := gcache.GetOrSetFunc(ctx, cacheKey, cacheFunc, cacheDuration)
+	result, err := m.db.GetMemCache().GetOrSetFunc(ctx, cacheKey, cacheFunc, cacheDuration)
 	if err != nil {
 		intlog.Error(ctx, err)
 	}

--- a/database/gdb/gdb_schema.go
+++ b/database/gdb/gdb_schema.go
@@ -23,6 +23,7 @@ func (c *Core) Schema(schema string) *Schema {
 	// Different schema share some same objects.
 	core.logger = c.logger
 	core.cache = c.cache
+	core.memCache = c.memCache
 	core.schema = schema
 	return &Schema{
 		DB: db,


### PR DESCRIPTION
Fixed: #3574 
1. add Memory Cache
2. hasTable from resultCache to memCache
3. getSoftFieldNameAndType from defaultCache to db.memCache (db uses its own memory cache to avoid global competition)