### PR TITLE
feat(util/gvalid): supporting set field bail and use json tag as alias name for validation

### DIFF
--- a/util/gvalid/gvalid_validator.go
+++ b/util/gvalid/gvalid_validator.go
@@ -30,6 +30,7 @@ type Validator struct {
 	bail                              bool                // Stop validation after the first validation error.
 	foreach                           bool                // It tells the next validation using current value as an array and validates each of its element.
 	caseInsensitive                   bool                // Case-Insensitive configuration for those rules that need value comparison.
+	jsonTagAsAlias                    bool                // Using the JSON tag value as an alias when the alias name is not set in the validation rule.
 }
 
 // New creates and returns a new Validator.
@@ -121,6 +122,13 @@ func (v *Validator) Foreach() *Validator {
 func (v *Validator) Ci() *Validator {
 	newValidator := v.Clone()
 	newValidator.caseInsensitive = true
+	return newValidator
+}
+
+// JsonTagAsAlias sets using the JSON tag value as an alias name.
+func (v *Validator) JsonTagAsAlias() *Validator {
+	newValidator := v.Clone()
+	newValidator.jsonTagAsAlias = true
 	return newValidator
 }
 

--- a/util/gvalid/gvalid_validator.go
+++ b/util/gvalid/gvalid_validator.go
@@ -28,6 +28,7 @@ type Validator struct {
 	ruleFuncMap                       map[string]RuleFunc // ruleFuncMap stores custom rule functions for current Validator.
 	useAssocInsteadOfObjectAttributes bool                // Using `assoc` as its validation source instead of attribute values from `Object`.
 	bail                              bool                // Stop validation after the first validation error.
+	fieldBail                         bool                // Stop field validation after the first validation error.
 	foreach                           bool                // It tells the next validation using current value as an array and validates each of its element.
 	caseInsensitive                   bool                // Case-Insensitive configuration for those rules that need value comparison.
 	jsonTagAsAlias                    bool                // Using the JSON tag value as an alias when the alias name is not set in the validation rule.
@@ -107,6 +108,13 @@ func (v *Validator) I18n(i18nManager *gi18n.Manager) *Validator {
 func (v *Validator) Bail() *Validator {
 	newValidator := v.Clone()
 	newValidator.bail = true
+	return newValidator
+}
+
+// FieldBail sets the mark for stopping field validation after the first validation error.
+func (v *Validator) FieldBail() *Validator {
+	newValidator := v.Clone()
+	newValidator.fieldBail = true
 	return newValidator
 }
 

--- a/util/gvalid/gvalid_validator_check_struct.go
+++ b/util/gvalid/gvalid_validator_check_struct.go
@@ -134,8 +134,8 @@ func (v *Validator) doCheckStruct(ctx context.Context, object interface{}) Error
 		)
 		// It uses json tag value as alias name if exists.
 		if len(name) == 0 && v.jsonTagAsAlias {
-			if jsonTag := field.Tag("json"); len(jsonTag) > 0 {
-				name = jsonTag
+			if jsonTag := field.Tag("json"); jsonTag != "" && jsonTag != "-" {
+				name = strings.Split(jsonTag, ",")[0]
 			}
 		}
 		if len(name) == 0 {

--- a/util/gvalid/gvalid_validator_check_struct.go
+++ b/util/gvalid/gvalid_validator_check_struct.go
@@ -132,6 +132,12 @@ func (v *Validator) doCheckStruct(ctx context.Context, object interface{}) Error
 			fieldName       = field.Name()                  // Attribute name.
 			name, rule, msg = ParseTagValue(field.TagValue) // The `name` is different from `attribute alias`, which is used for validation only.
 		)
+		// It uses json tag value as alias name if exists.
+		if len(name) == 0 && v.jsonTagAsAlias {
+			if jsonTag := field.Tag("json"); len(jsonTag) > 0 {
+				name = jsonTag
+			}
+		}
 		if len(name) == 0 {
 			if value, ok := fieldToAliasNameMap[fieldName]; ok {
 				// It uses alias name of the attribute if its alias name tag exists.

--- a/util/gvalid/gvalid_validator_check_value.go
+++ b/util/gvalid/gvalid_validator_check_value.go
@@ -53,6 +53,9 @@ func (v *Validator) doCheckValue(ctx context.Context, in doCheckValueInput) Erro
 	)
 	switch messages := in.Messages.(type) {
 	case string:
+		if v.fieldBail {
+			messages = "|" + messages
+		}
 		msgArray = strings.Split(messages, "|")
 
 	default:

--- a/util/gvalid/gvalid_validator_check_value.go
+++ b/util/gvalid/gvalid_validator_check_value.go
@@ -38,6 +38,9 @@ func (v *Validator) doCheckValue(ctx context.Context, in doCheckValueInput) Erro
 	if in.Rule == "" {
 		return nil
 	}
+	if v.fieldBail {
+		in.Rule = "bail|" + in.Rule
+	}
 	// It converts value to string and then does the validation.
 	var (
 		// Do not trim it as the space is also part of the value.

--- a/util/gvalid/gvalid_z_unit_feature_checkstruct_test.go
+++ b/util/gvalid/gvalid_z_unit_feature_checkstruct_test.go
@@ -512,3 +512,31 @@ func Test_CheckStruct_PointerAttribute(t *testing.T) {
 		t.Assert(err.String(), "The Age value `0` must be equal or greater than 18")
 	})
 }
+
+func Test_CheckStruct_JsonTagAsAlias(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Req struct {
+			Id       uint   `v:"min:10"`
+			Name     string `json:"" v:"min-length:12"`
+			Level    uint   `json:"-" v:"min:10"`
+			HomeAddr string `json:"home_addr" v:"min-length:30"`
+			Age      uint   `json:"age,omitempty" v:"min:18"`
+			Salary   uint   `json:",omitempty" v:"min:60000"`
+		}
+		req := Req{
+			Id:       2,
+			Name:     "johnson",
+			Level:    4,
+			HomeAddr: "Shenzhen",
+			Age:      6,
+			Salary:   1000,
+		}
+		err := g.Validator().JsonTagAsAlias().Data(req).Run(context.TODO())
+		t.Assert(err.Maps()["Id"]["min"], "The Id value `2` must be equal or greater than 10")
+		t.Assert(err.Maps()["Name"]["min-length"], "The Name value `johnson` length must be equal or greater than 12")
+		t.Assert(err.Maps()["Level"]["min"], "The Level value `4` must be equal or greater than 10")
+		t.Assert(err.Maps()["home_addr"]["min-length"], "The home_addr value `Shenzhen` length must be equal or greater than 30")
+		t.Assert(err.Maps()["age"]["min"], "The age value `6` must be equal or greater than 18")
+		t.Assert(err.Maps()["Salary"]["min"], "The Salary value `1000` must be equal or greater than 60000")
+	})
+}


### PR DESCRIPTION
**gvalid.New().FieldBail():** supporting set field bail for all validation rules
**gvalid.New().JsonTagAsAlias():** supporting use json tag as alias name for validation when not set alias name in validate rules and json tag is exists