### PR TITLE
fix(util/gconv): incorrect fuzzy converting logic

### DIFF
--- a/util/gconv/gconv_struct.go
+++ b/util/gconv/gconv_struct.go
@@ -257,7 +257,6 @@ func bindStructWithLoopParamsMap(
 	var (
 		fieldName       string
 		cachedFieldInfo *structcache.CachedFieldInfo
-		fuzzLastKey     string
 		fieldValue      reflect.Value
 		paramKey        string
 		paramValue      any
@@ -298,17 +297,11 @@ func bindStructWithLoopParamsMap(
 			if _, ok = usedParamsKeyOrTagNameMap[fieldName]; ok {
 				continue
 			}
-			fuzzLastKey = cachedFieldInfo.LastFuzzyKey.Load().(string)
-			paramValue, ok = paramsMap[fuzzLastKey]
-			if !ok {
-				if strings.EqualFold(
-					cachedFieldInfo.RemoveSymbolsFieldName, utils.RemoveSymbols(paramKey),
-				) {
-					paramValue, ok = paramsMap[paramKey]
-					// If it is found this time, update it based on what was not found last time.
-					cachedFieldInfo.LastFuzzyKey.Store(paramKey)
-				}
+			if !strings.EqualFold(
+				cachedFieldInfo.RemoveSymbolsFieldName, utils.RemoveSymbols(paramKey)) {
+				continue
 			}
+			paramValue, ok = paramsMap[paramKey]
 			if ok {
 				fieldValue = cachedFieldInfo.GetFieldReflectValueFrom(structValue)
 				if paramValue != nil {

--- a/util/gconv/gconv_struct.go
+++ b/util/gconv/gconv_struct.go
@@ -298,30 +298,28 @@ func bindStructWithLoopParamsMap(
 				continue
 			}
 			if !strings.EqualFold(
-				cachedFieldInfo.RemoveSymbolsFieldName, utils.RemoveSymbols(paramKey)) {
+				cachedFieldInfo.RemoveSymbolsFieldName,
+				utils.RemoveSymbols(paramKey)) {
 				continue
 			}
-			paramValue, ok = paramsMap[paramKey]
-			if ok {
-				fieldValue = cachedFieldInfo.GetFieldReflectValueFrom(structValue)
-				if paramValue != nil {
-					if err = bindVarToStructField(
-						fieldValue, paramValue, cachedFieldInfo, paramKeyToAttrMap,
+			fieldValue = cachedFieldInfo.GetFieldReflectValueFrom(structValue)
+			if paramValue != nil {
+				if err = bindVarToStructField(
+					fieldValue, paramValue, cachedFieldInfo, paramKeyToAttrMap,
+				); err != nil {
+					return err
+				}
+				// handle same field name in nested struct.
+				if len(cachedFieldInfo.OtherSameNameField) > 0 {
+					if err = setOtherSameNameField(
+						cachedFieldInfo, paramValue, structValue, paramKeyToAttrMap,
 					); err != nil {
 						return err
 					}
-					// handle same field name in nested struct.
-					if len(cachedFieldInfo.OtherSameNameField) > 0 {
-						if err = setOtherSameNameField(
-							cachedFieldInfo, paramValue, structValue, paramKeyToAttrMap,
-						); err != nil {
-							return err
-						}
-					}
 				}
-				usedParamsKeyOrTagNameMap[cachedFieldInfo.FieldName()] = struct{}{}
-				break
 			}
+			usedParamsKeyOrTagNameMap[cachedFieldInfo.FieldName()] = struct{}{}
+			break
 		}
 	}
 	return nil

--- a/util/gconv/gconv_z_unit_issue_test.go
+++ b/util/gconv/gconv_z_unit_issue_test.go
@@ -758,6 +758,7 @@ func Test_Issue3821(t *testing.T) {
 	})
 }
 
+// https://github.com/gogf/gf/issues/3868
 func Test_Issue3868(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		type Config struct {

--- a/util/gconv/gconv_z_unit_issue_test.go
+++ b/util/gconv/gconv_z_unit_issue_test.go
@@ -757,3 +757,28 @@ func Test_Issue3821(t *testing.T) {
 		t.AssertEQ(user.DoubleInnerUser.UserId, int64(1))
 	})
 }
+
+func Test_Issue3868(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Config struct {
+			Enable   bool
+			Spec     string
+			PoolSize int
+		}
+		data := gjson.New(`[{"enable":false,"spec":"a"},{"enable":true,"poolSize":1}]`)
+		for i := 0; i < 1000; i++ {
+			var configs []*Config
+			err := gconv.Structs(data, &configs)
+			t.AssertNil(err)
+			t.Assert(len(configs), 2)
+			t.Assert(configs[0], &Config{
+				Enable: false,
+				Spec:   "a",
+			})
+			t.Assert(configs[1], &Config{
+				Enable:   true,
+				PoolSize: 1,
+			})
+		}
+	})
+}


### PR DESCRIPTION
删除bindStructWithLoopParamsMap函数根据fuzzLastKey查找的逻辑

fix #3868
