### PR TITLE
cmd/gf: add `DaMeng` database driver support

### DIFF
--- a/cmd/gf/go.mod
+++ b/cmd/gf/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gogf/gf/contrib/drivers/oracle/v2 v2.7.1
 	github.com/gogf/gf/contrib/drivers/pgsql/v2 v2.7.1
 	github.com/gogf/gf/contrib/drivers/sqlite/v2 v2.7.1
+	github.com/gogf/gf/contrib/drivers/dm/v2 v2.7.1
 	github.com/gogf/gf/v2 v2.7.1
 	github.com/gogf/selfupdate v0.0.0-20231215043001-5c48c528462f
 	github.com/olekukonko/tablewriter v0.0.5

--- a/cmd/gf/go.work
+++ b/cmd/gf/go.work
@@ -16,5 +16,6 @@ replace (
 	github.com/gogf/gf/contrib/drivers/oracle/v2 => ../../contrib/drivers/oracle
 	github.com/gogf/gf/contrib/drivers/pgsql/v2 => ../../contrib/drivers/pgsql
 	github.com/gogf/gf/contrib/drivers/sqlite/v2 => ../../contrib/drivers/sqlite
+	github.com/gogf/gf/contrib/drivers/dm/v2 => ../../contrib/drivers/dm
 	github.com/gogf/gf/v2 => ../../
 )

--- a/cmd/gf/internal/cmd/cmd_gen_dao.go
+++ b/cmd/gf/internal/cmd/cmd_gen_dao.go
@@ -8,6 +8,7 @@ package cmd
 
 import (
 	_ "github.com/gogf/gf/contrib/drivers/clickhouse/v2"
+	_ "github.com/gogf/gf/contrib/drivers/dm/v2"
 	_ "github.com/gogf/gf/contrib/drivers/mssql/v2"
 	_ "github.com/gogf/gf/contrib/drivers/mysql/v2"
 	_ "github.com/gogf/gf/contrib/drivers/oracle/v2"

--- a/cmd/gf/internal/cmd/gendao/gendao_dao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_dao.go
@@ -58,8 +58,8 @@ func generateDaoSingle(ctx context.Context, in generateDaoSingleInput) {
 		mlog.Fatalf(`fetching tables fields failed for table "%s": %+v`, in.TableName, err)
 	}
 	var (
-		tableNameCamelCase      = gstr.CaseCamel(in.NewTableName)
-		tableNameCamelLowerCase = gstr.CaseCamelLower(in.NewTableName)
+		tableNameCamelCase      = gstr.CaseCamel(strings.ToLower(in.NewTableName))
+		tableNameCamelLowerCase = gstr.CaseCamelLower(strings.ToLower(in.NewTableName))
 		tableNameSnakeCase      = gstr.CaseSnake(in.NewTableName)
 		importPrefix            = in.ImportPrefix
 	)
@@ -178,7 +178,7 @@ func generateColumnNamesForDao(fieldMap map[string]*gdb.TableField, removeFieldP
 		}
 
 		array[index] = []string{
-			"            #" + gstr.CaseCamel(newFiledName) + ":",
+			"            #" + gstr.CaseCamel(strings.ToLower(newFiledName)) + ":",
 			fmt.Sprintf(` #"%s",`, field.Name),
 		}
 	}
@@ -218,7 +218,7 @@ func generateColumnDefinitionForDao(fieldMap map[string]*gdb.TableField, removeF
 			newFiledName = gstr.TrimLeftStr(newFiledName, v, 1)
 		}
 		array[index] = []string{
-			"    #" + gstr.CaseCamel(newFiledName),
+			"    #" + gstr.CaseCamel(strings.ToLower(newFiledName)),
 			" # " + "string",
 			" #" + fmt.Sprintf(`// %s`, comment),
 		}

--- a/cmd/gf/internal/cmd/gendao/gendao_do.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_do.go
@@ -40,7 +40,7 @@ func generateDo(ctx context.Context, in CGenDaoInternalInput) {
 			structDefinition, _ = generateStructDefinition(ctx, generateStructDefinitionInput{
 				CGenDaoInternalInput: in,
 				TableName:            tableName,
-				StructName:           gstr.CaseCamel(newTableName),
+				StructName:           gstr.CaseCamel(strings.ToLower(newTableName)),
 				FieldMap:             fieldMap,
 				IsDo:                 true,
 			})
@@ -61,7 +61,7 @@ func generateDo(ctx context.Context, in CGenDaoInternalInput) {
 			ctx,
 			in,
 			tableName,
-			gstr.CaseCamel(newTableName),
+			gstr.CaseCamel(strings.ToLower(newTableName)),
 			structDefinition,
 		)
 		in.genItems.AppendGeneratedFilePath(doFilePath)

--- a/cmd/gf/internal/cmd/gendao/gendao_entity.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_entity.go
@@ -36,7 +36,7 @@ func generateEntity(ctx context.Context, in CGenDaoInternalInput) {
 			structDefinition, appendImports = generateStructDefinition(ctx, generateStructDefinitionInput{
 				CGenDaoInternalInput: in,
 				TableName:            tableName,
-				StructName:           gstr.CaseCamel(newTableName),
+				StructName:           gstr.CaseCamel(strings.ToLower(newTableName)),
 				FieldMap:             fieldMap,
 				IsDo:                 false,
 			})
@@ -44,7 +44,7 @@ func generateEntity(ctx context.Context, in CGenDaoInternalInput) {
 				ctx,
 				in,
 				newTableName,
-				gstr.CaseCamel(newTableName),
+				gstr.CaseCamel(strings.ToLower(newTableName)),
 				structDefinition,
 				appendImports,
 			)

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -140,7 +140,7 @@ func generateStructFieldDefinition(
 	}
 
 	attrLines = []string{
-		"    #" + gstr.CaseCamel(newFiledName),
+		"    #" + gstr.CaseCamel(strings.ToLower(newFiledName)),
 		" #" + localTypeNameStr,
 	}
 	attrLines = append(attrLines, fmt.Sprintf(` #%sjson:"%s"`, tagKey, jsonTag))


### PR DESCRIPTION
The purpose is to be able to use the DM database to build a CLI.