### PR TITLE
os/gcfg: fix gcfg adaptfile dogetfilepath 

### DIFF
--- a/os/gcfg/gcfg_adapter_file_path.go
+++ b/os/gcfg/gcfg_adapter_file_path.go
@@ -216,9 +216,9 @@ func (a *AdapterFile) doGetFilePath(fileName string) (filePath string) {
 	// Searching local file system.
 	if filePath == "" {
 		// Absolute path.
-		if filePath = gfile.RealPath(fileName); filePath != "" && !gfile.IsDir(filePath) {
+		/*if filePath = gfile.RealPath(fileName); filePath != "" && !gfile.IsDir(filePath) {
 			return
-		}
+		}*/
 		a.searchPaths.RLockFunc(func(array []string) {
 			for _, searchPath := range array {
 				searchPath = gstr.TrimRight(searchPath, `\/`)
@@ -234,6 +234,12 @@ func (a *AdapterFile) doGetFilePath(fileName string) (filePath string) {
 				}
 			}
 		})
+	}
+	if filePath == "" {
+		// Absolute path.
+		if filePath = gfile.RealPath(fileName); filePath != "" && !gfile.IsDir(filePath) {
+			return
+		}
 	}
 	return
 }


### PR DESCRIPTION
当项目根目录下存在 `./config.yaml` 配置文件时，原代码将强制加载 `./config.yaml`
修复后将此逻辑排后
原始
![gf-fix-gcfg](https://github.com/gogf/gf/assets/2783477/1b5be575-59d5-48fe-bebf-cbd9182eb079)
修复后：
![gf-fix-gcfg-2](https://github.com/gogf/gf/assets/2783477/1e3615e2-3ad5-4e20-aff8-b4dff519004f)
