### PR TITLE
perf(ghttp):Optimize reflection handling in createRouterFunc to increase call rat…

### DIFF
--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -84,6 +84,14 @@ type (
 		ReqStructFields []gstructs.Field // Request struct fields.
 	}
 
+	// cachedHandlerInfo stores precomputed reflection information for a handler function.
+	cachedHandlerInfo struct {
+		inputType reflect.Type  // inputType represents the type of the input parameter for the handler function.
+		callFunc  reflect.Value // callFunc is the reflect.Value representing the handler function.
+		hasInput  bool          // hasInput indicates whether the handler function has an input parameter.
+		parsePtr  bool          // parsePtr indicates whether the input parameter is a pointer.
+	}
+
 	// HandlerItem is the registered handler for route handling,
 	// including middleware and hook functions.
 	HandlerItem struct {

--- a/net/ghttp/ghttp_reflection_optimized_test.go
+++ b/net/ghttp/ghttp_reflection_optimized_test.go
@@ -26,32 +26,7 @@ type HelloRes struct {
 // 原始的 createRouterFunc 性能测试
 // go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
 func BenchmarkOriginal(b *testing.B) {
-	// 创建一个模拟的 HandlerFunc
-	mockHandler := func(r *Request) {
-		// 实现具体的处理逻辑
-		r.Host = "127.0.0.1"
-	}
-
-	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
-		// 实现具体的处理逻辑
-		return res, nil
-	}
-	// 创建 handlerFuncInfo 结构体
-	funcInfo := handlerFuncInfo{
-		Func:            mockHandler,
-		Type:            reflect.TypeOf(mockControllerHandler),
-		Value:           reflect.ValueOf(mockControllerHandler),
-		IsStrictRoute:   false,
-		ReqStructFields: nil,
-	}
-
-	// 创建一个模拟的请求
-	req := &Request{}
-	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
-	if err != nil {
-		return
-	}
-	req.Request = request
+	req, funcInfo := SetupTest()
 	routerFunc := createRouterFuncOriginal(funcInfo)
 
 	// 执行基准测试
@@ -64,15 +39,24 @@ func BenchmarkOriginal(b *testing.B) {
 // 优化后的 createRouterFunc 性能测试
 // go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
 func BenchmarkOptimized(b *testing.B) {
+	req, funcInfo := SetupTest()
+	routerFunc := createRouterFunc(funcInfo)
+
+	// 执行基准测试
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		routerFunc(req)
+	}
+}
+
+func SetupTest() (*Request, handlerFuncInfo) {
 	// 创建一个模拟的 HandlerFunc
 	mockHandler := func(r *Request) {
-		// 实现具体的处理逻辑
 		r.Host = "127.0.0.1"
 	}
 
 	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
 		// 实现具体的处理逻辑
-		//res.Ip = "127.0.0.1"
 		return res, nil
 	}
 	// 创建 handlerFuncInfo 结构体
@@ -88,14 +72,8 @@ func BenchmarkOptimized(b *testing.B) {
 	req := &Request{}
 	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
 	if err != nil {
-		return
+		return nil, handlerFuncInfo{}
 	}
 	req.Request = request
-	routerFunc := createRouterFunc(funcInfo)
-
-	// 执行基准测试
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		routerFunc(req)
-	}
+	return req, funcInfo
 }

--- a/net/ghttp/ghttp_reflection_optimized_test.go
+++ b/net/ghttp/ghttp_reflection_optimized_test.go
@@ -1,0 +1,101 @@
+package ghttp
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type HelloReq struct {
+	//g.Meta  `path:"/hello" tags:"Hello" method:"post" summary:"You first hello api"`
+	Id      int32  `p:"id"  dc:"Id" json:"id"`
+	Name    string `p:"name" dc:"Id" json:"name"`
+	Address string `p:"address" dc:"Id" json:"address"`
+}
+
+type HelloRes struct {
+	//g.Meta  `mime:"text/html" example:"string"`
+	Id      int32  `json:"id"`
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Ip      string `json:"ip"`
+}
+
+// 原始的 createRouterFunc 性能测试
+// go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
+func BenchmarkOriginal(b *testing.B) {
+	// 创建一个模拟的 HandlerFunc
+	mockHandler := func(r *Request) {
+		// 实现具体的处理逻辑
+		r.Host = "127.0.0.1"
+	}
+
+	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
+		// 实现具体的处理逻辑
+		return res, nil
+	}
+	// 创建 handlerFuncInfo 结构体
+	funcInfo := handlerFuncInfo{
+		Func:            mockHandler,
+		Type:            reflect.TypeOf(mockControllerHandler),
+		Value:           reflect.ValueOf(mockControllerHandler),
+		IsStrictRoute:   false,
+		ReqStructFields: nil,
+	}
+
+	// 创建一个模拟的请求
+	req := &Request{}
+	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
+	if err != nil {
+		return
+	}
+	req.Request = request
+	routerFunc := createRouterFuncOriginal(funcInfo)
+
+	// 执行基准测试
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		routerFunc(req)
+	}
+}
+
+// 优化后的 createRouterFunc 性能测试
+// go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
+func BenchmarkOptimized(b *testing.B) {
+	// 创建一个模拟的 HandlerFunc
+	mockHandler := func(r *Request) {
+		// 实现具体的处理逻辑
+		r.Host = "127.0.0.1"
+	}
+
+	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
+		// 实现具体的处理逻辑
+		//res.Ip = "127.0.0.1"
+		return res, nil
+	}
+	// 创建 handlerFuncInfo 结构体
+	funcInfo := handlerFuncInfo{
+		Func:            mockHandler,
+		Type:            reflect.TypeOf(mockControllerHandler),
+		Value:           reflect.ValueOf(mockControllerHandler),
+		IsStrictRoute:   false,
+		ReqStructFields: nil,
+	}
+
+	// 创建一个模拟的请求
+	req := &Request{}
+	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
+	if err != nil {
+		return
+	}
+	req.Request = request
+	routerFunc := createRouterFunc(funcInfo)
+
+	// 执行基准测试
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		routerFunc(req)
+	}
+}

--- a/net/ghttp/ghttp_server_service_handler.go
+++ b/net/ghttp/ghttp_server_service_handler.go
@@ -9,12 +9,13 @@ package ghttp
 import (
 	"bytes"
 	"context"
+	"reflect"
+	"strings"
+
 	"github.com/gogf/gf/v2/errors/gcode"
 	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/os/gstructs"
 	"github.com/gogf/gf/v2/text/gstr"
-	"reflect"
-	"strings"
 )
 
 // BindHandler registers a handler function to server with a given pattern.


### PR DESCRIPTION
 优化createRouterFunc 方法中的反射调用，提升单位时间内的执行次数 

在性能测试操作中，需要分别注释掉新老方法中的   r.error = r.Parse(xxxx），新老方法都调用同一个request的Parse方法，这部分可以注释掉，再执行测试

测试指令   go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
性能测试效果 
 
goos: windows
goarch: amd64
pkg: github.com/gogf/gf/v2/net/ghttp
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkOriginal-8      3957397               608.7 ns/op           176 B/op          5 allocs/op
BenchmarkOriginal-8      3910057               605.9 ns/op           176 B/op          5 allocs/op
BenchmarkOriginal-8      3944840               604.4 ns/op           176 B/op          5 allocs/op
BenchmarkOptimized-8     4023745               595.7 ns/op           176 B/op          5 allocs/op
BenchmarkOptimized-8     4016392               597.0 ns/op           176 B/op          5 allocs/op
BenchmarkOptimized-8     4019696               596.3 ns/op           176 B/op          5 allocs/op
PASS
ok      github.com/gogf/gf/v2/net/ghttp 18.075s

BenchmarkOptimized为优化后 的方法，BenchmarkOriginal为原方法

其中一次测试截图
![image](https://github.com/user-attachments/assets/aaeb8353-8dc2-4fdf-8ab6-b1031b11eaa4)

测试结果中，可以看到   第二项耗时提升7ns/op 左右，第三四项一样，  第一项指标表示在2秒时间内的执行次数 每轮对比都多出5万次以上

在每次操作的平均时间、每次操作分配的内存和每次操作的内存分配次数都差不多的情况下，执行次数越多，通常可以认为性能越好。执行次数的增加直接反映了代码在单位时间内能够处理更多的操作，从而提升系统的吞吐量和效率