### PR TITLE
refactor(net/ghttp): trim referer -> AllowOrigin

### DIFF
--- a/net/ghttp/ghttp_response_cors.go
+++ b/net/ghttp/ghttp_response_cors.go
@@ -63,12 +63,6 @@ func (r *Response) DefaultCORSOptions() CORSOptions {
 	// Allow all anywhere origin in default.
 	if origin := r.Request.Header.Get("Origin"); origin != "" {
 		options.AllowOrigin = origin
-	} else if referer := r.Request.Referer(); referer != "" {
-		if p := gstr.PosR(referer, "/", 6); p != -1 {
-			options.AllowOrigin = referer[:p]
-		} else {
-			options.AllowOrigin = referer
-		}
 	}
 	return options
 }


### PR DESCRIPTION
> Broadly speaking, user agents add the Origin request header to:[^1]
>
> - [cross origin](https://developer.mozilla.org/en-US/docs/Glossary/CORS) requests.
> - [same-origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) requests except for [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET) or [HEAD](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/HEAD) requests (i.e., they are added to same-origin [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST), [OPTIONS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS), [PUT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT), [PATCH](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH), and [DELETE](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE) requests).

According to the documentation, in cross origin requests, the `Origin` request header is usually carried, so in the code, it is redundant to obtain the `Origin` based on the `Referer`.

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin#description