### PR TITLE
fix(cmd/gf): go back current working directory after gf gen pb

### DIFF
--- a/cmd/gf/internal/cmd/genpb/genpb.go
+++ b/cmd/gf/internal/cmd/genpb/genpb.go
@@ -94,6 +94,9 @@ func (c CGenPb) Pb(ctx context.Context, in CGenPbInput) (out *CGenPbOutput, err 
 		mlog.Fatalf(`no proto files found in folder "%s"`, in.Path)
 	}
 
+	var originPwd = gfile.Pwd()
+	defer gfile.Chdir(originPwd)
+
 	if err = gfile.Chdir(protoPath); err != nil {
 		mlog.Fatal(err)
 	}


### PR DESCRIPTION
Dear review:
在 `gen pb` 中会使用 `gfile.Chdir` 改变当前工作路径，而 `gen pbentity` 则依赖当前工作路径生成 `go_package in *.proto`。如此一来，一旦两者同时进行单测，`gen pbentity` 生成的 `*.proto` 会出现意外的 `go_package`，导致单测失败。
![image](https://github.com/user-attachments/assets/15911d93-6485-4f5a-96c7-db9da56aea3a)
详情查看：https://github.com/gogf/gf/actions/runs/11513842473/job/32051852646

fixed: #3894 