### PR TITLE
fix(cmd/gf): fix command `gf up` with `-u` option upgrading packages indirectly required would fail with higher version of go required

### DIFF
--- a/cmd/gf/internal/cmd/cmd_up.go
+++ b/cmd/gf/internal/cmd/cmd_up.go
@@ -142,6 +142,7 @@ func (c cUp) doUpgradeVersion(ctx context.Context, in cUpInput) (out *doUpgradeV
 			}
 			for _, pkg := range packages {
 				mlog.Printf(`upgrading "%s" from "%s" to "latest"`, pkg.Name, pkg.Version)
+				mlog.Printf(`running command: go get %s@latest`, pkg.Name)
 				// go get @latest
 				command := fmt.Sprintf(`cd %s && go get %s@latest`, dirPath, pkg.Name)
 				if err = gproc.ShellRun(ctx, command); err != nil {

--- a/cmd/gf/internal/cmd/cmd_up.go
+++ b/cmd/gf/internal/cmd/cmd_up.go
@@ -142,8 +142,8 @@ func (c cUp) doUpgradeVersion(ctx context.Context, in cUpInput) (out *doUpgradeV
 			}
 			for _, pkg := range packages {
 				mlog.Printf(`upgrading "%s" from "%s" to "latest"`, pkg.Name, pkg.Version)
-				// go get -u
-				command := fmt.Sprintf(`cd %s && go get -u %s@latest`, dirPath, pkg.Name)
+				// go get @latest
+				command := fmt.Sprintf(`cd %s && go get %s@latest`, dirPath, pkg.Name)
 				if err = gproc.ShellRun(ctx, command); err != nil {
 					return
 				}


### PR DESCRIPTION
`gf up`命令会在`go get`的时候加上`-u`参数，这会导致强制升级某些间接依赖，会导致依赖的go版本大于当前环境版本而导致报错。

如下图所示，带了`-u`参数会报错，只使用`@latest`标签则正常
![cf5b1e662aab1523f13eac73c2edcbb](https://github.com/user-attachments/assets/c8926e81-5bb8-42c6-8e69-ce66e0a1fa83)

![f852d74f8605881b687caab9d07711b](https://github.com/user-attachments/assets/f96679b4-2088-40cb-ac0a-0222fa6dda52)
