### PR TITLE
fix(os/gtime): fix gtime.Value() when time only, add `time only` example

### DIFF
--- a/contrib/drivers/mysql/mysql_z_unit_issue_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_issue_test.go
@@ -431,6 +431,45 @@ func Test_Issue1733(t *testing.T) {
 	})
 }
 
+// https://github.com/gogf/gf/issues/2012
+func Test_Issue2012(t *testing.T) {
+	table := "time_only_" + guid.S()
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s(
+			id int(8) unsigned zerofill NOT NULL AUTO_INCREMENT,
+			time_only time,
+			PRIMARY KEY (id)
+	    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+	    `, table,
+	)); err != nil {
+		gtest.AssertNil(err)
+	}
+	defer dropTable(table)
+
+	type TimeOnly struct {
+		Id       int         `json:"id"`
+		TimeOnly *gtime.Time `json:"timeOnly"`
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		timeOnly := gtime.New("15:04:05")
+		m := db.Model(table)
+
+		_, err := m.Insert(TimeOnly{
+			TimeOnly: gtime.New(timeOnly),
+		})
+		t.AssertNil(err)
+
+		_, err = m.Insert(g.Map{
+			"time_only": timeOnly,
+		})
+		t.AssertNil(err)
+
+		_, err = m.Insert("time_only", timeOnly)
+		t.AssertNil(err)
+	})
+}
+
 // https://github.com/gogf/gf/issues/2105
 func Test_Issue2105(t *testing.T) {
 	table := "issue2105"

--- a/os/gtime/gtime_sql.go
+++ b/os/gtime/gtime_sql.go
@@ -24,5 +24,11 @@ func (t *Time) Value() (driver.Value, error) {
 	if t.IsZero() {
 		return nil, nil
 	}
+
+	if t.Year() == 0 {
+		// Only time.
+		return t.Format("15:04:05"), nil
+	}
+
 	return t.Time, nil
 }

--- a/os/gtime/gtime_z_example_time_test.go
+++ b/os/gtime/gtime_z_example_time_test.go
@@ -23,12 +23,14 @@ func ExampleNew_Basic() {
 	t3 := gtime.New(curTime, "Y-m-d H:i:s")
 	t4 := gtime.New(curTime)
 	t5 := gtime.New(1533686888)
+	t6 := gtime.New("08:08:08")
 
 	fmt.Println(t1)
 	fmt.Println(t2)
 	fmt.Println(t3)
 	fmt.Println(t4)
 	fmt.Println(t5)
+	fmt.Println(t6)
 
 	// Output:
 	// 2018-08-08 08:08:08
@@ -36,6 +38,7 @@ func ExampleNew_Basic() {
 	// 2018-08-08 08:08:08
 	// 2018-08-08 08:08:08
 	// 2018-08-08 08:08:08
+	// 08:08:08
 }
 
 func ExampleNew_WithFormat() {
@@ -68,12 +71,15 @@ func ExampleNewFromTime() {
 // NewFromStr creates and returns a Time object with given string.
 // Note that it returns nil if there's error occurs.
 func ExampleNewFromStr() {
-	t := gtime.NewFromStr("2018-08-08 08:08:08")
+	t1 := gtime.NewFromStr("2018-08-08 08:08:08")
+	t2 := gtime.NewFromStr("08:08:08")
 
-	fmt.Println(t)
+	fmt.Println(t1)
+	fmt.Println(t2)
 
 	// Output:
 	// 2018-08-08 08:08:08
+	// 08:08:08
 }
 
 // NewFromStrFormat creates and returns a Time object with given string and
@@ -189,25 +195,37 @@ func ExampleTime_Second() {
 
 // String returns current time object as string.
 func ExampleTime_String() {
-	gt := gtime.New("2018-08-08 08:08:08")
-	t1 := gt.String()
+	gt1 := gtime.New("2018-08-08 08:08:08")
+	t1 := gt1.String()
+	gt2 := gtime.New("08:08:08")
 
 	fmt.Println(t1)
 	fmt.Println(reflect.TypeOf(t1))
+	fmt.Println(gt2)
 
 	// Output:
 	// 2018-08-08 08:08:08
 	// string
+	// 08:08:08
 }
 
 // IsZero reports whether t represents the zero time instant,
 // January 1, year 1, 00:00:00 UTC.
 func ExampleTime_IsZero() {
-	gt := gtime.New("2018-08-08 08:08:08")
+	gt1 := gtime.New("2018-08-08 08:08:08")
+	gt2 := gtime.New("00:00:00")
+	timer, _ := time.Parse("15:04:05", "00:00:00")
+	gt3 := gtime.NewFromTime(timer)
 
-	fmt.Println(gt.IsZero())
+	fmt.Println(gt1.IsZero())
+	fmt.Println(gt2.IsZero())
+	fmt.Println(timer.IsZero()) // stdlib is also false
+	fmt.Println(gt3.IsZero())
 
 	// Output:
+	// false
+	// false
+	// false
 	// false
 }
 


### PR DESCRIPTION
#### add only time case for `func (t *Time) Value() (driver.Value, error)`:
```go
// Value is the interface providing the Value method for package database/sql/driver
// for retrieving value from golang variable to database.
func (t *Time) Value() (driver.Value, error) {
	if t == nil {
		return nil, nil
	}
	if t.IsZero() {
		return nil, nil
	}

	if t.Year() == 0 {
		// Only time.
		return t.Format("15:04:05"), nil
	}

	return t.Time, nil
}

```
the pr can Fixes #2012

#### add some `time only` example.

