### PR TITLE
perf(net/ghttp): Using assembly instead of reflection to call routing on the AMD64 platform

### DIFF
--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -77,11 +77,12 @@ type (
 
 	// handlerFuncInfo contains the HandlerFunc address and its reflection type.
 	handlerFuncInfo struct {
-		Func            HandlerFunc      // Handler function address.
-		Type            reflect.Type     // Reflect type information for current handler, which is used for extensions of the handler feature.
-		Value           reflect.Value    // Reflect value information for current handler, which is used for extensions of the handler feature.
-		IsStrictRoute   bool             // Whether strict route matching is enabled.
-		ReqStructFields []gstructs.Field // Request struct fields.
+		Func               HandlerFunc      // Handler function address.
+		Type               reflect.Type     // Reflect type information for current handler, which is used for extensions of the handler feature.
+		Value              reflect.Value    // Reflect value information for current handler, which is used for extensions of the handler feature.
+		IsStrictRoute      bool             // Whether strict route matching is enabled.
+		ReqStructFields    []gstructs.Field // Request struct fields.
+		handlerFuncClosure any              // handlerFuncClosure = Value.Interface()
 	}
 
 	// HandlerItem is the registered handler for route handling,

--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/gorilla/websocket"
 
@@ -77,12 +78,14 @@ type (
 
 	// handlerFuncInfo contains the HandlerFunc address and its reflection type.
 	handlerFuncInfo struct {
-		Func               HandlerFunc      // Handler function address.
-		Type               reflect.Type     // Reflect type information for current handler, which is used for extensions of the handler feature.
-		Value              reflect.Value    // Reflect value information for current handler, which is used for extensions of the handler feature.
-		IsStrictRoute      bool             // Whether strict route matching is enabled.
-		ReqStructFields    []gstructs.Field // Request struct fields.
-		handlerFuncClosure any              // handlerFuncClosure = Value.Interface()
+		Func                  HandlerFunc      // Handler function address.
+		Type                  reflect.Type     // Reflect type information for current handler, which is used for extensions of the handler feature.
+		Value                 reflect.Value    // Reflect value information for current handler, which is used for extensions of the handler feature.
+		IsStrictRoute         bool             // Whether strict route matching is enabled.
+		ReqStructFields       []gstructs.Field // Request struct fields.
+		handlerFuncClosure    any              // handlerFuncClosure = Value.Interface()
+		rawHandlerFuncCodePtr unsafe.Pointer   // The first parameter is the receiver
+		objPointer            unsafe.Pointer   // receiver object
 	}
 
 	// HandlerItem is the registered handler for route handling,

--- a/net/ghttp/ghttp_server_router_group.go
+++ b/net/ghttp/ghttp_server_router_group.go
@@ -331,7 +331,7 @@ func (g *RouterGroup) doBindRoutersToServer(ctx context.Context, item *preBindIt
 	switch bindType {
 	case groupBindTypeHandler:
 		if reflect.ValueOf(object).Kind() == reflect.Func {
-			funcInfo, err := g.server.checkAndCreateFuncInfo(object, "", "", "")
+			funcInfo, err := g.server.checkAndCreateFuncInfo(object, "", "", "", reflect.Value{})
 			if err != nil {
 				g.server.Logger().Fatal(ctx, err.Error())
 				return g

--- a/net/ghttp/ghttp_server_service_handler.go
+++ b/net/ghttp/ghttp_server_service_handler.go
@@ -293,8 +293,8 @@ func createRouterFunc(funcInfo handlerFuncInfo) func(r *Request) {
 			inputValues = append(inputValues, inputObject)
 		}
 		if runtime.GOARCH == "amd64" {
-			if funcInfo.handlerFuncClosure != nil {
-				asmCall(&funcInfo, r, reqParameter)
+			if funcInfo.IsStrictRoute && funcInfo.handlerFuncClosure != nil {
+				asmCallStrictRoute(&funcInfo, r, reqParameter)
 				return
 			}
 		}
@@ -318,47 +318,6 @@ func createRouterFunc(funcInfo handlerFuncInfo) func(r *Request) {
 		}
 	}
 }
-
-func asmCall(funcInfo *handlerFuncInfo, r *Request, req unsafe.Pointer) {
-	type iface struct {
-		typ  unsafe.Pointer
-		data unsafe.Pointer
-	}
-	switch funcInfo.Type.NumOut() {
-	case 2:
-		if funcInfo.Type.Out(0).Kind() == reflect.Slice {
-			res, err := doAnyCallRequest_with_sliceRes_err(funcInfo.handlerFuncClosure, r.Context(), req)
-			sliceValue := reflect.New(funcInfo.Type.Out(0)).Elem().Interface()
-			out := (*iface)(unsafe.Pointer(&sliceValue))
-			(*out).data = unsafe.Pointer(&res)
-			r.handlerResponse = sliceValue
-			r.error = err
-		} else {
-			res, err := doAnyCallRequest_with_res_err(funcInfo.handlerFuncClosure, r.Context(), req)
-			outType := funcInfo.Type.Out(0).Elem()
-			outValue := reflect.New(outType).Interface()
-			out := (*iface)(unsafe.Pointer(&outValue))
-			(*out).data = res
-			r.handlerResponse = outValue
-			r.error = err
-		}
-	case 1:
-		err := doAnyCallRequest_with_err(funcInfo.handlerFuncClosure, r.Context(), req)
-		r.error = err
-	}
-}
-
-func doAnyCallRequest_with_err(fn any, ctx context.Context, req unsafe.Pointer) error
-
-func doAnyCallRequest_with_res_err(fn any, ctx context.Context, req unsafe.Pointer) (unsafe.Pointer, error)
-
-type _slice struct {
-	ptr unsafe.Pointer
-	len int
-	cap int
-}
-
-func doAnyCallRequest_with_sliceRes_err(fn any, ctx context.Context, req unsafe.Pointer) (_slice, error)
 
 // trimGeneric removes type definitions string from response type name if generic
 func trimGeneric(structName string) string {

--- a/net/ghttp/ghttp_server_service_object.go
+++ b/net/ghttp/ghttp_server_service_object.go
@@ -129,7 +129,7 @@ func (s *Server) doBindObject(ctx context.Context, in doBindObjectInput) {
 			objName = fmt.Sprintf(`(%s)`, objName)
 		}
 
-		funcInfo, err := s.checkAndCreateFuncInfo(reflectValue.Method(i).Interface(), pkgPath, objName, methodName)
+		funcInfo, err := s.checkAndCreateFuncInfo(reflectValue.Method(i).Interface(), pkgPath, objName, methodName, reflectValue)
 		if err != nil {
 			s.Logger().Fatalf(ctx, `%+v`, err)
 		}
@@ -225,7 +225,7 @@ func (s *Server) doBindObjectMethod(ctx context.Context, in doBindObjectMethodIn
 		objName = fmt.Sprintf(`(%s)`, objName)
 	}
 
-	funcInfo, err := s.checkAndCreateFuncInfo(methodValue.Interface(), pkgPath, objName, methodName)
+	funcInfo, err := s.checkAndCreateFuncInfo(methodValue.Interface(), pkgPath, objName, methodName, reflectValue)
 	if err != nil {
 		s.Logger().Fatalf(ctx, `%+v`, err)
 	}
@@ -283,7 +283,7 @@ func (s *Server) doBindObjectRest(ctx context.Context, in doBindObjectInput) {
 			reflectValue.Method(i).Interface(),
 			pkgPath,
 			objName,
-			methodName,
+			methodName, reflectValue,
 		)
 		if err != nil {
 			s.Logger().Fatalf(ctx, `%+v`, err)

--- a/net/ghttp/ghttp_strict_route_call_amd64.go
+++ b/net/ghttp/ghttp_strict_route_call_amd64.go
@@ -1,0 +1,54 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package ghttp
+
+import (
+	"context"
+	"reflect"
+	"unsafe"
+)
+
+func asmCallStrictRoute(funcInfo *handlerFuncInfo, r *Request, req unsafe.Pointer) {
+	type iface struct {
+		typ  unsafe.Pointer
+		data unsafe.Pointer
+	}
+	switch funcInfo.Type.NumOut() {
+	case 2:
+		if funcInfo.Type.Out(0).Kind() == reflect.Slice {
+			res, err := doAnyCallRequest_with_sliceRes_err(funcInfo.handlerFuncClosure, r.Context(), req)
+			sliceValue := reflect.New(funcInfo.Type.Out(0)).Elem().Interface()
+			out := (*iface)(unsafe.Pointer(&sliceValue))
+			(*out).data = unsafe.Pointer(&res)
+			r.handlerResponse = sliceValue
+			r.error = err
+		} else {
+			res, err := doAnyCallRequest_with_res_err(funcInfo.handlerFuncClosure, r.Context(), req)
+			outType := funcInfo.Type.Out(0).Elem()
+			outValue := reflect.New(outType).Interface()
+			out := (*iface)(unsafe.Pointer(&outValue))
+			(*out).data = res
+			r.handlerResponse = outValue
+			r.error = err
+		}
+	case 1:
+		err := doAnyCallRequest_with_err(funcInfo.handlerFuncClosure, r.Context(), req)
+		r.error = err
+	}
+}
+
+func doAnyCallRequest_with_err(fn any, ctx context.Context, req unsafe.Pointer) error
+
+func doAnyCallRequest_with_res_err(fn any, ctx context.Context, req unsafe.Pointer) (unsafe.Pointer, error)
+
+type _slice struct {
+	ptr unsafe.Pointer
+	len int
+	cap int
+}
+
+func doAnyCallRequest_with_sliceRes_err(fn any, ctx context.Context, req unsafe.Pointer) (_slice, error)

--- a/net/ghttp/ghttp_strict_route_call_amd64.s
+++ b/net/ghttp/ghttp_strict_route_call_amd64.s
@@ -1,0 +1,69 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+// ctx It is an interface type that will pass two pointers in
+// fn.data = &closure         It is a closure structure, similar to the following
+// type closure struct{
+//      Fn unsafe.Pointer     What is saved here is the address of the actual function
+//      captured variables... This is the parameter field captured by the closure function, which may be of pointer or value type
+//      // A int
+//      // B *int
+//      // others...
+// }
+// The convention for calling closure functions in Go language is usually to store&closure in the dx register
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloReq,error)
+TEXT  ·doAnyCallRequest_with_res_err(SB), $24
+    MOVQ fn_data+8(FP),DX
+
+    MOVQ ctx_type+16(FP), AX
+    MOVQ ctx_data+24(FP), BX
+    MOVQ req+32(FP), CX
+
+    CALL 0(DX)
+
+    MOVQ AX, res+40(FP)
+    MOVQ BX, err_type+48(FP)
+    MOVQ CX, err_data+56(FP)
+    RET
+
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) error
+TEXT  ·doAnyCallRequest_with_err(SB), $16
+    MOVQ fn_data+8(FP),DX
+
+    MOVQ ctx_type+16(FP), AX
+    MOVQ ctx_data+24(FP), BX
+    MOVQ req+32(FP), CX
+
+    CALL 0(DX)
+
+    MOVQ BX, err_type+40(FP)
+    MOVQ CX, err_data+48(FP)
+    RET
+
+// type slice struct{
+//      ptr unsafe.Pointer
+//      len int
+//      cap int
+// }
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) ([]HelloRes,error)
+TEXT  ·doAnyCallRequest_with_sliceRes_err(SB), $40
+    // Save the closure object to dx
+    MOVQ fn_data+8(FP),DX
+    // Passing ctx parameters
+    MOVQ ctx_type+16(FP), AX
+    MOVQ ctx_data+24(FP), BX
+    // Passing req parameters
+    MOVQ req+32(FP), CX
+    // Call the closure function
+    CALL 0(DX)
+    // Set return value
+    MOVQ AX, slice_ptr+40(FP)
+    MOVQ BX, slice_len+48(FP)
+    MOVQ CX, slice_cap+56(FP)
+    MOVQ DI, err_type+64(FP)
+    MOVQ SI, err_data+72(FP)
+    RET
+

--- a/net/ghttp/ghttp_strict_route_call_amd64.s
+++ b/net/ghttp/ghttp_strict_route_call_amd64.s
@@ -14,7 +14,7 @@
 //      // others...
 // }
 // The convention for calling closure functions in Go language is usually to store&closure in the dx register
-// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloReq,error)
+// func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloRes,error)
 TEXT  ·doAnyCallRequest_with_res_err(SB), $24
     MOVQ fn_data+8(FP),DX
 

--- a/net/ghttp/ghttp_strict_route_call_amd64.s
+++ b/net/ghttp/ghttp_strict_route_call_amd64.s
@@ -15,32 +15,58 @@
 // }
 // The convention for calling closure functions in Go language is usually to store&closure in the dx register
 // func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) (*HelloRes,error)
-TEXT  ·doAnyCallRequest_with_res_err(SB), $24
+TEXT  ·doAnyCallRequest_with_res_err(SB), $80
+    MOVQ AX,48(SP)
+    MOVQ BX,56(SP)
+    MOVQ CX,64(SP)
+    MOVQ DX,72(SP)
+
     MOVQ fn_data+8(FP),DX
 
     MOVQ ctx_type+16(FP), AX
     MOVQ ctx_data+24(FP), BX
     MOVQ req+32(FP), CX
-
+    // Passing parameters
+    MOVQ AX,0(SP)
+    MOVQ BX,8(SP)
+    MOVQ CX,16(SP)
     CALL 0(DX)
-
+    // Set return value
     MOVQ AX, res+40(FP)
     MOVQ BX, err_type+48(FP)
     MOVQ CX, err_data+56(FP)
+
+    MOVQ 48(SP),AX
+    MOVQ 56(SP),BX
+    MOVQ 64(SP),CX
+    MOVQ 72(SP),DX
     RET
 
 // func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) error
-TEXT  ·doAnyCallRequest_with_err(SB), $16
+TEXT  ·doAnyCallRequest_with_err(SB), $72
+    MOVQ AX,48(SP)
+    MOVQ BX,56(SP)
+    MOVQ CX,64(SP)
+    MOVQ DX,72(SP)
+
     MOVQ fn_data+8(FP),DX
 
     MOVQ ctx_type+16(FP), AX
     MOVQ ctx_data+24(FP), BX
     MOVQ req+32(FP), CX
-
+    // Passing parameters
+    MOVQ AX,0(SP)
+    MOVQ BX,8(SP)
+    MOVQ CX,16(SP)
     CALL 0(DX)
+    // Set return value
+    MOVQ AX, err_type+40(FP)
+    MOVQ BX, err_data+48(FP)
 
-    MOVQ BX, err_type+40(FP)
-    MOVQ CX, err_data+48(FP)
+    MOVQ 48(SP),AX
+    MOVQ 56(SP),BX
+    MOVQ 64(SP),CX
+    MOVQ 72(SP),DX
     RET
 
 // type slice struct{
@@ -49,7 +75,12 @@ TEXT  ·doAnyCallRequest_with_err(SB), $16
 //      cap int
 // }
 // func request(fn {typ, data unsafe.Pointer}, ctx {typ, data unsafe.Pointer},req *HelloReq) ([]HelloRes,error)
-TEXT  ·doAnyCallRequest_with_sliceRes_err(SB), $40
+TEXT  ·doAnyCallRequest_with_sliceRes_err(SB), $96
+    MOVQ AX,64(SP)
+    MOVQ BX,72(SP)
+    MOVQ CX,80(SP)
+    MOVQ DX,88(SP)
+
     // Save the closure object to dx
     MOVQ fn_data+8(FP),DX
     // Passing ctx parameters
@@ -57,6 +88,10 @@ TEXT  ·doAnyCallRequest_with_sliceRes_err(SB), $40
     MOVQ ctx_data+24(FP), BX
     // Passing req parameters
     MOVQ req+32(FP), CX
+    // Passing parameters
+    MOVQ AX,0(SP)
+    MOVQ BX,8(SP)
+    MOVQ CX,16(SP)
     // Call the closure function
     CALL 0(DX)
     // Set return value
@@ -65,5 +100,111 @@ TEXT  ·doAnyCallRequest_with_sliceRes_err(SB), $40
     MOVQ CX, slice_cap+56(FP)
     MOVQ DI, err_type+64(FP)
     MOVQ SI, err_data+72(FP)
+
+    MOVQ 64(SP),AX
+    MOVQ 72(SP),BX
+    MOVQ 80(SP),CX
+    MOVQ 88(SP),DX
     RET
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// func(fn,obj unsafe.Pointer, ctx context.Context, req unsafe.Pointer) (unsafe.Pointer, error)
+TEXT  ·doMethodCallRequest_with_res_err(SB), $96
+    MOVQ AX,56(SP)
+    MOVQ BX,64(SP)
+    MOVQ CX,72(SP)
+    MOVQ DI,80(SP)
+    MOVQ SI,88(SP)
+
+    MOVQ fn+0(FP),SI
+
+    MOVQ obj+8(FP),AX
+    MOVQ ctx_typ+16(FP),BX
+    MOVQ ctx_data+24(FP),CX
+    MOVQ req+32(FP),DI
+    // Passing parameters
+    MOVQ AX, 0(SP)
+    MOVQ BX, 8(SP)
+    MOVQ CX, 16(SP)
+    MOVQ DI, 24(SP)
+    CALL SI
+    // Set return value
+    MOVQ AX,res+40(FP)
+    MOVQ BX,err_typ+48(FP)
+    MOVQ CX,err_data+56(FP)
+
+    MOVQ 56(SP),AX
+    MOVQ 64(SP),BX
+    MOVQ 72(SP),CX
+    MOVQ 80(SP),DI
+    MOVQ 88(SP),SI
+    RET
+
+// func(fn,obj unsafe.Pointer, ctx context.Context, req unsafe.Pointer) error
+TEXT  ·doMethodCallRequest_with_err(SB), $96
+    MOVQ AX,56(SP)
+    MOVQ BX,64(SP)
+    MOVQ CX,72(SP)
+    MOVQ DI,80(SP)
+    MOVQ SI,88(SP)
+
+     MOVQ fn+0(FP),SI
+
+     MOVQ obj+8(FP),AX
+     MOVQ ctx_typ+16(FP),BX
+     MOVQ ctx_data+24(FP),CX
+     MOVQ req+32(FP),DI
+    // Passing parameters
+     MOVQ AX, 0(SP)
+     MOVQ BX, 8(SP)
+     MOVQ CX, 16(SP)
+     MOVQ DI, 24(SP)
+     CALL SI
+    // Set return value
+     MOVQ AX,err_typ+40(FP)
+     MOVQ BX,err_data+48(FP)
+
+     MOVQ 56(SP),AX
+     MOVQ 64(SP),BX
+     MOVQ 72(SP),CX
+     MOVQ 80(SP),DI
+     MOVQ 88(SP),SI
+     RET
+
+
+// func(fn,obj unsafe.Pointer, ctx context.Context, req unsafe.Pointer) (_slice, error)
+TEXT  ·doMethodCallRequest_with_sliceRes_err(SB), $112
+    MOVQ AX,72(SP)
+    MOVQ BX,80(SP)
+    MOVQ CX,88(SP)
+    MOVQ DI,96(SP)
+    MOVQ SI,104(SP)
+
+    MOVQ fn+0(FP),SI
+
+    MOVQ obj+8(FP),AX
+    MOVQ ctx_typ+16(FP),BX
+    MOVQ ctx_data+24(FP),CX
+    MOVQ req+32(FP),DI
+    // Passing parameters
+    MOVQ AX, 0(SP)
+    MOVQ BX, 8(SP)
+    MOVQ CX, 16(SP)
+    MOVQ DI, 24(SP)
+    CALL SI
+    // Set return value
+    MOVQ AX, slice_ptr+40(FP)
+    MOVQ BX, slice_len+48(FP)
+    MOVQ CX, slice_cap+56(FP)
+    MOVQ DI, err_type+64(FP)
+    MOVQ SI, err_data+72(FP)
+
+    MOVQ 72(SP),AX
+    MOVQ 80(SP),BX
+    MOVQ 88(SP),CX
+    MOVQ 96(SP),DI
+    MOVQ 104(SP),SI
+    RET


### PR DESCRIPTION
在amd64平台用汇编代替反射调用路由
