### PR TITLE
change-gcmd-search-command

### DIFF
--- a/os/gcmd/gcmd_command_run.go
+++ b/os/gcmd/gcmd_command_run.go
@@ -235,11 +235,20 @@ func (c *Command) searchCommand(
 			//
 			// Note that the args here (using default args parsing) could be different with the args
 			// that are parsed in command.
-			if cmd.hasArgumentFromIndex() || len(leftArgs) == 0 {
-				ctx = context.WithValue(ctx, CtxKeyArgumentsIndex, fromArgIndex+1)
-				return c, cmd, ctx
+
+			// 2024.11.05-ynwcel-fix
+			// if cmd.hasArgumentFromIndex() || len(leftArgs) == 0 {
+			// 	ctx = context.WithValue(ctx, CtxKeyArgumentsIndex, fromArgIndex+1)
+			// 	return c, cmd, ctx
+			// }
+			// return cmd.searchCommand(ctx, leftArgs, fromArgIndex+1)
+
+			//2024.11.05-ynwcel-add
+			if subc, subcmd, subCtx := cmd.searchCommand(ctx, leftArgs, fromArgIndex+1); subcmd != nil {
+				return subc, subcmd, subCtx
 			}
-			return cmd.searchCommand(ctx, leftArgs, fromArgIndex+1)
+			ctx = context.WithValue(ctx, CtxKeyArgumentsIndex, fromArgIndex+1)
+			return c, cmd, ctx
 		}
 	}
 	return c, nil, ctx


### PR DESCRIPTION
* 修改之前：
    * 如果不存在子命令，并且提供了 参数 将报错
* 修改之后：
     * 根据参数顺序，优先查找子命令，如果未找到子命令，则认为是参数

附：
![1](https://github.com/user-attachments/assets/771f5fad-bc85-4c01-a613-7f1e302bc1f5)
![2](https://github.com/user-attachments/assets/2207374e-2aa7-407b-b5f4-641408b0a0c4)
