### PR TITLE
fix(cmd/gf): protoc file comments contain backticks and double quotes, resulting in syntax errors in the generated file of go

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_pb_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_pb_test.go
@@ -1,0 +1,50 @@
+// Copyright GoFrame gf Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gogf/gf/cmd/gf/v2/internal/cmd/genpb"
+	"github.com/gogf/gf/v2/os/gfile"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/text/gstr"
+	"github.com/gogf/gf/v2/util/guid"
+)
+
+func TestGenPbIssue3882(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			outputPath     = gfile.Temp(guid.S())
+			outputApiPath  = filepath.Join(outputPath, "api")
+			outputCtrlPath = filepath.Join(outputPath, "controller")
+
+			protobufFolder = gtest.DataPath("issue", "3882")
+			in             = genpb.CGenPbInput{
+				Path:       protobufFolder,
+				OutputApi:  outputApiPath,
+				OutputCtrl: outputCtrlPath,
+			}
+			err error
+		)
+		err = gfile.Mkdir(outputApiPath)
+		t.AssertNil(err)
+		err = gfile.Mkdir(outputCtrlPath)
+		t.AssertNil(err)
+		defer gfile.Remove(outputPath)
+
+		_, err = genpb.CGenPb{}.Pb(ctx, in)
+		t.AssertNil(err)
+
+		var (
+			genContent = gfile.GetContents(filepath.Join(outputApiPath, "issue3882.pb.go"))
+			exceptText = `dc:"Some comment on field with 'one' 'two' 'three' in the comment."`
+		)
+		t.Assert(gstr.Contains(genContent, exceptText), true)
+	})
+}

--- a/cmd/gf/internal/cmd/genpb/genpb_tag.go
+++ b/cmd/gf/internal/cmd/genpb/genpb_tag.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 	"github.com/gogf/gf/v2/container/gmap"
+	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/os/gfile"
 	"github.com/gogf/gf/v2/text/gregex"
 	"github.com/gogf/gf/v2/text/gstr"
@@ -90,8 +91,12 @@ func (c CGenPb) tagCommentIntoListMap(comment string, lineTagMap *gmap.ListMap) 
 		lineTagMap.Set(tagName, lineTagMap.GetVar(tagName).String()+tagContent)
 	} else {
 		var (
-			tagName    = "dc"
-			tagContent = comment
+			tagName = "dc"
+			// Convert backticks and double quotes to single quotes.
+			tagContent = gstr.ReplaceByMap(comment, g.MapStrStr{
+				"`": `'`,
+				`"`: `'`,
+			})
 		)
 		lineTagMap.Set(tagName, lineTagMap.GetVar(tagName).String()+tagContent)
 	}

--- a/cmd/gf/internal/cmd/testdata/issue/3882/issue3882.proto
+++ b/cmd/gf/internal/cmd/testdata/issue/3882/issue3882.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package test;
+
+option go_package = "github.com/gogf/gf/cmd/gf/test";
+
+message SomeMessage {
+  // Some comment on field with "one" `two` 'three' in the comment.
+  string field = 1;
+}


### PR DESCRIPTION
fixed #3882 