### PR TITLE
fix(database/gdb): fix #3649 when constructing query param, `gdb.Row` value not directly write to Buffer

### DIFF
--- a/contrib/drivers/mysql/mysql_z_unit_issue_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_issue_test.go
@@ -1160,3 +1160,16 @@ func Test_Issue3238(t *testing.T) {
 		}
 	})
 }
+
+// https://github.com/gogf/gf/issues/3649
+func Test_Issue3649(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		user := db.Model(table)
+		_, err := user.Where("create_time = ?", gdb.Raw("now()")).WhereLT("create_time", gdb.Raw("now()")).Count()
+		t.AssertNil(err)
+		//t.Assert(n, 1)
+	})
+}

--- a/database/gdb/gdb_func.go
+++ b/database/gdb/gdb_func.go
@@ -777,11 +777,7 @@ func formatWhereKeyValue(in formatWhereKeyValueInput) (newArgs []interface{}) {
 			} else {
 				in.Buffer.WriteString(quotedKey)
 			}
-			if s, ok := in.Value.(Raw); ok {
-				in.Buffer.WriteString(gconv.String(s))
-			} else {
-				in.Args = append(in.Args, in.Value)
-			}
+			in.Args = append(in.Args, in.Value)
 		}
 	}
 	return in.Args


### PR DESCRIPTION
fix #3649 when constructing query param, `gdb.Row` value not directly write to Buffer