### PR TITLE
.github/workflows: 修复ci设置时区的node16废弃警告

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -192,7 +192,7 @@ jobs:
     # TODO: szenius/set-timezone update to node16
     # sudo ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
     - name: Setup Timezone
-      uses: szenius/set-timezone@v1.1
+      uses: szenius/set-timezone@v2.0
       with:
         timezoneLinux: "Asia/Shanghai"
 

--- a/.github/workflows/ci-sub.yml
+++ b/.github/workflows/ci-sub.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Setup Timezone
-      uses: szenius/set-timezone@v1.1
+      uses: szenius/set-timezone@v2.0
       with:
         timezoneLinux: "Asia/Shanghai"
 


### PR DESCRIPTION
https://github.com/szenius/set-timezone/releases/tag/v2.0