### PR TITLE
fix(util/gconv): assigned the same value to struct field and its same name field in embedded struct failed

### DIFF
--- a/util/gconv/gconv_z_unit_issue_test.go
+++ b/util/gconv/gconv_z_unit_issue_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gogf/gf/v2/container/gtype"
+	"github.com/gogf/gf/v2/container/gvar"
 	"github.com/gogf/gf/v2/encoding/gjson"
 	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/internal/json"
@@ -781,5 +782,26 @@ func Test_Issue3868(t *testing.T) {
 				PoolSize: 1,
 			})
 		}
+	})
+}
+
+// https://github.com/gogf/gf/issues/3903
+func Test_Issue3903(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type TestA struct {
+			UserId int `json:"UserId"   orm:"user_id"   `
+		}
+		type TestB struct {
+			TestA
+			UserId int `json:"NewUserId"  description:""`
+		}
+		var input = map[string]interface{}{
+			"user_id": gvar.New(100, true),
+		}
+		var a TestB
+		err := gconv.StructTag(input, &a, "orm")
+		t.AssertNil(err)
+		t.Assert(a.TestA.UserId, 100)
+		t.Assert(a.UserId, 100)
 	})
 }

--- a/util/gconv/internal/structcache/structcache_cached_struct_info.go
+++ b/util/gconv/internal/structcache/structcache_cached_struct_info.go
@@ -59,16 +59,17 @@ func (csi *CachedStructInfo) AddField(field reflect.StructField, fieldIndexes []
 }
 
 func (csi *CachedStructInfo) makeOrCopyCachedInfo(
-	field reflect.StructField,
-	fieldIndexes []int,
-	priorityTags []string,
+	field reflect.StructField, fieldIndexes []int, priorityTags []string,
 	cachedFieldInfo *CachedFieldInfo,
 	currTagOrFieldName string,
 ) (newFieldInfo *CachedFieldInfo) {
 	if cachedFieldInfo == nil {
 		// If the field is not cached, it creates a new one.
 		newFieldInfo = csi.makeCachedFieldInfo(field, fieldIndexes, priorityTags)
-	} else if cachedFieldInfo.StructField.Type != field.Type {
+		newFieldInfo.IsField = currTagOrFieldName == field.Name
+		return
+	}
+	if cachedFieldInfo.StructField.Type != field.Type {
 		// If the types are different, some information needs to be reset.
 		newFieldInfo = csi.makeCachedFieldInfo(field, fieldIndexes, priorityTags)
 	} else {


### PR DESCRIPTION
删除bindStructWithLoopParamsMap的逻辑,
只保留一个赋值的逻辑，当时使用bindStructWithLoopParamsMap
是因为paramsMap的长度可能比被赋值的结构体字段数多，
所以会以paramsMap的长度来做主循环，以减少循环次数，达到性能提升的目的
且维护两个逻辑，可能会对测试的结果有影响，
我在bindStructWithLoopParamsMap的逻辑后，有一个测试就没通过

在bindStructWithLoopFieldInfos的逻辑没办法通过记录赋值次数来判断可以提前退出，
```go
        type Data struct {
		A int `json:"a" orm:"a" conv:"a" p:"a"`
		B int `json:"b" orm:"a" conv:"a" p:"a"`
		C int `json:"c"`
	}

	paramsMap := map[string]any{

		"c": 3,
	}
	// 此时有3个字段
	// 根据A,B,C的顺序来循环查找paramsMap
	// 这时候要循环到第三次才能找到paramsMap.c并给C字段赋值
	// 在前两次没有找到的时候，也需要使用A和B字段的tag来循环依次查找paramsMap
	// 相当于查找8+1次
	// 在原版的bindStructWithLoopParamsMap逻辑下可能只需要1次
	// 当然这是最极端的情况

	// 更多的可能是下面这种情况
	paramsMap2 := map[string]any{
		"a": 2,
		"c": 3,
	}
```
