### PR TITLE
chore: add OpenSSF Scorecard for README.md

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,6 +5,8 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/gogf/gf/v2.svg)](https://pkg.go.dev/github.com/gogf/gf/v2)
 [![GoFrame CI](https://github.com/gogf/gf/actions/workflows/ci-main.yml/badge.svg)](https://github.com/gogf/gf/actions/workflows/ci-main.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/gogf/gf/badge)](https://scorecard.dev/viewer/?uri=github.com/gogf/gf)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/9233/badge)](https://bestpractices.coreinfrastructure.org/projects/9233)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gogf/gf/v2)](https://goreportcard.com/report/github.com/gogf/gf/v2)
 [![Code Coverage](https://codecov.io/gh/gogf/gf/branch/master/graph/badge.svg)](https://codecov.io/gh/gogf/gf)
 [![Production Ready](https://img.shields.io/badge/production-ready-blue.svg?style=flat)](https://github.com/gogf/gf)


### PR DESCRIPTION
Why is this needed:

The OpenSSF Scorecard improves open-source project's security by providing automated, transparent assessments of their security practices. It will help you identify vulnerabilities, adhere to best practices, and continuously enhance your security posture, increasing user trust and reducing the risk of security exploits.

I'll be the one to create the PR to add the scorecard GitHub action, and I will also work with you to remediate the identified vulnerabilities. I'll go through each [scorecard check](https://github.com/ossf/scorecard/blob/main/docs/checks.md) to see where the score has dropped and how it can be improved.


Integrate [scorecard](https://github.com/ossf/scorecard) in CI, and display a Scorecard badge on the gogf repository
You also need to manually create a project, refer to https://bestpractices.coreinfrastructure.org/en/projects
Manually create an gogf organization to report results, please see https://sonarcloud.io/explore/projects?sort=-analysis_date