### PR TITLE
fix(cmd/gf): gen service error when there's version number at the end of package import path

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_service_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_service_test.go
@@ -22,9 +22,9 @@ func Test_Gen_Service_Default(t *testing.T) {
 		var (
 			path      = gfile.Temp(guid.S())
 			dstFolder = path + filepath.FromSlash("/service")
-			apiFolder = gtest.DataPath("genservice", "logic")
+			srvFolder = gtest.DataPath("genservice", "logic")
 			in        = genservice.CGenServiceInput{
-				SrcFolder:       apiFolder,
+				SrcFolder:       srvFolder,
 				DstFolder:       dstFolder,
 				DstFileNameCase: "Snake",
 				WatchFile:       "",
@@ -46,11 +46,11 @@ func Test_Gen_Service_Default(t *testing.T) {
 
 		// logic file
 		var (
-			genApi       = apiFolder + filepath.FromSlash("/logic.go")
-			genApiExpect = apiFolder + filepath.FromSlash("/logic_expect.go")
+			genSrv       = srvFolder + filepath.FromSlash("/logic.go")
+			genSrvExpect = srvFolder + filepath.FromSlash("/logic_expect.go")
 		)
-		defer gfile.Remove(genApi)
-		t.Assert(gfile.GetContents(genApi), gfile.GetContents(genApiExpect))
+		defer gfile.Remove(genSrv)
+		t.Assert(gfile.GetContents(genSrv), gfile.GetContents(genSrvExpect))
 
 		// files
 		files, err := gfile.ScanDir(dstFolder, "*.go", true)
@@ -80,10 +80,10 @@ func Test_Issue3328(t *testing.T) {
 		var (
 			path        = gfile.Temp(guid.S())
 			dstFolder   = path + filepath.FromSlash("/service")
-			apiFolder   = gtest.DataPath("issue", "3328", "logic")
-			logicGoPath = apiFolder + filepath.FromSlash("/logic.go")
+			srvFolder   = gtest.DataPath("issue", "3328", "logic")
+			logicGoPath = srvFolder + filepath.FromSlash("/logic.go")
 			in          = genservice.CGenServiceInput{
-				SrcFolder:       apiFolder,
+				SrcFolder:       srvFolder,
 				DstFolder:       dstFolder,
 				DstFileNameCase: "Snake",
 				WatchFile:       "",
@@ -106,7 +106,7 @@ func Test_Issue3328(t *testing.T) {
 		_, err = genservice.CGenService{}.Service(ctx, in)
 		t.AssertNil(err)
 
-		files, err := gfile.ScanDir(apiFolder, "*", true)
+		files, err := gfile.ScanDir(srvFolder, "*", true)
 		for _, file := range files {
 			if file == logicGoPath {
 				if gfile.IsDir(logicGoPath) {
@@ -114,5 +114,42 @@ func Test_Issue3328(t *testing.T) {
 				}
 			}
 		}
+	})
+}
+
+// https://github.com/gogf/gf/issues/3835
+func Test_Issue3835(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			path      = gfile.Temp(guid.S())
+			dstFolder = path + filepath.FromSlash("/service")
+			srvFolder = gtest.DataPath("issue", "3835", "logic")
+			in        = genservice.CGenServiceInput{
+				SrcFolder:       srvFolder,
+				DstFolder:       dstFolder,
+				DstFileNameCase: "Snake",
+				WatchFile:       "",
+				StPattern:       "",
+				Packages:        nil,
+				ImportPrefix:    "",
+				Clear:           false,
+			}
+		)
+		err := gutil.FillStructWithDefault(&in)
+		t.AssertNil(err)
+
+		err = gfile.Mkdir(path)
+		t.AssertNil(err)
+		defer gfile.Remove(path)
+
+		_, err = genservice.CGenService{}.Service(ctx, in)
+		t.AssertNil(err)
+
+		// contents
+		var (
+			genFile    = dstFolder + filepath.FromSlash("/issue_3835.go")
+			expectFile = gtest.DataPath("issue", "3835", "service", "issue_3835.go")
+		)
+		t.Assert(gfile.GetContents(genFile), gfile.GetContents(expectFile))
 	})
 }

--- a/cmd/gf/internal/cmd/testdata/issue/3835/logic/issue3835/issue3835.go
+++ b/cmd/gf/internal/cmd/testdata/issue/3835/logic/issue3835/issue3835.go
@@ -1,0 +1,23 @@
+package issue3835
+
+import (
+	"context"
+
+	"github.com/gogf/gf/cmd/gf/v2/internal/cmd/testdata/issue/3835/service"
+	"github.com/gogf/gf/contrib/drivers/mysql/v2"
+)
+
+func init() {
+	service.RegisterItest(New())
+}
+
+type sItest struct {
+}
+
+func New() *sItest {
+	return &sItest{}
+}
+
+func (s *sItest) F(ctx context.Context) (d mysql.Driver, err error) {
+	return mysql.Driver{}, nil
+}

--- a/cmd/gf/internal/cmd/testdata/issue/3835/logic/logic.go
+++ b/cmd/gf/internal/cmd/testdata/issue/3835/logic/logic.go
@@ -1,0 +1,9 @@
+// ==========================================================================
+// Code generated and maintained by GoFrame CLI tool. DO NOT EDIT.
+// ==========================================================================
+
+package logic
+
+import (
+	_ "github.com/gogf/gf/cmd/gf/v2/internal/cmd/testdata/issue/3835/logic/issue3835"
+)

--- a/cmd/gf/internal/cmd/testdata/issue/3835/service/issue_3835.go
+++ b/cmd/gf/internal/cmd/testdata/issue/3835/service/issue_3835.go
@@ -1,0 +1,33 @@
+// ================================================================================
+// Code generated and maintained by GoFrame CLI tool. DO NOT EDIT.
+// You can delete these comments if you wish manually maintain this interface file.
+// ================================================================================
+
+package service
+
+import (
+	"context"
+
+	"github.com/gogf/gf/contrib/drivers/mysql/v2"
+)
+
+type (
+	IItest interface {
+		F(ctx context.Context) (d mysql.Driver, err error)
+	}
+)
+
+var (
+	localItest IItest
+)
+
+func Itest() IItest {
+	if localItest == nil {
+		panic("implement not found for interface IItest, forgot register?")
+	}
+	return localItest
+}
+
+func RegisterItest(i IItest) {
+	localItest = i
+}


### PR DESCRIPTION
Dear review:
当 logic 中存在类似携带版本号的引入包名，例如：`github.com/gogf/gf/v2`，那么在生成 `service` 的时候，会导致该包名识别为 `v2`。
故此当结尾以版本号结尾时，向前推进一位，使用正确的 `gf` 做为包名。

Fixed #3835 