### PR TITLE
fix(utils/gvalid): missing pkg path for enums pointer

### DIFF
--- a/util/gvalid/gvalid_z_unit_feature_rule_test.go
+++ b/util/gvalid/gvalid_z_unit_feature_rule_test.go
@@ -1577,6 +1577,10 @@ func Test_Enums(t *testing.T) {
 			Id    int
 			Enums EnumsTest `v:"enums"`
 		}
+		type PointerParams struct {
+			Id    int
+			Enums *EnumsTest `v:"enums"`
+		}
 		type SliceParams struct {
 			Id    int
 			Enums []EnumsTest `v:"foreach|enums"`
@@ -1600,6 +1604,13 @@ func Test_Enums(t *testing.T) {
 			Enums: "c",
 		}).Run(ctx)
 		t.Assert(err, "The Enums value `c` should be in enums of: [\"a\",\"b\"]")
+
+		var b EnumsTest = "b"
+		err = g.Validator().Data(&PointerParams{
+			Id:    1,
+			Enums: &b,
+		}).Run(ctx)
+		t.AssertNil(err)
 
 		err = g.Validator().Data(&SliceParams{
 			Id:    1,

--- a/util/gvalid/internal/builtin/builtin_enums.go
+++ b/util/gvalid/internal/builtin/builtin_enums.go
@@ -47,8 +47,9 @@ func (r RuleEnums) Run(in RunInput) error {
 	var (
 		pkgPath  = in.ValueType.PkgPath()
 		typeName = in.ValueType.Name()
+		typeKind = in.ValueType.Kind()
 	)
-	if in.ValueType.Kind() == reflect.Slice {
+	if typeKind == reflect.Slice || typeKind == reflect.Ptr {
 		pkgPath = in.ValueType.Elem().PkgPath()
 		typeName = in.ValueType.Elem().Name()
 	}


### PR DESCRIPTION
Fix the error when defining API parameter types using enum pointer