### PR TITLE
driver/pgsql: optimize regex for version matching

### DIFF
--- a/cmd/gf/internal/cmd/cmd_build.go
+++ b/cmd/gf/internal/cmd/cmd_build.go
@@ -35,6 +35,8 @@ var (
 		nodeNameInConfigFile: "gfcli.build",
 		packedGoFileName:     "internal/packed/build_pack_data.go",
 	}
+
+	spaceRegex  = regexp.MustCompile(`\s+`)
 )
 
 type cBuild struct {
@@ -190,7 +192,6 @@ func (c cBuild) Index(ctx context.Context, in cBuildInput) (out *cBuildOutput, e
 	}
 	// System and arch checks.
 	var (
-		spaceRegex  = regexp.MustCompile(`\s+`)
 		platformMap = make(map[string]map[string]bool)
 	)
 	for _, line := range strings.Split(strings.TrimSpace(cBuildPlatforms), "\n") {

--- a/cmd/gf/internal/cmd/cmd_build.go
+++ b/cmd/gf/internal/cmd/cmd_build.go
@@ -36,7 +36,7 @@ var (
 		packedGoFileName:     "internal/packed/build_pack_data.go",
 	}
 
-	spaceRegex  = regexp.MustCompile(`\s+`)
+	spaceRegex = regexp.MustCompile(`\s+`)
 )
 
 type cBuild struct {

--- a/cmd/gf/internal/cmd/cmd_build.go
+++ b/cmd/gf/internal/cmd/cmd_build.go
@@ -35,8 +35,6 @@ var (
 		nodeNameInConfigFile: "gfcli.build",
 		packedGoFileName:     "internal/packed/build_pack_data.go",
 	}
-
-	spaceRegex = regexp.MustCompile(`\s+`)
 )
 
 type cBuild struct {
@@ -192,6 +190,7 @@ func (c cBuild) Index(ctx context.Context, in cBuildInput) (out *cBuildOutput, e
 	}
 	// System and arch checks.
 	var (
+		spaceRegex  = regexp.MustCompile(`\s+`)
 		platformMap = make(map[string]map[string]bool)
 	)
 	for _, line := range strings.Split(strings.TrimSpace(cBuildPlatforms), "\n") {

--- a/contrib/drivers/pgsql/pgsql_tables.go
+++ b/contrib/drivers/pgsql/pgsql_tables.go
@@ -32,6 +32,8 @@ WHERE
 ORDER BY
 	c.relname
 `
+
+	postgreRegex = regexp.MustCompile(`PostgreSQL (\d+\.\d+)`)
 )
 
 func init() {
@@ -90,7 +92,7 @@ func (d *Driver) version(ctx context.Context, link gdb.Link) string {
 	}
 	if len(result) > 0 {
 		if v, ok := result[0]["version"]; ok {
-			matches := regexp.MustCompile(`PostgreSQL (\d+\.\d+)`).FindStringSubmatch(v.String())
+			matches := postgreRegex.FindStringSubmatch(v.String())
 			if len(matches) >= 2 {
 				return matches[1]
 			}

--- a/contrib/drivers/pgsql/pgsql_tables.go
+++ b/contrib/drivers/pgsql/pgsql_tables.go
@@ -33,7 +33,7 @@ ORDER BY
 	c.relname
 `
 
-	postgreRegex = regexp.MustCompile(`PostgreSQL (\d+\.\d+)`)
+	versionRegex = regexp.MustCompile(`PostgreSQL (\d+\.\d+)`)
 )
 
 func init() {
@@ -92,7 +92,7 @@ func (d *Driver) version(ctx context.Context, link gdb.Link) string {
 	}
 	if len(result) > 0 {
 		if v, ok := result[0]["version"]; ok {
-			matches := postgreRegex.FindStringSubmatch(v.String())
+			matches := versionRegex.FindStringSubmatch(v.String())
 			if len(matches) >= 2 {
 				return matches[1]
 			}


### PR DESCRIPTION
**Please ensure you adhere to every item in this list.**
every time function **Index** and **version** execute, these regexp are initialized. which situation reduce the performance.


