### PR TITLE
fix(util/gutil): code scanning alert no. 17: Potentially unsafe quoting

### DIFF
--- a/util/gutil/gutil_dump.go
+++ b/util/gutil/gutil_dump.go
@@ -465,6 +465,7 @@ func doDumpDefault(in doDumpInternalInput) {
 func addSlashesForString(s string) string {
 	return gstr.ReplaceByMap(s, map[string]string{
 		`"`:  `\"`,
+		`'`:  `\'`,
 		"\r": `\r`,
 		"\t": `\t`,
 		"\n": `\n`,


### PR DESCRIPTION
Fixes [https://github.com/gogf/gf/security/code-scanning/17](https://github.com/gogf/gf/security/code-scanning/17)

To fix the problem, we need to ensure that single quotes are also escaped in the `addSlashesForString` function. This will prevent any potential injection vulnerabilities when the resulting string is embedded in a context that uses single quotes for quoting.

- Modify the `addSlashesForString` function to escape single quotes.
- Ensure that the escaping mechanism is consistent with the context in which the string will be used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
