### PR TITLE
fix(net/ghttp): get origin through referer

### DIFF
--- a/net/ghttp/ghttp_response_cors.go
+++ b/net/ghttp/ghttp_response_cors.go
@@ -64,8 +64,8 @@ func (r *Response) DefaultCORSOptions() CORSOptions {
 	if origin := r.Request.Header.Get("Origin"); origin != "" {
 		options.AllowOrigin = origin
 	} else if referer := r.Request.Referer(); referer != "" {
-		if p := gstr.PosR(referer, "/", 6); p != -1 {
-			options.AllowOrigin = referer[:p]
+		if ref, err := url.Parse(referer); err == nil {
+			options.AllowOrigin = ref.Scheme + "://" + ref.Host
 		} else {
 			options.AllowOrigin = referer
 		}


### PR DESCRIPTION
https://github.com/gogf/gf/pull/3986#issuecomment-2507522224

> Example 2 has a problem.
>
> ```go
>referer := "https://example.com/path/to/page.html"
> if p := gstr.PosR(referer, "/", 6); p != -1 {
> 	fmt.Println(referer[:p]) //https://example.com/path/to
> } else {
> 	fmt.Println(referer)
> }
> ```