### PR TITLE
fix(database/gdb): support OrderRandom feature in different databases

### DIFF
--- a/contrib/drivers/oracle/oracle_order.go
+++ b/contrib/drivers/oracle/oracle_order.go
@@ -6,7 +6,7 @@
 
 package oracle
 
-// OrderRandomStatement returns the SQL statement for random ordering.
-func (d *Driver) OrderRandomStatement() string {
+// OrderRandomFunction returns the SQL function for random ordering.
+func (d *Driver) OrderRandomFunction() string {
 	return "DBMS_RANDOM.VALUE()"
 }

--- a/contrib/drivers/oracle/oracle_order.go
+++ b/contrib/drivers/oracle/oracle_order.go
@@ -1,0 +1,12 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package oracle
+
+// OrderRandomStatement returns the SQL statement for random ordering.
+func (d *Driver) OrderRandomStatement() string {
+	return "DBMS_RANDOM.VALUE()"
+}

--- a/contrib/drivers/oracle/oracle_z_unit_model_test.go
+++ b/contrib/drivers/oracle/oracle_z_unit_model_test.go
@@ -1180,7 +1180,6 @@ func Test_Model_Replace(t *testing.T) {
 func Test_OrderRandom(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)
-	db.SetDebug(true)
 
 	gtest.C(t, func(t *gtest.T) {
 		result, err := db.Model(table).OrderRandom().All()

--- a/contrib/drivers/oracle/oracle_z_unit_model_test.go
+++ b/contrib/drivers/oracle/oracle_z_unit_model_test.go
@@ -1177,6 +1177,18 @@ func Test_Model_Replace(t *testing.T) {
 	})
 }
 
+func Test_OrderRandom(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	db.SetDebug(true)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).OrderRandom().All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+}
+
 /* not support the "AS"
 func Test_Model_Raw(t *testing.T) {
 	table := createInitTable()

--- a/contrib/drivers/pgsql/pgsql_order.go
+++ b/contrib/drivers/pgsql/pgsql_order.go
@@ -6,7 +6,7 @@
 
 package pgsql
 
-// OrderRandomStatement returns the SQL statement for random ordering.
-func (d *Driver) OrderRandomStatement() string {
+// OrderRandomFunction returns the SQL function for random ordering.
+func (d *Driver) OrderRandomFunction() string {
 	return "RANDOM()"
 }

--- a/contrib/drivers/pgsql/pgsql_order.go
+++ b/contrib/drivers/pgsql/pgsql_order.go
@@ -1,0 +1,12 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package pgsql
+
+// OrderRandomStatement returns the SQL statement for random ordering.
+func (d *Driver) OrderRandomStatement() string {
+	return "RANDOM()"
+}

--- a/contrib/drivers/pgsql/pgsql_z_unit_model_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_model_test.go
@@ -587,3 +587,14 @@ func Test_Model_OnDuplicateEx(t *testing.T) {
 		t.Assert(one["nickname"], "name_1")
 	})
 }
+
+func Test_OrderRandom(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).OrderRandom().All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+}

--- a/contrib/drivers/sqlite/sqlite_order.go
+++ b/contrib/drivers/sqlite/sqlite_order.go
@@ -1,0 +1,12 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package sqlite
+
+// OrderRandomStatement returns the SQL statement for random ordering.
+func (d *Driver) OrderRandomStatement() string {
+	return "RANDOM()"
+}

--- a/contrib/drivers/sqlite/sqlite_order.go
+++ b/contrib/drivers/sqlite/sqlite_order.go
@@ -6,7 +6,7 @@
 
 package sqlite
 
-// OrderRandomStatement returns the SQL statement for random ordering.
-func (d *Driver) OrderRandomStatement() string {
+// OrderRandomFunction returns the SQL function for random ordering.
+func (d *Driver) OrderRandomFunction() string {
 	return "RANDOM()"
 }

--- a/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
+++ b/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
@@ -4299,3 +4299,14 @@ func TestResult_Structs1(t *testing.T) {
 		t.Assert(array[1].Name, "smith")
 	})
 }
+
+func Test_OrderRandom(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).OrderRandom().All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+}

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -178,6 +178,7 @@ type DB interface {
 	ConvertValueForLocal(ctx context.Context, fieldType string, fieldValue interface{}) (interface{}, error) // See Core.ConvertValueForLocal
 	CheckLocalTypeForField(ctx context.Context, fieldType string, fieldValue interface{}) (LocalType, error) // See Core.CheckLocalTypeForField
 	FormatUpsert(columns []string, list List, option DoInsertOption) (string, error)                         // See Core.DoFormatUpsert
+	OrderRandomStatement() string                                                                            // See Core.OrderRandom
 }
 
 // TX defines the interfaces for ORM transaction operations.

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -178,7 +178,7 @@ type DB interface {
 	ConvertValueForLocal(ctx context.Context, fieldType string, fieldValue interface{}) (interface{}, error) // See Core.ConvertValueForLocal
 	CheckLocalTypeForField(ctx context.Context, fieldType string, fieldValue interface{}) (LocalType, error) // See Core.CheckLocalTypeForField
 	FormatUpsert(columns []string, list List, option DoInsertOption) (string, error)                         // See Core.DoFormatUpsert
-	OrderRandomStatement() string                                                                            // See Core.OrderRandom
+	OrderRandomFunction() string                                                                             // See Core.OrderRandomFunction
 }
 
 // TX defines the interfaces for ORM transaction operations.

--- a/database/gdb/gdb_core_underlying.go
+++ b/database/gdb/gdb_core_underlying.go
@@ -455,6 +455,11 @@ func (c *Core) RowsToResult(ctx context.Context, rows *sql.Rows) (Result, error)
 	return result, nil
 }
 
+// OrderRandomStatement returns the SQL statement for random ordering.
+func (c *Core) OrderRandomStatement() string {
+	return "RAND()"
+}
+
 func (c *Core) columnValueToLocalValue(ctx context.Context, value interface{}, columnType *sql.ColumnType) (interface{}, error) {
 	var scanType = columnType.ScanType()
 	if scanType != nil {

--- a/database/gdb/gdb_core_underlying.go
+++ b/database/gdb/gdb_core_underlying.go
@@ -455,8 +455,8 @@ func (c *Core) RowsToResult(ctx context.Context, rows *sql.Rows) (Result, error)
 	return result, nil
 }
 
-// OrderRandomStatement returns the SQL statement for random ordering.
-func (c *Core) OrderRandomStatement() string {
+// OrderRandomFunction returns the SQL function for random ordering.
+func (c *Core) OrderRandomFunction() string {
 	return "RAND()"
 }
 

--- a/database/gdb/gdb_model_order_group.go
+++ b/database/gdb/gdb_model_order_group.go
@@ -59,7 +59,7 @@ func (m *Model) OrderDesc(column string) *Model {
 // OrderRandom sets the "ORDER BY RANDOM()" statement for the model.
 func (m *Model) OrderRandom() *Model {
 	model := m.getModel()
-	model.orderBy = m.db.OrderRandomStatement()
+	model.orderBy = m.db.OrderRandomFunction()
 	return model
 }
 

--- a/database/gdb/gdb_model_order_group.go
+++ b/database/gdb/gdb_model_order_group.go
@@ -59,7 +59,7 @@ func (m *Model) OrderDesc(column string) *Model {
 // OrderRandom sets the "ORDER BY RANDOM()" statement for the model.
 func (m *Model) OrderRandom() *Model {
 	model := m.getModel()
-	model.orderBy = "RAND()"
+	model.orderBy = m.db.OrderRandomStatement()
 	return model
 }
 


### PR DESCRIPTION
Dear review：
不同数据库 `order by rand()` 子句中使用的函数是不一样的，orm 之前固定使用 `rand()` 函数，无法支持 **oracle, pg, sqlite**

fixed #3705