### PR TITLE
fix(os/gtime): fix gtime.StrToTime("00:00:00") is not zero time instant

### DIFF
--- a/contrib/drivers/mysql/mysql_z_unit_issue_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_issue_test.go
@@ -431,6 +431,41 @@ func Test_Issue1733(t *testing.T) {
 	})
 }
 
+// https://github.com/gogf/gf/issues/2102
+func Test_Issue2012(t *testing.T) {
+	table := "issue2012"
+	array := gstr.SplitAndTrim(gtest.DataContent(`issue2012.sql`), ";")
+	for _, v := range array {
+		if _, err := db.Exec(ctx, v); err != nil {
+			gtest.Error(err)
+		}
+	}
+	defer dropTable(table)
+
+	type TimeOnly struct {
+		Id       int         `json:"id"`
+		TimeOnly *gtime.Time `json:"timeOnly"`
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		timeOnly := gtime.New("15:04:05")
+		m := db.Model(table)
+
+		_, err := m.Insert(TimeOnly{
+			TimeOnly: gtime.New(timeOnly),
+		})
+		t.AssertNil(err)
+
+		_, err = m.Insert(g.Map{
+			"time_only": timeOnly,
+		})
+		t.AssertNil(err)
+
+		_, err = m.Insert("time_only", timeOnly)
+		t.AssertNil(err)
+	})
+}
+
 // https://github.com/gogf/gf/issues/2105
 func Test_Issue2105(t *testing.T) {
 	table := "issue2105"

--- a/contrib/drivers/mysql/testdata/issue2012.sql
+++ b/contrib/drivers/mysql/testdata/issue2012.sql
@@ -1,0 +1,10 @@
+-- ----------------------------
+-- Table structure for issue2012
+-- ----------------------------
+DROP TABLE IF EXISTS `issue2012`;
+
+CREATE TABLE `issue2012`(
+    `id`        int(11) NOT NULL AUTO_INCREMENT,
+    `time_only` time,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci ROW_FORMAT = Dynamic;

--- a/os/gtime/gtime.go
+++ b/os/gtime/gtime.go
@@ -233,7 +233,7 @@ func StrToTime(str string, format ...string) (*Time, error) {
 		for i := 0; i < 9-len(match[4]); i++ {
 			nsec *= 10
 		}
-		return NewFromTime(time.Date(0, time.Month(1), 1, hour, min, sec, nsec, local)), nil
+		return NewFromTime(time.Date(1, time.Month(1), 1, hour, min, sec, nsec, local)), nil
 	} else {
 		return nil, gerror.NewCodef(gcode.CodeInvalidParameter, `unsupported time converting for string "%s"`, str)
 	}


### PR DESCRIPTION
### updated on 2024-07-27 

in stdlib, 
```go
timer, _ := time.Parse("15:04:05", "00:00:00")
fmt.Println(timer.IsZero()) // false
fmt.Println(timer)          // 0000-01-01 00:00:00 +0000 UTC
```
so, is is ok that `gtime.StrToTime("00:00:00")`is not zero time instant. 


---

### origin

`gtime.StrToTime` parse string `h:m:s` like `00:00:00`，the return is not zero time instant.

for example:

```go
gtime.StrToTime("15:04:05")
// is equal to

date := time.Date(0, 1, 1, 15, 4, 5, 0, time.Local)
gtime.NewFromTime(date)
```

and in std, zero time instant is : `time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)` not `time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC)`
```go
// IsZero reports whether t represents the zero time instant,
// January 1, year 1, 00:00:00 UTC.
func (t Time) IsZero() bool {
	return t.sec() == 0 && t.nsec() == 0
}
```

so, I think it is a bug.

the pr will Fixes #2012 ， and make 
```go
gtime.New(0).Equal(gtime.New("00:00:00")) // true
```