### PR TITLE
docs(database/gdb): remove misleading comment in Order method

### DIFF
--- a/database/gdb/gdb_model_order_group.go
+++ b/database/gdb/gdb_model_order_group.go
@@ -17,7 +17,6 @@ import (
 //
 // Example:
 // Order("id desc")
-// Order("id", "desc")
 // Order("id desc,name asc")
 // Order("id desc", "name asc")
 // Order("id desc").Order("name asc")


### PR DESCRIPTION
remove misleading comment in Order method