### PR TITLE
fix(util/gconv): #3797 暂时修复结构体和字段名字重复时，有一定几率会覆盖

### DIFF
--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -568,3 +568,53 @@ func Test_Issue3245(t *testing.T) {
 		t.Assert(c.GetContent(ctx, "/hello?nickname=oldme"), expect)
 	})
 }
+
+type ItemSecondThird struct {
+	SecondID uint64 `json:"secondId,string"`
+	ThirdID  uint64 `json:"thirdId,string"`
+}
+type ItemFirst struct {
+	ID uint64 `json:"id,string"`
+	ItemSecondThird
+}
+type ItemInput struct {
+	ItemFirst
+}
+type Issue3789Req struct {
+	g.Meta `path:"/hello" method:"GET"`
+	ItemInput
+}
+type Issue3789Res struct {
+	ItemInput
+}
+
+type Issue3789 struct{}
+
+func (Issue3789) Say(ctx context.Context, req *Issue3789Req) (res *Issue3789Res, err error) {
+	g.Log().Debugf(ctx, `receive say: %+v`, req)
+	res = &Issue3789Res{
+		ItemInput: req.ItemInput,
+	}
+	return
+}
+
+// https://github.com/gogf/gf/issues/3789
+func TestIssue3789(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		s := g.Server()
+		s.Use(ghttp.MiddlewareHandlerResponse)
+		s.Group("/", func(group *ghttp.RouterGroup) {
+			group.Bind(
+				new(Issue3789),
+			)
+		})
+		s.Start()
+		defer s.Shutdown()
+		time.Sleep(100 * time.Millisecond)
+
+		c := g.Client()
+		c.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+		expect := `{"code":0,"message":"","data":{"id":"0","secondId":"2","thirdId":"3"}}`
+		t.Assert(c.GetContent(ctx, "/hello?id=&secondId=2&thirdId=3"), expect)
+	})
+}

--- a/util/gconv/gconv_struct.go
+++ b/util/gconv/gconv_struct.go
@@ -201,7 +201,7 @@ func doStruct(
 				); err != nil {
 					return err
 				}
-				if len(fieldInfo.OtherSameNameFieldIndex) > 0 {
+				if len(fieldInfo.OtherSameNameField) > 0 {
 					if err = setOtherSameNameField(
 						fieldInfo, paramsValue, pointerReflectValue, paramKeyToAttrMap,
 					); err != nil {
@@ -234,9 +234,9 @@ func setOtherSameNameField(
 	paramKeyToAttrMap map[string]string,
 ) (err error) {
 	// loop the same field name of all sub attributes.
-	for i := range fieldInfo.OtherSameNameFieldIndex {
+	for i, otherFieldInfo := range fieldInfo.OtherSameNameField {
 		fieldValue := fieldInfo.GetOtherFieldReflectValue(structValue, i)
-		if err = bindVarToStructField(fieldValue, srcValue, fieldInfo, paramKeyToAttrMap); err != nil {
+		if err = bindVarToStructField(fieldValue, srcValue, otherFieldInfo, paramKeyToAttrMap); err != nil {
 			return err
 		}
 	}
@@ -279,7 +279,7 @@ func bindStructWithLoopParamsMap(
 				return err
 			}
 			// handle same field name in nested struct.
-			if len(fieldInfo.OtherSameNameFieldIndex) > 0 {
+			if len(fieldInfo.OtherSameNameField) > 0 {
 				if err = setOtherSameNameField(fieldInfo, paramValue, structValue, paramKeyToAttrMap); err != nil {
 					return err
 				}
@@ -314,7 +314,7 @@ func bindStructWithLoopParamsMap(
 						return err
 					}
 					// handle same field name in nested struct.
-					if len(fieldInfo.OtherSameNameFieldIndex) > 0 {
+					if len(fieldInfo.OtherSameNameField) > 0 {
 						if err = setOtherSameNameField(
 							fieldInfo, paramValue, structValue, paramKeyToAttrMap,
 						); err != nil {
@@ -362,7 +362,7 @@ func bindStructWithLoopFieldInfos(
 				return err
 			}
 			// handle same field name in nested struct.
-			if len(fieldInfo.OtherSameNameFieldIndex) > 0 {
+			if len(fieldInfo.OtherSameNameField) > 0 {
 				if err = setOtherSameNameField(
 					fieldInfo, paramValue, structValue, paramKeyToAttrMap,
 				); err != nil {
@@ -395,7 +395,7 @@ func bindStructWithLoopFieldInfos(
 					return err
 				}
 				// handle same field name in nested struct.
-				if len(fieldInfo.OtherSameNameFieldIndex) > 0 {
+				if len(fieldInfo.OtherSameNameField) > 0 {
 					if err = setOtherSameNameField(
 						fieldInfo, paramValue, structValue, paramKeyToAttrMap,
 					); err != nil {

--- a/util/gconv/gconv_z_unit_issue_test.go
+++ b/util/gconv/gconv_z_unit_issue_test.go
@@ -446,3 +446,31 @@ func TestIssue3789(t *testing.T) {
 		t.Assert(dest.ThirdID, uint64(3))
 	})
 }
+
+// https://github.com/gogf/gf/issues/3797
+func TestIssue3797(t *testing.T) {
+	type Option struct {
+		F1 int
+		F2 string
+	}
+	type Rule struct {
+		ID   int64     `json:"id"`
+		Rule []*Option `json:"rule"`
+	}
+	type Res1 struct {
+		g.Meta
+		Rule
+	}
+	gtest.C(t, func(t *gtest.T) {
+		var r = &Rule{
+			ID: 100,
+		}
+		var res = &Res1{}
+		for i := 0; i < 10000; i++ {
+			err := gconv.Scan(r, res)
+			t.AssertNil(err)
+			t.Assert(res.ID, 100)
+			t.AssertEQ(res.Rule.Rule, nil)
+		}
+	})
+}

--- a/util/gconv/gconv_z_unit_issue_test.go
+++ b/util/gconv/gconv_z_unit_issue_test.go
@@ -414,3 +414,35 @@ func TestIssue3764(t *testing.T) {
 		t.AssertEQ(*tt.FalsePtr, falseValue)
 	})
 }
+
+// https://github.com/gogf/gf/issues/3789
+func TestIssue3789(t *testing.T) {
+	type ItemSecondThird struct {
+		SecondID uint64 `json:"secondId,string"`
+		ThirdID  uint64 `json:"thirdId,string"`
+	}
+	type ItemFirst struct {
+		ID uint64 `json:"id,string"`
+		ItemSecondThird
+	}
+	type ItemInput struct {
+		ItemFirst
+	}
+	type HelloReq struct {
+		g.Meta `path:"/hello" method:"GET"`
+		ItemInput
+	}
+	gtest.C(t, func(t *gtest.T) {
+		m := map[string]interface{}{
+			"id":       1,
+			"secondId": 2,
+			"thirdId":  3,
+		}
+		var dest HelloReq
+		err := gconv.Scan(m, &dest)
+		t.AssertNil(err)
+		t.Assert(dest.ID, uint64(1))
+		t.Assert(dest.SecondID, uint64(2))
+		t.Assert(dest.ThirdID, uint64(3))
+	})
+}

--- a/util/gconv/gconv_z_unit_struct_test.go
+++ b/util/gconv/gconv_z_unit_struct_test.go
@@ -7,6 +7,7 @@
 package gconv_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -179,6 +180,39 @@ func TestStruct(t *testing.T) {
 		t.Assert(expect.PlanetName, "")
 		t.Assert(expect.Planet_Place, "")
 		t.Assert(expect.planetTime, "")
+	})
+}
+
+func TestStructDuplicateField(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		m := map[string]any{
+			"ID": 100,
+		}
+		type Nested1 struct {
+			ID string
+		}
+		type Nested2 struct {
+			ID uint
+		}
+		type Nested3 struct {
+			ID int
+		}
+		type Dest struct {
+			ID int
+			Nested1
+			Nested2
+			Nested3
+		}
+		var (
+			err  error
+			dest = new(Dest)
+		)
+		err = gconv.Struct(m, dest)
+		t.AssertNil(err)
+		t.Assert(dest.ID, m["ID"])
+		t.Assert(dest.Nested1.ID, strconv.Itoa(m["ID"].(int)))
+		t.Assert(dest.Nested2.ID, m["ID"])
+		t.Assert(dest.Nested3.ID, m["ID"])
 	})
 }
 

--- a/util/gconv/internal/structcache/structcache_cached.go
+++ b/util/gconv/internal/structcache/structcache_cached.go
@@ -113,8 +113,14 @@ func parseStruct(
 			continue
 		}
 
-		// store field
-		structInfo.AddField(structField, append(fieldIndexes, i), priorityTagArray)
+		copyFieldIndexes := make([]int, len(fieldIndexes))
+		copy(copyFieldIndexes, fieldIndexes)
+		// Do not directly use append(fieldIndexes, i)
+		// When the structure is nested deeply, it may lead to bugs,
+		// which are caused by the slice expansion mechanism
+		// So it is necessary to allocate a separate index for each field
+		// See details https://github.com/gogf/gf/issues/3789
+		structInfo.AddField(structField, append(copyFieldIndexes, i), priorityTagArray)
 
 		// normal basic attributes.
 		if structField.Anonymous {
@@ -128,7 +134,7 @@ func parseStruct(
 			if structField.Tag != "" {
 				// TODO: If it's an anonymous field with a tag, doesn't it need to be recursive?
 			}
-			parseStruct(fieldType, append(fieldIndexes, i), structInfo, priorityTagArray)
+			parseStruct(fieldType, append(copyFieldIndexes, i), structInfo, priorityTagArray)
 		}
 	}
 }

--- a/util/gconv/internal/structcache/structcache_cached.go
+++ b/util/gconv/internal/structcache/structcache_cached.go
@@ -112,15 +112,11 @@ func parseStruct(
 		if !utils.IsLetterUpper(fieldName[0]) {
 			continue
 		}
-
+		if fieldType.String() == "gmeta.Meta" {
+			continue
+		}
 		copyFieldIndexes := make([]int, len(fieldIndexes))
 		copy(copyFieldIndexes, fieldIndexes)
-		// Do not directly use append(fieldIndexes, i)
-		// When the structure is nested deeply, it may lead to bugs,
-		// which are caused by the slice expansion mechanism
-		// So it is necessary to allocate a separate index for each field
-		// See details https://github.com/gogf/gf/issues/3789
-		structInfo.AddField(structField, append(copyFieldIndexes, i), priorityTagArray)
 
 		// normal basic attributes.
 		if structField.Anonymous {
@@ -132,9 +128,18 @@ func parseStruct(
 				continue
 			}
 			if structField.Tag != "" {
-				// TODO: If it's an anonymous field with a tag, doesn't it need to be recursive?
+				// Do not add anonymous structures without tags
+				structInfo.AddField(structField, append(copyFieldIndexes, i), priorityTagArray)
 			}
 			parseStruct(fieldType, append(copyFieldIndexes, i), structInfo, priorityTagArray)
+			continue
 		}
+
+		// Do not directly use append(fieldIndexes, i)
+		// When the structure is nested deeply, it may lead to bugs,
+		// which are caused by the slice expansion mechanism
+		// So it is necessary to allocate a separate index for each field
+		// See details https://github.com/gogf/gf/issues/3789
+		structInfo.AddField(structField, append(copyFieldIndexes, i), priorityTagArray)
 	}
 }


### PR DESCRIPTION
Updates #3797  不完全修复，对于字段和结构体同名时，字段如果为零值时，有几率会重新初始化结构体
建议以后类似问题，解决方案是:不要把名字搞成一样的
