### PR TITLE
feat: AutoMigrate Automatically Generates Corresponding Table Structure Based on Model Struct Fields

### DIFF
--- a/database/gdb/gdb_model_create_table.go
+++ b/database/gdb/gdb_model_create_table.go
@@ -1,0 +1,262 @@
+package gdb
+
+import (
+	"context"
+	"fmt"
+	"github.com/gogf/gf/v2/text/gstr"
+	"log"
+	"reflect"
+)
+
+// 不同库对应 golang字段类型与数据库类型映射
+var typeMapping = map[string]map[reflect.Kind]string{
+	"mysql": {
+		reflect.Int:     "INT",
+		reflect.Int8:    "TINYINT",
+		reflect.Int16:   "SMALLINT",
+		reflect.Int32:   "INT",
+		reflect.Int64:   "BIGINT",
+		reflect.Uint:    "INT",
+		reflect.Uint8:   "TINYINT",
+		reflect.Uint16:  "SMALLINT",
+		reflect.Uint32:  "INT",
+		reflect.Uint64:  "BIGINT",
+		reflect.Float32: "FLOAT",
+		reflect.Float64: "DOUBLE",
+		reflect.String:  "VARCHAR(255)",
+		reflect.Bool:    "BOOLEAN",
+		reflect.Ptr:     "DATETIME", // 假设是指向时间类型的指针
+	},
+	"mariadb": {
+		reflect.Int:     "INT",
+		reflect.Int8:    "TINYINT",
+		reflect.Int16:   "SMALLINT",
+		reflect.Int32:   "INT",
+		reflect.Int64:   "BIGINT",
+		reflect.Uint:    "INT",
+		reflect.Uint8:   "TINYINT",
+		reflect.Uint16:  "SMALLINT",
+		reflect.Uint32:  "INT",
+		reflect.Uint64:  "BIGINT",
+		reflect.Float32: "FLOAT",
+		reflect.Float64: "DOUBLE", // MariaDB 支持 DOUBLE
+		reflect.String:  "VARCHAR(255)",
+		reflect.Bool:    "BOOLEAN",
+		reflect.Ptr:     "DATETIME", // 假设是指向时间类型的指针
+	},
+	"tidb": {
+		reflect.Int:     "INT",
+		reflect.Int8:    "TINYINT",
+		reflect.Int16:   "SMALLINT",
+		reflect.Int32:   "INT",
+		reflect.Int64:   "BIGINT",
+		reflect.Uint:    "INT",
+		reflect.Uint8:   "TINYINT",
+		reflect.Uint16:  "SMALLINT",
+		reflect.Uint32:  "INT",
+		reflect.Uint64:  "BIGINT",
+		reflect.Float32: "FLOAT",
+		reflect.Float64: "DOUBLE", // TiDB 支持 DOUBLE
+		reflect.String:  "VARCHAR(255)",
+		reflect.Bool:    "BOOLEAN",
+		reflect.Ptr:     "DATETIME", // 假设是指向时间类型的指针
+	},
+	"mssql": {
+		reflect.Int:     "INT",
+		reflect.Int8:    "TINYINT",
+		reflect.Int16:   "SMALLINT",
+		reflect.Int32:   "INT",
+		reflect.Int64:   "BIGINT",
+		reflect.Uint:    "INT",
+		reflect.Uint8:   "TINYINT",
+		reflect.Uint16:  "SMALLINT",
+		reflect.Uint32:  "INT",
+		reflect.Uint64:  "BIGINT",
+		reflect.Float32: "FLOAT",
+		reflect.Float64: "FLOAT", // MSSQL 支持 FLOAT
+		reflect.String:  "NVARCHAR(255)",
+		reflect.Bool:    "BIT",
+		reflect.Ptr:     "DATETIME2", // 假设是指向时间类型的指针
+	},
+	"sqlite": {
+		reflect.Int:     "INTEGER",
+		reflect.Int8:    "INTEGER",
+		reflect.Int16:   "INTEGER",
+		reflect.Int32:   "INTEGER",
+		reflect.Int64:   "INTEGER",
+		reflect.Uint:    "INTEGER",
+		reflect.Uint8:   "INTEGER",
+		reflect.Uint16:  "INTEGER",
+		reflect.Uint32:  "INTEGER",
+		reflect.Uint64:  "INTEGER",
+		reflect.Float32: "REAL",
+		reflect.Float64: "REAL", // SQLite 支持 REAL
+		reflect.String:  "TEXT",
+		reflect.Bool:    "INTEGER",
+		reflect.Ptr:     "DATETIME", // 假设是指向时间类型的指针
+	},
+	"oracle": {
+		reflect.Int:     "NUMBER",
+		reflect.Int8:    "NUMBER",
+		reflect.Int16:   "NUMBER",
+		reflect.Int32:   "NUMBER",
+		reflect.Int64:   "NUMBER",
+		reflect.Uint:    "NUMBER",
+		reflect.Uint8:   "NUMBER",
+		reflect.Uint16:  "NUMBER",
+		reflect.Uint32:  "NUMBER",
+		reflect.Uint64:  "NUMBER",
+		reflect.Float32: "FLOAT",
+		reflect.Float64: "NUMBER", // Oracle 支持 NUMBER
+		reflect.String:  "VARCHAR2(255)",
+		reflect.Bool:    "NUMBER(1)",
+		reflect.Ptr:     "TIMESTAMP", // 假设是指向时间类型的指针
+	},
+	"dm": {
+		reflect.Int:     "INTEGER",
+		reflect.Int8:    "TINYINT",
+		reflect.Int16:   "SMALLINT",
+		reflect.Int32:   "INTEGER",
+		reflect.Int64:   "BIGINT",
+		reflect.Uint:    "INTEGER",
+		reflect.Uint8:   "TINYINT",
+		reflect.Uint16:  "SMALLINT",
+		reflect.Uint32:  "INTEGER",
+		reflect.Uint64:  "BIGINT",
+		reflect.Float32: "FLOAT",
+		reflect.Float64: "DOUBLE", // DM 支持 DOUBLE
+		reflect.String:  "VARCHAR(255)",
+		reflect.Bool:    "BOOLEAN",
+		reflect.Ptr:     "TIMESTAMP", // 假设是指向时间类型的指针
+	},
+	"pgsql": {
+		reflect.Int:     "INTEGER",
+		reflect.Int8:    "SMALLINT",
+		reflect.Int16:   "SMALLINT",
+		reflect.Int32:   "INTEGER",
+		reflect.Int64:   "BIGINT",
+		reflect.Uint:    "INTEGER",
+		reflect.Uint8:   "SMALLINT",
+		reflect.Uint16:  "SMALLINT",
+		reflect.Uint32:  "INTEGER",
+		reflect.Uint64:  "BIGINT",
+		reflect.Float32: "REAL",
+		reflect.Float64: "DOUBLE PRECISION",
+		reflect.String:  "VARCHAR(255)",
+		reflect.Bool:    "BOOLEAN",
+		reflect.Ptr:     "TIMESTAMPTZ", // 假设是指向时间类型的指针
+	},
+	"clickhouse": {
+		reflect.Int:     "Int32",
+		reflect.Int8:    "Int8",
+		reflect.Int16:   "Int16",
+		reflect.Int32:   "Int32",
+		reflect.Int64:   "Int64",
+		reflect.Uint:    "UInt32",
+		reflect.Uint8:   "UInt8",
+		reflect.Uint16:  "UInt16",
+		reflect.Uint32:  "UInt32",
+		reflect.Uint64:  "UInt64",
+		reflect.Float32: "Float32",
+		reflect.Float64: "Float64",
+		reflect.String:  "String",
+		reflect.Bool:    "UInt8",
+		reflect.Ptr:     "DateTime", // 假设是指向时间类型的指针
+	},
+}
+
+// 自增字段语法映射
+var autoIncrementMapping = map[string]string{
+	"mysql":      "AUTO_INCREMENT",
+	"mariadb":    "AUTO_INCREMENT",
+	"tidb":       "AUTO_INCREMENT",
+	"mssql":      "IDENTITY(1,1)",
+	"sqlite":     "AUTOINCREMENT",
+	"oracle":     "GENERATED BY DEFAULT AS IDENTITY",
+	"dm":         "AUTO_INCREMENT",
+	"duckdb":     "",       // 内存库,不支持传统意义上的自增
+	"pgsql":      "SERIAL", //最新版本psql 使用BIGSERIAL
+	"clickhouse": "AUTO_INCREMENT",
+}
+
+// AutoMigrate 自动迁移模型到数据库。
+// 该方法根据模型的结构体字段自动生成对应的数据库表结构。
+// 参数:
+//
+//	ctx - 上下文，用于传递请求范围的信息。
+//	model - 需要进行迁移的模型结构体。
+//
+// 返回值:
+//
+//	如果迁移过程中发生错误，则返回错误。
+func (m *Model) AutoMigrate(ctx context.Context, model interface{}) error {
+	// 获取结构体的字段信息
+	t := reflect.TypeOf(model)
+	if t.Kind() != reflect.Struct {
+		return fmt.Errorf("model must be a struct")
+	}
+	// 获取数据库类型
+	dbType := m.db.GetCore().config.Type
+
+	//获取字段类型映射
+	typeMap, ok := typeMapping[dbType]
+	if !ok {
+		return fmt.Errorf("unsupported database type: %s", dbType)
+	}
+
+	//获取自增字段语法映射
+	autoIncrement, ok := autoIncrementMapping[dbType]
+	if !ok {
+		return fmt.Errorf("unsupported database type for auto increment: %s", dbType)
+	}
+
+	var columns []string
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		// 将字段名称转换为小写并用下划线分隔
+		fieldName := gstr.CaseSnake(field.Name)
+		//如果存在 orm 中的配置 则取orm中配置的字段名
+		ormTag := field.Tag.Get("orm")
+		if ormTag != "" {
+			fieldName = ormTag
+		}
+
+		//使用默认的字段类型映射
+		fieldType, ok := typeMap[field.Type.Kind()]
+		if !ok {
+			return fmt.Errorf("unsupported field type: %s", field.Type.Kind())
+		}
+
+		// 构建列定义
+		columnDef := fmt.Sprintf(" %s %s", m.db.GetCore().QuoteString(fieldName), fieldType)
+
+		// 添加默认选项
+		if field.Type.Kind() == reflect.String {
+			columnDef += " NOT NULL DEFAULT ''"
+		} else if field.Type.Kind() == reflect.Bool {
+			columnDef += " NOT NULL DEFAULT FALSE"
+		}
+
+		columns = append(columns, columnDef)
+	}
+
+	//默认给 id 字段设置为主键,orm标签目前是配置的字段,后续考虑通过配置orm标签扩展主键自增
+	for i, column := range columns {
+		if gstr.Contains(column, "id") {
+			columns[i] = column + " PRIMARY KEY UNIQUE " + autoIncrement
+			break
+		}
+	}
+
+	// 生成创建表的 SQL 语句
+	sql := fmt.Sprintf("CREATE TABLE %s (%s)", m.db.GetCore().QuotePrefixTableName(m.tables), gstr.Join(columns, ", "))
+
+	_, err := m.db.Exec(ctx, sql)
+	if err != nil {
+		return err
+	} else {
+		log.Printf("生成表:%s---成功", m.tables)
+	}
+
+	return nil
+}

--- a/net/ghttp/ghttp.go
+++ b/net/ghttp/ghttp.go
@@ -84,6 +84,14 @@ type (
 		ReqStructFields []gstructs.Field // Request struct fields.
 	}
 
+	// cachedHandlerInfo stores precomputed reflection information for a handler function.
+	cachedHandlerInfo struct {
+		inputType reflect.Type  // inputType represents the type of the input parameter for the handler function.
+		callFunc  reflect.Value // callFunc is the reflect.Value representing the handler function.
+		hasInput  bool          // hasInput indicates whether the handler function has an input parameter.
+		parsePtr  bool          // parsePtr indicates whether the input parameter is a pointer.
+	}
+
 	// HandlerItem is the registered handler for route handling,
 	// including middleware and hook functions.
 	HandlerItem struct {

--- a/net/ghttp/ghttp_reflection_optimized_test.go
+++ b/net/ghttp/ghttp_reflection_optimized_test.go
@@ -26,32 +26,7 @@ type HelloRes struct {
 // 原始的 createRouterFunc 性能测试
 // go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
 func BenchmarkOriginal(b *testing.B) {
-	// 创建一个模拟的 HandlerFunc
-	mockHandler := func(r *Request) {
-		// 实现具体的处理逻辑
-		r.Host = "127.0.0.1"
-	}
-
-	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
-		// 实现具体的处理逻辑
-		return res, nil
-	}
-	// 创建 handlerFuncInfo 结构体
-	funcInfo := handlerFuncInfo{
-		Func:            mockHandler,
-		Type:            reflect.TypeOf(mockControllerHandler),
-		Value:           reflect.ValueOf(mockControllerHandler),
-		IsStrictRoute:   false,
-		ReqStructFields: nil,
-	}
-
-	// 创建一个模拟的请求
-	req := &Request{}
-	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
-	if err != nil {
-		return
-	}
-	req.Request = request
+	req, funcInfo := SetupTest()
 	routerFunc := createRouterFuncOriginal(funcInfo)
 
 	// 执行基准测试
@@ -64,15 +39,24 @@ func BenchmarkOriginal(b *testing.B) {
 // 优化后的 createRouterFunc 性能测试
 // go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
 func BenchmarkOptimized(b *testing.B) {
+	req, funcInfo := SetupTest()
+	routerFunc := createRouterFunc(funcInfo)
+
+	// 执行基准测试
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		routerFunc(req)
+	}
+}
+
+func SetupTest() (*Request, handlerFuncInfo) {
 	// 创建一个模拟的 HandlerFunc
 	mockHandler := func(r *Request) {
-		// 实现具体的处理逻辑
 		r.Host = "127.0.0.1"
 	}
 
 	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
 		// 实现具体的处理逻辑
-		//res.Ip = "127.0.0.1"
 		return res, nil
 	}
 	// 创建 handlerFuncInfo 结构体
@@ -88,14 +72,8 @@ func BenchmarkOptimized(b *testing.B) {
 	req := &Request{}
 	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
 	if err != nil {
-		return
+		return nil, handlerFuncInfo{}
 	}
 	req.Request = request
-	routerFunc := createRouterFunc(funcInfo)
-
-	// 执行基准测试
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		routerFunc(req)
-	}
+	return req, funcInfo
 }

--- a/net/ghttp/ghttp_reflection_optimized_test.go
+++ b/net/ghttp/ghttp_reflection_optimized_test.go
@@ -1,0 +1,101 @@
+package ghttp
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type HelloReq struct {
+	//g.Meta  `path:"/hello" tags:"Hello" method:"post" summary:"You first hello api"`
+	Id      int32  `p:"id"  dc:"Id" json:"id"`
+	Name    string `p:"name" dc:"Id" json:"name"`
+	Address string `p:"address" dc:"Id" json:"address"`
+}
+
+type HelloRes struct {
+	//g.Meta  `mime:"text/html" example:"string"`
+	Id      int32  `json:"id"`
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	Ip      string `json:"ip"`
+}
+
+// 原始的 createRouterFunc 性能测试
+// go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
+func BenchmarkOriginal(b *testing.B) {
+	// 创建一个模拟的 HandlerFunc
+	mockHandler := func(r *Request) {
+		// 实现具体的处理逻辑
+		r.Host = "127.0.0.1"
+	}
+
+	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
+		// 实现具体的处理逻辑
+		return res, nil
+	}
+	// 创建 handlerFuncInfo 结构体
+	funcInfo := handlerFuncInfo{
+		Func:            mockHandler,
+		Type:            reflect.TypeOf(mockControllerHandler),
+		Value:           reflect.ValueOf(mockControllerHandler),
+		IsStrictRoute:   false,
+		ReqStructFields: nil,
+	}
+
+	// 创建一个模拟的请求
+	req := &Request{}
+	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
+	if err != nil {
+		return
+	}
+	req.Request = request
+	routerFunc := createRouterFuncOriginal(funcInfo)
+
+	// 执行基准测试
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		routerFunc(req)
+	}
+}
+
+// 优化后的 createRouterFunc 性能测试
+// go test -bench='Benchmark(Original|Optimized)' -run=none -benchmem -benchtime=2s -count=3
+func BenchmarkOptimized(b *testing.B) {
+	// 创建一个模拟的 HandlerFunc
+	mockHandler := func(r *Request) {
+		// 实现具体的处理逻辑
+		r.Host = "127.0.0.1"
+	}
+
+	mockControllerHandler := func(ctx context.Context, r *HelloReq) (res *HelloRes, err error) {
+		// 实现具体的处理逻辑
+		//res.Ip = "127.0.0.1"
+		return res, nil
+	}
+	// 创建 handlerFuncInfo 结构体
+	funcInfo := handlerFuncInfo{
+		Func:            mockHandler,
+		Type:            reflect.TypeOf(mockControllerHandler),
+		Value:           reflect.ValueOf(mockControllerHandler),
+		IsStrictRoute:   false,
+		ReqStructFields: nil,
+	}
+
+	// 创建一个模拟的请求
+	req := &Request{}
+	request, err := http.NewRequest("GET", "/hello", strings.NewReader("name=bar"))
+	if err != nil {
+		return
+	}
+	req.Request = request
+	routerFunc := createRouterFunc(funcInfo)
+
+	// 执行基准测试
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		routerFunc(req)
+	}
+}

--- a/net/ghttp/ghttp_server_service_handler.go
+++ b/net/ghttp/ghttp_server_service_handler.go
@@ -9,12 +9,13 @@ package ghttp
 import (
 	"bytes"
 	"context"
+	"reflect"
+	"strings"
+
 	"github.com/gogf/gf/v2/errors/gcode"
 	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/os/gstructs"
 	"github.com/gogf/gf/v2/text/gstr"
-	"reflect"
-	"strings"
 )
 
 // BindHandler registers a handler function to server with a given pattern.


### PR DESCRIPTION
平常写数据处理工具很多，给 goframe  orm增加一个 根据结构体生成表的方法，这样减少一些繁琐的创建表 后启动，在 gdb 里面的model上 增加了一个方法AutoMigrate ， 实现类似 gorm 根据实体 创建表的方法

Feature Description: Add the AutoMigrate feature, which automatically creates or updates the database table structure based on the fields of the model struct.
Implementation Method: After defining the model, call the AutoMigrate method, and the framework will automatically detect the struct fields and generate the corresponding database table structure.

**提交前请遵守每个事项，感谢！**
+ PR 标题格式如下：`<类型>[可选 范围]: <描述>` 例如 `fix(os/gtime): fix time zone issue`
  + `<类型>`是必须的，可以是 `fix`、`feat`、`build`、`ci`、`docs`、`style`、`refactor`、`perf`、`test`、`chore` 中的一个
    + fix: 用于修复了一个 bug
    + feat: 用于新增了一个功能
    + build: 用于修改项目构建系统，例如修改依赖库、外部接口或者升级 Node 版本等
    + ci: 用于修改持续集成流程，例如修改 Travis、Jenkins 等工作流配置
    + docs: 用于修改文档，例如修改 README 文件、API 文档等
    + style: 用于修改代码的样式，例如调整缩进、空格、空行等
    + refactor: 用于重构代码，例如修改代码结构、变量名、函数名等但不修改功能逻辑
    + perf: 用于优化性能，例如提升代码的性能、减少内存占用等
    + test: 用于修改测试用例，例如添加、删除、修改代码的测试用例等
    + chore: 用于对非业务性代码进行修改，例如修改构建流程或者工具配置等
  + `<类型>`后在括号中填写受影响的包名或范围，例如 `(os/gtime)`
  + 冒号后使用动词时态 + 短语
  + 冒号后的动词小写
  + 不要有结尾句号
  + 标题尽量保持简短，最好在 76 个字符或更短
  + [参考文档](https://www.conventionalcommits.org/zh-hans/v1.0.0/)
+ 如果有对应的 issue，请在此评论中添加 `Fixes #1234`，如果不是完全修复则添加 `Updates #1234`
+ 应用这些规则后删除所有的说明
