### PR TITLE
fix(net/ghttp/): fix  the issue of using application/octet stream to upload large files causing excessive memory and crashing

### DIFF
--- a/net/ghttp/ghttp_request_param.go
+++ b/net/ghttp/ghttp_request_param.go
@@ -229,6 +229,12 @@ func (r *Request) parseBody() {
 	if r.parsedBody {
 		return
 	}
+
+	// If it's binary data, it does not need to be parsed.
+	if contentType := r.Header.Get("Content-Type"); contentType == "" || gstr.Contains(contentType, "octet-stream") {
+		return
+	}
+
 	r.parsedBody = true
 	// There's no data posted.
 	if r.ContentLength == 0 {
@@ -273,6 +279,11 @@ func (r *Request) parseForm() {
 			err            error
 			repeatableRead = true
 		)
+		// If it's binary data, it does not need to be parsed.
+		if gstr.Contains(contentType, "octet-stream") {
+			return
+		}
+
 		if gstr.Contains(contentType, "multipart/") {
 			// To avoid big memory consuming.
 			// The `multipart/` type form always contains binary data, which is not necessary read twice.


### PR DESCRIPTION

The reason for this problem is that when creating RouterFunc initializes the request, it calls the MakeBodyRepeatableRead method to write the r.body to memory and change it to Repeatable. However, pure binary files do not require formatting of either the form or the body

So the solution is to detect the application/octet stream type and exit it early in the formatted form and body methods

Fixes #3692