### PR TITLE
fix(net/ghttp&gclient,contrib/rpc/grpcx): remove request and response contents in opentelemetry tracing attributes

### DIFF
--- a/contrib/rpc/grpcx/internal/tracing/tracing.go
+++ b/contrib/rpc/grpcx/internal/tracing/tracing.go
@@ -29,12 +29,10 @@ const (
 	tracingInstrumentGrpcClient      = "github.com/gogf/gf/contrib/rpc/grpcx/v2/krpc.GrpcClient"
 	tracingInstrumentGrpcServer      = "github.com/gogf/gf/contrib/rpc/grpcx/v2/krpc.GrpcServer"
 	tracingEventGrpcRequest          = "grpc.request"
-	tracingEventGrpcRequestMessage   = "grpc.request.message"
 	tracingEventGrpcRequestBaggage   = "grpc.request.baggage"
 	tracingEventGrpcMetadataOutgoing = "grpc.metadata.outgoing"
 	tracingEventGrpcMetadataIncoming = "grpc.metadata.incoming"
 	tracingEventGrpcResponse         = "grpc.response"
-	tracingEventGrpcResponseMessage  = "grpc.response.message"
 )
 
 type metadataSupplier struct {

--- a/contrib/rpc/grpcx/internal/tracing/tracing_interceptor_client.go
+++ b/contrib/rpc/grpcx/internal/tracing/tracing_interceptor_client.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/gogf/gf/contrib/rpc/grpcx/v2/internal/grpcctx"
-	"github.com/gogf/gf/contrib/rpc/grpcx/v2/internal/utils"
 	"github.com/gogf/gf/v2"
 	"github.com/gogf/gf/v2/net/gtrace"
 	"github.com/gogf/gf/v2/util/gconv"
@@ -59,24 +58,9 @@ func UnaryClientInterceptor(ctx context.Context, method string, req, reply inter
 	span.AddEvent(tracingEventGrpcRequest, trace.WithAttributes(
 		attribute.String(tracingEventGrpcRequestBaggage, gconv.String(gtrace.GetBaggageMap(ctx))),
 		attribute.String(tracingEventGrpcMetadataOutgoing, gconv.String(grpcctx.Ctx{}.OutgoingMap(ctx))),
-		attribute.String(
-			tracingEventGrpcRequestMessage,
-			utils.MarshalMessageToJsonStringForTracing(
-				req, "Request", tracingMaxContentLogSize,
-			),
-		),
 	))
 
 	err := invoker(ctx, method, req, reply, cc, callOpts...)
-
-	span.AddEvent(tracingEventGrpcResponse, trace.WithAttributes(
-		attribute.String(
-			tracingEventGrpcResponseMessage,
-			utils.MarshalMessageToJsonStringForTracing(
-				reply, "Response", tracingMaxContentLogSize,
-			),
-		),
-	))
 
 	if err != nil {
 		s, _ := status.FromError(err)

--- a/contrib/rpc/grpcx/internal/tracing/tracing_interceptor_server.go
+++ b/contrib/rpc/grpcx/internal/tracing/tracing_interceptor_server.go
@@ -20,7 +20,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/gogf/gf/contrib/rpc/grpcx/v2/internal/grpcctx"
-	"github.com/gogf/gf/contrib/rpc/grpcx/v2/internal/utils"
 	"github.com/gogf/gf/v2"
 	"github.com/gogf/gf/v2/net/gtrace"
 	"github.com/gogf/gf/v2/util/gconv"
@@ -58,24 +57,9 @@ func UnaryServerInterceptor(ctx context.Context, req interface{}, info *grpc.Una
 	span.AddEvent(tracingEventGrpcRequest, trace.WithAttributes(
 		attribute.String(tracingEventGrpcRequestBaggage, gconv.String(gtrace.GetBaggageMap(ctx))),
 		attribute.String(tracingEventGrpcMetadataIncoming, gconv.String(grpcctx.Ctx{}.IncomingMap(ctx))),
-		attribute.String(
-			tracingEventGrpcRequestMessage,
-			utils.MarshalMessageToJsonStringForTracing(
-				req, "Request", tracingMaxContentLogSize,
-			),
-		),
 	))
 
 	res, err := handler(ctx, req)
-
-	span.AddEvent(tracingEventGrpcResponse, trace.WithAttributes(
-		attribute.String(
-			tracingEventGrpcResponseMessage,
-			utils.MarshalMessageToJsonStringForTracing(
-				res, "Response", tracingMaxContentLogSize,
-			),
-		),
-	))
 
 	if err != nil {
 		s, _ := status.FromError(err)

--- a/net/gclient/gclient_observability.go
+++ b/net/gclient/gclient_observability.go
@@ -9,7 +9,6 @@ package gclient
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptrace"
 
@@ -21,7 +20,6 @@ import (
 
 	"github.com/gogf/gf/v2"
 	"github.com/gogf/gf/v2/internal/httputil"
-	"github.com/gogf/gf/v2/internal/utils"
 	"github.com/gogf/gf/v2/net/gtrace"
 	"github.com/gogf/gf/v2/os/gctx"
 	"github.com/gogf/gf/v2/os/gmetric"
@@ -39,10 +37,8 @@ const (
 	tracingEventHttpRequest                     = "http.request"
 	tracingEventHttpRequestHeaders              = "http.request.headers"
 	tracingEventHttpRequestBaggage              = "http.request.baggage"
-	tracingEventHttpRequestBody                 = "http.request.body"
 	tracingEventHttpResponse                    = "http.response"
 	tracingEventHttpResponseHeaders             = "http.response.headers"
-	tracingEventHttpResponseBody                = "http.response.body"
 	tracingMiddlewareHandled        gctx.StrKey = `MiddlewareClientTracingHandled`
 )
 
@@ -101,18 +97,12 @@ func internalMiddlewareObservability(c *Client, r *http.Request) (response *Resp
 	if response == nil || response.Response == nil {
 		return
 	}
-	// TODO ignore binary content ReadAll, for example downloading request.
-	reqBodyContentBytes, _ := io.ReadAll(response.Body)
-	response.Body = utils.NewReadCloser(reqBodyContentBytes, false)
-
-	resBodyContent, err := gtrace.SafeContentForHttp(reqBodyContentBytes, response.Header)
-	if err != nil {
-		span.SetStatus(codes.Error, fmt.Sprintf(`converting safe content failed: %s`, err.Error()))
-	}
 
 	span.AddEvent(tracingEventHttpResponse, trace.WithAttributes(
-		attribute.String(tracingEventHttpResponseHeaders, gconv.String(httputil.HeaderToMap(response.Header))),
-		attribute.String(tracingEventHttpResponseBody, resBodyContent),
+		attribute.String(
+			tracingEventHttpResponseHeaders,
+			gconv.String(httputil.HeaderToMap(response.Header)),
+		),
 	))
 	return
 }

--- a/net/gclient/gclient_tracer_tracing.go
+++ b/net/gclient/gclient_tracer_tracing.go
@@ -218,14 +218,8 @@ func (ct *clientTracerTracing) WroteRequest(info httptrace.WroteRequestInfo) {
 		ct.span.SetStatus(codes.Error, fmt.Sprintf(`%+v`, info.Err))
 	}
 
-	reqBodyContent, err := gtrace.SafeContentForHttp(ct.requestBody, ct.request.Header)
-	if err != nil {
-		ct.span.SetStatus(codes.Error, fmt.Sprintf(`converting safe content failed: %s`, err.Error()))
-	}
-
 	ct.span.AddEvent(tracingEventHttpRequest, trace.WithAttributes(
 		attribute.String(tracingEventHttpRequestHeaders, gconv.String(ct.headers)),
 		attribute.String(tracingEventHttpRequestBaggage, gtrace.GetBaggageMap(ct.Context).String()),
-		attribute.String(tracingEventHttpRequestBody, reqBodyContent),
 	))
 }


### PR DESCRIPTION
fixed #3791 

It is necessary adding request and response content to opentelemetry tracing attributes, which will slow the performance for http & grpc operations.

The main purpose of tracing is to locate the error among services.