### PR TITLE
zookeeper : grpc用zookeeper服务注册发现 prefix不正确 多个杠

### DIFF
--- a/contrib/registry/zookeeper/zookeeper_discovery.go
+++ b/contrib/registry/zookeeper/zookeeper_discovery.go
@@ -19,7 +19,7 @@ import (
 
 // Search searches and returns services with specified condition.
 func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Service, error) {
-	prefix := strings.TrimPrefix(strings.ReplaceAll(in.Prefix, "/", "-"), "-")
+	prefix := strings.Trim(strings.ReplaceAll(in.Prefix, "/", "-"), "-")
 	instances, err, _ := r.group.Do(prefix, func() (interface{}, error) {
 		serviceNamePath := path.Join(r.opts.namespace, prefix)
 		servicesID, _, err := r.conn.Children(serviceNamePath)

--- a/contrib/registry/zookeeper/zookeeper_registrar.go
+++ b/contrib/registry/zookeeper/zookeeper_registrar.go
@@ -31,7 +31,7 @@ func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Servi
 			r.opts.namespace,
 		)
 	}
-	prefix := strings.TrimPrefix(strings.ReplaceAll(service.GetPrefix(), "/", "-"), "-")
+	prefix := strings.Trim(strings.ReplaceAll(service.GetPrefix(), "/", "-"), "-")
 	servicePrefixPath := path.Join(r.opts.namespace, prefix)
 	if err = r.ensureName(servicePrefixPath, []byte(""), 0); err != nil {
 		return service, gerror.Wrapf(


### PR DESCRIPTION
服务注册的时候zookeeper_registrar里会取service.GetPrefix()得到的prefix是service-default-default-idalloc-latest，而在查找服务时
resolver_builder里用target.URL.Path作为watchKey，是这样的/service/default/default/idalloc/latest/，传到zookeeper_discovery的Search里 prefix转成了service-default-default-idalloc-latest-，最后面有个杠-    
