### PR TITLE
perf(net/ghttp):  using assembly instead of reflection to call canonical routing

### DIFF
--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -77,11 +77,12 @@ type (
 
 	// handlerFuncInfo contains the HandlerFunc address and its reflection type.
 	handlerFuncInfo struct {
-		Func            HandlerFunc      // Handler function address.
-		Type            reflect.Type     // Reflect type information for current handler, which is used for extensions of the handler feature.
-		Value           reflect.Value    // Reflect value information for current handler, which is used for extensions of the handler feature.
-		IsStrictRoute   bool             // Whether strict route matching is enabled.
-		ReqStructFields []gstructs.Field // Request struct fields.
+		Func               HandlerFunc      // Handler function address.
+		Type               reflect.Type     // Reflect type information for current handler, which is used for extensions of the handler feature.
+		Value              reflect.Value    // Reflect value information for current handler, which is used for extensions of the handler feature.
+		IsStrictRoute      bool             // Whether strict route matching is enabled.
+		ReqStructFields    []gstructs.Field // Request struct fields.
+		handlerFuncClosure any              // handlerFuncClosure = Value.Interface()
 	}
 
 	// HandlerItem is the registered handler for route handling,

--- a/net/ghttp/ghttp_server_service_handler.go
+++ b/net/ghttp/ghttp_server_service_handler.go
@@ -293,8 +293,8 @@ func createRouterFunc(funcInfo handlerFuncInfo) func(r *Request) {
 			inputValues = append(inputValues, inputObject)
 		}
 		if runtime.GOARCH == "amd64" {
-			if funcInfo.handlerFuncClosure != nil {
-				asmCall(&funcInfo, r, reqParameter)
+			if funcInfo.IsStrictRoute && funcInfo.handlerFuncClosure != nil {
+				asmCallStrictRoute(&funcInfo, r, reqParameter)
 				return
 			}
 		}
@@ -318,47 +318,6 @@ func createRouterFunc(funcInfo handlerFuncInfo) func(r *Request) {
 		}
 	}
 }
-
-func asmCall(funcInfo *handlerFuncInfo, r *Request, req unsafe.Pointer) {
-	type iface struct {
-		typ  unsafe.Pointer
-		data unsafe.Pointer
-	}
-	switch funcInfo.Type.NumOut() {
-	case 2:
-		if funcInfo.Type.Out(0).Kind() == reflect.Slice {
-			res, err := doAnyCallRequest_with_sliceRes_err(funcInfo.handlerFuncClosure, r.Context(), req)
-			sliceValue := reflect.New(funcInfo.Type.Out(0)).Elem().Interface()
-			out := (*iface)(unsafe.Pointer(&sliceValue))
-			(*out).data = unsafe.Pointer(&res)
-			r.handlerResponse = sliceValue
-			r.error = err
-		} else {
-			res, err := doAnyCallRequest_with_res_err(funcInfo.handlerFuncClosure, r.Context(), req)
-			outType := funcInfo.Type.Out(0).Elem()
-			outValue := reflect.New(outType).Interface()
-			out := (*iface)(unsafe.Pointer(&outValue))
-			(*out).data = res
-			r.handlerResponse = outValue
-			r.error = err
-		}
-	case 1:
-		err := doAnyCallRequest_with_err(funcInfo.handlerFuncClosure, r.Context(), req)
-		r.error = err
-	}
-}
-
-func doAnyCallRequest_with_err(fn any, ctx context.Context, req unsafe.Pointer) error
-
-func doAnyCallRequest_with_res_err(fn any, ctx context.Context, req unsafe.Pointer) (unsafe.Pointer, error)
-
-type _slice struct {
-	ptr unsafe.Pointer
-	len int
-	cap int
-}
-
-func doAnyCallRequest_with_sliceRes_err(fn any, ctx context.Context, req unsafe.Pointer) (_slice, error)
 
 // trimGeneric removes type definitions string from response type name if generic
 func trimGeneric(structName string) string {

--- a/net/ghttp/ghttp_strict_route_call_amd64.go
+++ b/net/ghttp/ghttp_strict_route_call_amd64.go
@@ -1,0 +1,54 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package ghttp
+
+import (
+	"context"
+	"reflect"
+	"unsafe"
+)
+
+func asmCallStrictRoute(funcInfo *handlerFuncInfo, r *Request, req unsafe.Pointer) {
+	type iface struct {
+		typ  unsafe.Pointer
+		data unsafe.Pointer
+	}
+	switch funcInfo.Type.NumOut() {
+	case 2:
+		if funcInfo.Type.Out(0).Kind() == reflect.Slice {
+			res, err := doAnyCallRequest_with_sliceRes_err(funcInfo.handlerFuncClosure, r.Context(), req)
+			sliceValue := reflect.New(funcInfo.Type.Out(0)).Elem().Interface()
+			out := (*iface)(unsafe.Pointer(&sliceValue))
+			(*out).data = unsafe.Pointer(&res)
+			r.handlerResponse = sliceValue
+			r.error = err
+		} else {
+			res, err := doAnyCallRequest_with_res_err(funcInfo.handlerFuncClosure, r.Context(), req)
+			outType := funcInfo.Type.Out(0).Elem()
+			outValue := reflect.New(outType).Interface()
+			out := (*iface)(unsafe.Pointer(&outValue))
+			(*out).data = res
+			r.handlerResponse = outValue
+			r.error = err
+		}
+	case 1:
+		err := doAnyCallRequest_with_err(funcInfo.handlerFuncClosure, r.Context(), req)
+		r.error = err
+	}
+}
+
+func doAnyCallRequest_with_err(fn any, ctx context.Context, req unsafe.Pointer) error
+
+func doAnyCallRequest_with_res_err(fn any, ctx context.Context, req unsafe.Pointer) (unsafe.Pointer, error)
+
+type _slice struct {
+	ptr unsafe.Pointer
+	len int
+	cap int
+}
+
+func doAnyCallRequest_with_sliceRes_err(fn any, ctx context.Context, req unsafe.Pointer) (_slice, error)

--- a/net/ghttp/ghttp_strict_route_call_amd64.s
+++ b/net/ghttp/ghttp_strict_route_call_amd64.s
@@ -1,0 +1,69 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+// ctx It is an interface type that will pass two pointers in
+// fn.data = &closure         It is a closure structure, similar to the following
+// type closure struct{
+//      Fn unsafe.Pointer     What is saved here is the address of the actual function
+//      captured variables... This is the parameter field captured by the closure function, which may be of pointer or value type
+//      // A int
+//      // B *int
+//      // others...
+// }
+// The convention for calling closure functions in Go language is usually to store&closure in the dx register
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloReq,error)
+TEXT  ·doAnyCallRequest_with_res_err(SB), $24
+    MOVQ fn_data+8(FP),DX
+
+    MOVQ ctx_type+16(FP), AX
+    MOVQ ctx_data+24(FP), BX
+    MOVQ req+32(FP), CX
+
+    CALL 0(DX)
+
+    MOVQ AX, res+40(FP)
+    MOVQ BX, err_type+48(FP)
+    MOVQ CX, err_data+56(FP)
+    RET
+
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) error
+TEXT  ·doAnyCallRequest_with_err(SB), $16
+    MOVQ fn_data+8(FP),DX
+
+    MOVQ ctx_type+16(FP), AX
+    MOVQ ctx_data+24(FP), BX
+    MOVQ req+32(FP), CX
+
+    CALL 0(DX)
+
+    MOVQ BX, err_type+40(FP)
+    MOVQ CX, err_data+48(FP)
+    RET
+
+// type slice struct{
+//      ptr unsafe.Pointer
+//      len int
+//      cap int
+// }
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) ([]HelloRes,error)
+TEXT  ·doAnyCallRequest_with_sliceRes_err(SB), $40
+    // Save the closure object to dx
+    MOVQ fn_data+8(FP),DX
+    // Passing ctx parameters
+    MOVQ ctx_type+16(FP), AX
+    MOVQ ctx_data+24(FP), BX
+    // Passing req parameters
+    MOVQ req+32(FP), CX
+    // Call the closure function
+    CALL 0(DX)
+    // Set return value
+    MOVQ AX, slice_ptr+40(FP)
+    MOVQ BX, slice_len+48(FP)
+    MOVQ CX, slice_cap+56(FP)
+    MOVQ DI, err_type+64(FP)
+    MOVQ SI, err_data+72(FP)
+    RET
+

--- a/net/ghttp/ghttp_strict_route_call_amd64.s
+++ b/net/ghttp/ghttp_strict_route_call_amd64.s
@@ -14,7 +14,7 @@
 //      // others...
 // }
 // The convention for calling closure functions in Go language is usually to store&closure in the dx register
-// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloReq,error)
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloRes,error)
 TEXT  ·doAnyCallRequest_with_res_err(SB), $24
     MOVQ fn_data+8(FP),DX
 


### PR DESCRIPTION
目前只在amd64平台实现了汇编调用
