### PR TITLE
feat(os/gfsnotify):add watcher path to moniter the dir which create after start

### DIFF
--- a/os/gfsnotify/gfsnotify_watcher.go
+++ b/os/gfsnotify/gfsnotify_watcher.go
@@ -41,25 +41,21 @@ func (w *Watcher) Add(path string, callbackFunc func(event *Event), recursive ..
 // new sub-directories are captured, thus maintaining comprehensive monitoring coverage
 // without manual interventions after initial setup.
 func (w *Watcher) AppendPath(path string, recursive ...bool) error {
-
 	// Check and convert the given path to absolute path.
 	if t := fileRealPath(path); t == "" {
 		return gerror.NewCodef(gcode.CodeInvalidParameter, `"%s" does not exist`, path)
 	} else {
 		path = t
 	}
-
 	// Validate if the path or its parent has a callback.
 	if !w.hasCallbackOrParentCallback(path) {
 		return gerror.NewCodef(gcode.CodeInvalidParameter, `no callback set for path "%s" or its parents`, path)
 	}
-
 	// Add the path to underlying monitor.
 	if err := w.watcher.Add(path); err != nil {
 		return gerror.Wrapf(err, `add watch failed for path "%s"`, path)
 	}
 	intlog.Printf(context.TODO(), "watcher adds monitor for: %s", path)
-
 	// If it's recursive adding, it then adds all sub-folders to the monitor.
 	// NOTE:
 	// 1. It only recursively adds **folders** to the monitor, NOT files,

--- a/os/gfsnotify/gfsnotify_z_unit_test.go
+++ b/os/gfsnotify/gfsnotify_z_unit_test.go
@@ -55,6 +55,52 @@ func TestWatcher_AddOnce(t *testing.T) {
 	})
 }
 
+func TestWatcher_AppendPath(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			err        error
+			array      = garray.New(true) // To track events
+			dirPath    = gfile.Temp(gtime.TimestampNanoStr())
+			subDirPath = gfile.Join(dirPath, "subfolder")
+		)
+
+		// Create the main directory
+		err = gfile.Mkdir(dirPath)
+		t.AssertNil(err)
+		defer gfile.Remove(dirPath)
+
+		watcher, err := gfsnotify.New()
+		t.AssertNil(err)
+		t.AssertNE(watcher, nil)
+		defer watcher.Close()
+
+		// Add a callback to the main directory
+		_, err = watcher.Add(dirPath, func(event *gfsnotify.Event) {
+			// Track events
+			array.Append(1)
+		})
+		t.AssertNil(err)
+
+		// Using AppendPath to add subfolder
+		err = watcher.AppendPath(subDirPath)
+		t.AssertNE(err, "Expected an error since no callback is directly set for subDirPath")
+
+		// Manually create the sub-folder to check callback binding
+		err = gfile.Mkdir(subDirPath)
+		t.AssertNil(err)
+		time.Sleep(time.Millisecond * 100)
+
+		// Now create a file in the sub-folder to see if any event is tracked
+		f, err := gfile.Create(gfile.Join(subDirPath, "file.txt"))
+		t.AssertNil(err)
+		t.AssertNil(f.Close())
+
+		time.Sleep(time.Millisecond * 100)
+		// Ensure the event in the subDirPath is tracked through the parent's callback
+		t.Assert(array.Len() > 0, "Expected parent directory callback to track sub-directory events")
+	})
+}
+
 func TestWatcher_AddRemove(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		path1 := gfile.Temp() + gfile.Separator + gconv.String(gtime.TimestampNano())

--- a/os/gfsnotify/gfsnotify_z_unit_test.go
+++ b/os/gfsnotify/gfsnotify_z_unit_test.go
@@ -7,6 +7,7 @@
 package gfsnotify_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -77,17 +78,20 @@ func TestWatcher_AppendPath(t *testing.T) {
 		// Add a callback to the main directory
 		_, err = watcher.Add(dirPath, func(event *gfsnotify.Event) {
 			// Track events
-			array.Append(1)
+			if strings.Contains(event.Path, "file.txt") {
+				array.Append(1)
+			}
 		})
+		t.AssertNil(err)
+
+		// Manually create the sub-folder to check callback binding
+		err = gfile.Mkdir(subDirPath)
 		t.AssertNil(err)
 
 		// Using AppendPath to add subfolder
 		err = watcher.AppendPath(subDirPath)
 		t.AssertNil(err)
 
-		// Manually create the sub-folder to check callback binding
-		err = gfile.Mkdir(subDirPath)
-		t.AssertNil(err)
 		time.Sleep(time.Millisecond * 100)
 
 		// Now create a file in the sub-folder to see if any event is tracked

--- a/os/gfsnotify/gfsnotify_z_unit_test.go
+++ b/os/gfsnotify/gfsnotify_z_unit_test.go
@@ -55,52 +55,6 @@ func TestWatcher_AddOnce(t *testing.T) {
 	})
 }
 
-func TestWatcher_AppendPath(t *testing.T) {
-	gtest.C(t, func(t *gtest.T) {
-		var (
-			err        error
-			array      = garray.New(true) // To track events
-			dirPath    = gfile.Temp(gtime.TimestampNanoStr())
-			subDirPath = gfile.Join(dirPath, "subfolder")
-		)
-
-		// Create the main directory
-		err = gfile.Mkdir(dirPath)
-		t.AssertNil(err)
-		defer gfile.Remove(dirPath)
-
-		watcher, err := gfsnotify.New()
-		t.AssertNil(err)
-		t.AssertNE(watcher, nil)
-		defer watcher.Close()
-
-		// Add a callback to the main directory
-		_, err = watcher.Add(dirPath, func(event *gfsnotify.Event) {
-			// Track events
-			array.Append(1)
-		})
-		t.AssertNil(err)
-
-		// Using AppendPath to add subfolder
-		err = watcher.AppendPath(subDirPath)
-		t.AssertNE(err, "Expected an error since no callback is directly set for subDirPath")
-
-		// Manually create the sub-folder to check callback binding
-		err = gfile.Mkdir(subDirPath)
-		t.AssertNil(err)
-		time.Sleep(time.Millisecond * 100)
-
-		// Now create a file in the sub-folder to see if any event is tracked
-		f, err := gfile.Create(gfile.Join(subDirPath, "file.txt"))
-		t.AssertNil(err)
-		t.AssertNil(f.Close())
-
-		time.Sleep(time.Millisecond * 100)
-		// Ensure the event in the subDirPath is tracked through the parent's callback
-		t.Assert(array.Len() > 0, "Expected parent directory callback to track sub-directory events")
-	})
-}
-
 func TestWatcher_AddRemove(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		path1 := gfile.Temp() + gfile.Separator + gconv.String(gtime.TimestampNano())


### PR DESCRIPTION
When using the fsnotify library to monitor file system changes, a common requirement is to watch not only a specific directory but also all of its subdirectories, including those that are created after the monitoring process has started. However, fsnotify does not natively support recursive watching of directories. This limitation means that if a new subdirectory is created within a watched directory, changes within this new subdirectory will not be detected unless it is explicitly added to the watch list.

Manual Recursion: Users must manually implement a recursive mechanism to add all existing subdirectories to the watch list at the start and continue to monitor for new directories.So this function is append the watcher path，if path is not in callbackMap，it will not append.

