### PR TITLE
feat(database/gdb):  New ValueScan function encapsulation of Model.Value

### DIFF
--- a/contrib/drivers/mssql/mssql_z_unit_model_test.go
+++ b/contrib/drivers/mssql/mssql_z_unit_model_test.go
@@ -461,6 +461,25 @@ func Test_Model_Value(t *testing.T) {
 	})
 }
 
+func Test_Model_ValueScan(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 1).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), false)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 0).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), true)
+	})
+}
+
 func Test_Model_Array(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/contrib/drivers/mysql/mysql_z_unit_model_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_model_test.go
@@ -674,6 +674,25 @@ func Test_Model_Value(t *testing.T) {
 	})
 }
 
+func Test_Model_ValueScan(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 1).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), false)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 0).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), true)
+	})
+}
+
 func Test_Model_Array(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/contrib/drivers/oracle/oracle_z_unit_model_test.go
+++ b/contrib/drivers/oracle/oracle_z_unit_model_test.go
@@ -397,6 +397,25 @@ func Test_Model_Value(t *testing.T) {
 	})
 }
 
+func Test_Model_ValueScan(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("CREATE_TIME").Where("ID", 1).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), false)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("CREATE_TIME").Where("ID", 0).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), true)
+	})
+}
+
 func Test_Model_Array(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
+++ b/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
@@ -805,6 +805,25 @@ func Test_Model_Value(t *testing.T) {
 	})
 }
 
+func Test_Model_ValueScan(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 1).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), false)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 0).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), true)
+	})
+}
+
 func Test_Model_Array(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/contrib/drivers/sqlitecgo/sqlitecgo_z_unit_model_test.go
+++ b/contrib/drivers/sqlitecgo/sqlitecgo_z_unit_model_test.go
@@ -764,6 +764,25 @@ func Test_Model_Value(t *testing.T) {
 	})
 }
 
+func Test_Model_ValueScan(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 1).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), false)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		var gtimePtr *gtime.Time
+		err := db.Model(table).Fields("create_time").Where("id", 0).ValueScan(&gtimePtr)
+		t.AssertNil(err)
+		t.Assert(gtimePtr.IsZero(), true)
+	})
+}
+
 func Test_Model_Array(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/database/gdb/gdb_model_select.go
+++ b/database/gdb/gdb_model_select.go
@@ -377,6 +377,15 @@ func (m *Model) ScanList(structSlicePointer interface{}, bindToAttrName string, 
 	})
 }
 
+// ValueScan Encapsulation of Model.Value, support converting the result of a single field to a specified pointer
+func (m *Model) ValueScan(pointer interface{}, fieldsAndWhere ...interface{}) (err error) {
+	val, err := m.Value(fieldsAndWhere...)
+	if err != nil {
+		return err
+	}
+	return val.Scan(pointer)
+}
+
 // Value retrieves a specified record value from table and returns the result as interface type.
 // It returns nil if there's no record found with the given conditions from table.
 //


### PR DESCRIPTION
ValueScan Encapsulation of Model.Value, support converting the result of a single field to a specified pointer。
```
var gtimePtr *gtime.Time
err := db.Model("user").Fields("create_time").Where("id", 1).ValueScan(&gtimePtr)
```