### PR TITLE
feat(gctx): rename and remove gctx functions to prevent ambiguity

### DIFF
--- a/net/ghttp/ghttp_request_param_ctx.go
+++ b/net/ghttp/ghttp_request_param_ctx.go
@@ -30,8 +30,6 @@ func (r *Request) Context() context.Context {
 	if RequestFromCtx(ctx) == nil {
 		// Inject Request object into context.
 		ctx = context.WithValue(ctx, ctxKeyForRequest, r)
-		// Add default tracing info if using default tracing provider.
-		ctx = gctx.WithCtx(ctx)
 		// Update the values of the original HTTP request.
 		*r.Request = *r.Request.WithContext(ctx)
 	}

--- a/os/gctx/gctx.go
+++ b/os/gctx/gctx.go
@@ -52,7 +52,7 @@ func New() context.Context {
 }
 
 // WithCtx creates and returns a context containing context id upon given parent context `ctx`.
-// Deprecated, use WithSpan instead.
+// Deprecated: use WithSpan instead.
 func WithCtx(ctx context.Context) context.Context {
 	if CtxId(ctx) != "" {
 		return ctx

--- a/os/gctx/gctx.go
+++ b/os/gctx/gctx.go
@@ -44,21 +44,35 @@ func init() {
 		context.Background(),
 		propagation.MapCarrier(m),
 	)
-	initCtx = WithCtx(initCtx)
 }
 
 // New creates and returns a context which contains context id.
 func New() context.Context {
-	return WithCtx(context.Background())
+	return WithSpan(context.Background(), "gctx.New")
 }
 
 // WithCtx creates and returns a context containing context id upon given parent context `ctx`.
+// Deprecated, use WithSpan instead.
 func WithCtx(ctx context.Context) context.Context {
 	if CtxId(ctx) != "" {
 		return ctx
 	}
 	var span *gtrace.Span
 	ctx, span = gtrace.NewSpan(ctx, "gctx.WithCtx")
+	defer span.End()
+	return ctx
+}
+
+// WithSpan creates and returns a context containing span upon given parent context `ctx`.
+func WithSpan(ctx context.Context, spanName ...string) context.Context {
+	if CtxId(ctx) != "" {
+		return ctx
+	}
+	if len(spanName) == 0 {
+		spanName = append(spanName, "gctx.WithSpan")
+	}
+	var span *gtrace.Span
+	ctx, span = gtrace.NewSpan(ctx, spanName[0])
 	defer span.End()
 	return ctx
 }

--- a/os/gctx/gctx.go
+++ b/os/gctx/gctx.go
@@ -64,15 +64,15 @@ func WithCtx(ctx context.Context) context.Context {
 }
 
 // WithSpan creates and returns a context containing span upon given parent context `ctx`.
-func WithSpan(ctx context.Context, spanName ...string) context.Context {
+func WithSpan(ctx context.Context, spanName string) context.Context {
 	if CtxId(ctx) != "" {
 		return ctx
 	}
-	if len(spanName) == 0 {
-		spanName = append(spanName, "gctx.WithSpan")
+	if spanName == "" {
+		spanName = "gctx.WithSpan"
 	}
 	var span *gtrace.Span
-	ctx, span = gtrace.NewSpan(ctx, spanName[0])
+	ctx, span = gtrace.NewSpan(ctx, spanName)
 	defer span.End()
 	return ctx
 }

--- a/os/gctx/gctx_z_unit_test.go
+++ b/os/gctx/gctx_z_unit_test.go
@@ -25,7 +25,7 @@ func Test_New(t *testing.T) {
 func Test_WithCtx(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		ctx := context.WithValue(context.TODO(), "TEST", 1)
-		ctx = gctx.WithSpan(ctx)
+		ctx = gctx.WithSpan(ctx, "test")
 		t.AssertNE(gctx.CtxId(ctx), "")
 		t.Assert(ctx.Value("TEST"), 1)
 	})

--- a/os/gctx/gctx_z_unit_test.go
+++ b/os/gctx/gctx_z_unit_test.go
@@ -25,7 +25,7 @@ func Test_New(t *testing.T) {
 func Test_WithCtx(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		ctx := context.WithValue(context.TODO(), "TEST", 1)
-		ctx = gctx.WithCtx(ctx)
+		ctx = gctx.WithSpan(ctx)
 		t.AssertNE(gctx.CtxId(ctx), "")
 		t.Assert(ctx.Value("TEST"), 1)
 	})


### PR DESCRIPTION
- Removed the `gctx.WithCtx` function from ghttp.
- Renamed `gctx.WithCtx` to `gctx.WithSpan` to prevent naming ambiguity.