### PR TITLE
feat: redis script more user-friendly

### DIFF
--- a/contrib/nosql/redis/redis_script.go
+++ b/contrib/nosql/redis/redis_script.go
@@ -1,0 +1,69 @@
+package redis
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/database/gredis"
+	"github.com/gogf/gf/v2/os/gmlock"
+	"io"
+	"strings"
+)
+
+var cacheScriptLock = gmlock.New()
+
+type Script struct {
+	src, hash string
+}
+
+func NewScript(src string) *Script {
+	h := sha1.New()
+	_, _ = io.WriteString(h, src)
+	return &Script{
+		src:  src,
+		hash: hex.EncodeToString(h.Sum(nil)),
+	}
+}
+
+func (s *Script) Hash() string {
+	return s.hash
+}
+
+func (s *Script) Load(ctx context.Context, c gredis.IGroupScript) (string, error) {
+	return c.ScriptLoad(ctx, s.src)
+}
+
+func (s *Script) Exist(ctx context.Context, c gredis.IGroupScript) (bool, error) {
+	exists, err := c.ScriptExists(ctx, s.hash)
+	if err != nil {
+		return false, err
+	}
+	return exists[s.hash], nil
+}
+
+func (s *Script) Eval(ctx context.Context, c gredis.IGroupScript, keys []string, args ...interface{}) (*gvar.Var, error) {
+	return c.Eval(ctx, s.src, int64(len(keys)), keys, args)
+}
+
+func (s *Script) EvalSha(ctx context.Context, c gredis.IGroupScript, keys []string, args ...interface{}) (*gvar.Var, error) {
+	return c.EvalSha(ctx, s.hash, int64(len(keys)), keys, args)
+}
+
+// Run optimistically uses EVALSHA to run the script. If script does not exist
+// it is retried using EVAL and cache the script
+func (s *Script) Run(ctx context.Context, c gredis.IGroupScript, keys []string, args ...interface{}) (val *gvar.Var, err error) {
+	if val, err = s.EvalSha(ctx, c, keys, args...); err != nil {
+		if strings.Contains(err.Error(), "NOSCRIPT") {
+			go s.tryCacheScript(c)
+			return s.Eval(ctx, c, keys, args...)
+		}
+	}
+	return
+}
+
+func (s *Script) tryCacheScript(c gredis.IGroupScript) {
+	cacheScriptLock.TryLockFunc(s.hash, func() {
+		_, _ = s.Load(context.Background(), c)
+	})
+}

--- a/contrib/nosql/redis/redis_z_script_test.go
+++ b/contrib/nosql/redis/redis_z_script_test.go
@@ -1,0 +1,23 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package redis_test
+
+import (
+	redis2 "github.com/gogf/gf/contrib/nosql/redis/v2"
+	"github.com/gogf/gf/v2/test/gtest"
+	"testing"
+)
+
+func Test_Script_Eval(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		defer redis.FlushDB(ctx)
+		script := redis2.NewScript(`return ARGV[1]`)
+		v, err := script.Run(ctx, redis, nil, "hello")
+		t.AssertNil(err)
+		t.Assert(v.String(), "hello")
+	})
+}


### PR DESCRIPTION
Redis 脚本封装:
减少`numKeys`的传递，根据调用调用函数时传递`keys`自主判断
`Run`函数运行脚本时，使用`EVALSHA`运行脚本，如果脚本不存在，则使用`EVAL`重试并尝试缓存脚本，以提升运行效率

