### PR TITLE
fix(cmd/gf): create logic.go empty folder when there is no correct logic service

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_service_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_service_test.go
@@ -73,3 +73,46 @@ func Test_Gen_Service_Default(t *testing.T) {
 		}
 	})
 }
+
+// https://github.com/gogf/gf/issues/3328
+func Test_Issue3328(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			path        = gfile.Temp(guid.S())
+			dstFolder   = path + filepath.FromSlash("/service")
+			apiFolder   = gtest.DataPath("issue", "3328", "logic")
+			logicGoPath = apiFolder + filepath.FromSlash("/logic.go")
+			in          = genservice.CGenServiceInput{
+				SrcFolder:       apiFolder,
+				DstFolder:       dstFolder,
+				DstFileNameCase: "Snake",
+				WatchFile:       "",
+				StPattern:       "",
+				Packages:        nil,
+				ImportPrefix:    "",
+				Clear:           false,
+			}
+		)
+		gfile.Remove(logicGoPath)
+		defer gfile.Remove(logicGoPath)
+
+		err := gutil.FillStructWithDefault(&in)
+		t.AssertNil(err)
+
+		err = gfile.Mkdir(path)
+		t.AssertNil(err)
+		defer gfile.Remove(path)
+
+		_, err = genservice.CGenService{}.Service(ctx, in)
+		t.AssertNil(err)
+
+		files, err := gfile.ScanDir(apiFolder, "*", true)
+		for _, file := range files {
+			if file == logicGoPath {
+				if gfile.IsDir(logicGoPath) {
+					t.Fatalf("%s should not is folder", logicGoPath)
+				}
+			}
+		}
+	})
+}

--- a/cmd/gf/internal/utility/utils/utils.go
+++ b/cmd/gf/internal/utility/utils/utils.go
@@ -81,7 +81,6 @@ func GetImportPath(filePath string) string {
 	// If `filePath` does not exist, create it firstly to find the import path.
 	var realPath = gfile.RealPath(filePath)
 	if realPath == "" {
-		_ = gfile.Mkdir(filePath)
 		realPath = gfile.RealPath(filePath)
 	}
 

--- a/test/gtest/gtest_util.go
+++ b/test/gtest/gtest_util.go
@@ -364,11 +364,11 @@ func AssertNil(value interface{}) {
 // which will be joined with current system separator and returned with the path.
 func DataPath(names ...string) string {
 	_, path, _ := gdebug.CallerWithFilter([]string{pathFilterKey})
-	path = filepath.Dir(path) + string(filepath.Separator) + "testdata"
+	path = filepath.Dir(path) + "/testdata"
 	for _, name := range names {
-		path += string(filepath.Separator) + name
+		path += "/" + name
 	}
-	return path
+	return filepath.FromSlash(path)
 }
 
 // DataContent retrieves and returns the file content for specified testdata path of current package


### PR DESCRIPTION
Dear review:
当 logic 下没有正确编写 logic 文件时，会在 logic 中生成一个空的 logic.go 目录