### PR TITLE
fix(util/gpage): code scanning alert no. 9: Potentially unsafe quoting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,17 +1,8 @@
-# Tencent is pleased to support the open source community by making Polaris available.
+# Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
 #
-# Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
-#
-# Licensed under the BSD 3-Clause License (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# https://opensource.org/licenses/BSD-3-Clause
-#
-# Unless required by applicable law or agreed to in writing, software distributed
-# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations under the License.
+# This Source Code Form is subject to the terms of the MIT License.
+# If a copy of the MIT was not distributed with this file,
+# You can obtain one at https://github.com/gogf/gf.
 
 name: GolangCI-Lint
 on:

--- a/util/gpage/gpage.go
+++ b/util/gpage/gpage.go
@@ -10,6 +10,7 @@ package gpage
 import (
 	"fmt"
 	"math"
+	"html"
 
 	"github.com/gogf/gf/v2/text/gstr"
 	"github.com/gogf/gf/v2/util/gconv"
@@ -215,12 +216,12 @@ func (p *Page) GetLink(page int, text, title string) string {
 	if len(p.AjaxActionName) > 0 {
 		return fmt.Sprintf(
 			`<a class="%s" href="javascript:%s('%s')" title="%s">%s</a>`,
-			p.LinkStyle, p.AjaxActionName, p.GetUrl(page), title, text,
+			p.LinkStyle, p.AjaxActionName, p.GetUrl(page), html.EscapeString(title), text,
 		)
 	} else {
 		return fmt.Sprintf(
 			`<a class="%s" href="%s" title="%s">%s</a>`,
-			p.LinkStyle, p.GetUrl(page), title, text,
+			p.LinkStyle, p.GetUrl(page), html.EscapeString(title), text,
 		)
 	}
 }

--- a/util/gpage/gpage.go
+++ b/util/gpage/gpage.go
@@ -9,8 +9,8 @@ package gpage
 
 import (
 	"fmt"
-	"math"
 	"html"
+	"math"
 
 	"github.com/gogf/gf/v2/text/gstr"
 	"github.com/gogf/gf/v2/util/gconv"


### PR DESCRIPTION
Fixes [https://github.com/gogf/gf/security/code-scanning/9](https://github.com/gogf/gf/security/code-scanning/9)

To fix the problem, we need to ensure that the `title` parameter is properly escaped before being embedded in the HTML attribute. The best way to fix this is to use a proper HTML escaping function that will convert special characters to their corresponding HTML entities. This will prevent any special characters in the `title` from breaking the HTML structure.

We will use the `html.EscapeString` function from the `html` package to escape the `title` parameter. This function converts special characters like `<`, `>`, `&`, and `"` to their corresponding HTML entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
