### PR TITLE
chore(database/gdb): comment update for function `Model.Order`

### DIFF
--- a/database/gdb/gdb_model_order_group.go
+++ b/database/gdb/gdb_model_order_group.go
@@ -17,7 +17,6 @@ import (
 //
 // Eg:
 // Order("id desc")
-// Order("id", "desc").
 // Order("id desc,name asc")
 // Order("id desc").Order("name asc")
 // Order(gdb.Raw("field(id, 3,1,2)")).


### PR DESCRIPTION
remove Eg:Order(id,desc) from function Order comments, since new version no more support this mode. it will cause error. treat asc and desc as a column


