### PR TITLE
database/gdb: remove duplicated SQL records in tracing events

### DIFF
--- a/database/gdb/gdb_core_trace.go
+++ b/database/gdb/gdb_core_trace.go
@@ -29,7 +29,6 @@ const (
 	traceAttrDbLink           = "db.link"
 	traceAttrDbGroup          = "db.group"
 	traceEventDbExecution     = "db.execution"
-	traceEventDbExecutionSql  = "db.execution.sql"
 	traceEventDbExecutionCost = "db.execution.cost"
 	traceEventDbExecutionRows = "db.execution.rows"
 	traceEventDbExecutionTxID = "db.execution.txid"
@@ -70,7 +69,6 @@ func (c *Core) traceSpanEnd(ctx context.Context, span trace.Span, sql *Sql) {
 	}
 	span.SetAttributes(labels...)
 	events := []attribute.KeyValue{
-		attribute.String(traceEventDbExecutionSql, sql.Format),
 		attribute.String(traceEventDbExecutionCost, fmt.Sprintf(`%d ms`, sql.End-sql.Start)),
 		attribute.String(traceEventDbExecutionRows, fmt.Sprintf(`%d`, sql.RowsAffected)),
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/clbanning/mxj/v2 v2.7.0
+	github.com/emirpasic/gods v1.18.1
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gorilla/websocket v1.5.1
@@ -20,7 +21,6 @@ require (
 )
 
 require (
-	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
#3658 

改为统一的官方协议，以及去除重复记录，减少trace的存储大小
