### PR TITLE
fix(cmd/gf): incorrect environment variables printing before cli does some environment changes

### DIFF
--- a/cmd/gf/internal/cmd/cmd_build.go
+++ b/cmd/gf/internal/cmd/cmd_build.go
@@ -138,11 +138,6 @@ type cBuildInput struct {
 type cBuildOutput struct{}
 
 func (c cBuild) Index(ctx context.Context, in cBuildInput) (out *cBuildOutput, err error) {
-	// print used go env
-	if in.DumpENV {
-		_, _ = Env.Index(ctx, cEnvInput{})
-	}
-
 	mlog.SetHeaderPrint(true)
 
 	mlog.Debugf(`build command input: %+v`, in)
@@ -240,6 +235,10 @@ func (c cBuild) Index(ctx context.Context, in cBuildInput) (out *cBuildOutput, e
 		genv.MustSet("CGO_ENABLED", "1")
 	} else {
 		genv.MustSet("CGO_ENABLED", "0")
+	}
+	// print used go env
+	if in.DumpENV {
+		_, _ = Env.Index(ctx, cEnvInput{})
 	}
 	for system, item := range platformMap {
 		if len(customSystems) > 0 && customSystems[0] != "all" && !gstr.InArray(customSystems, system) {


### PR DESCRIPTION
调整打印环境变量的位置，修复cmd build命令打印env与实际不符的问题
