### PR TITLE
chore: add example for openapi/swagger authentication

### DIFF
--- a/example/httpserver/swagger/main.go
+++ b/example/httpserver/swagger/main.go
@@ -45,5 +45,14 @@ func main() {
 			new(Hello),
 		)
 	})
+	// if api.json requires authentication, add openApiBasicAuth handler
+	s.BindHookHandler(s.GetOpenApiPath(), ghttp.HookBeforeServe, openApiBasicAuth)
 	s.Run()
+}
+
+func openApiBasicAuth(r *ghttp.Request) {
+	if !r.BasicAuth("OpenApiAuthUserName", "OpenApiAuthPass", "Restricted") {
+		r.ExitAll()
+		return
+	}
 }

--- a/net/ghttp/ghttp_server_config_api.go
+++ b/net/ghttp/ghttp_server_config_api.go
@@ -21,3 +21,8 @@ func (s *Server) SetSwaggerUITemplate(swaggerUITemplate string) {
 func (s *Server) SetOpenApiPath(path string) {
 	s.config.OpenApiPath = path
 }
+
+// GetOpenApiPath get the OpenApiPath for server.
+func (s *Server) GetOpenApiPath() string {
+	return s.config.OpenApiPath
+}

--- a/net/ghttp/ghttp_server_config_api.go
+++ b/net/ghttp/ghttp_server_config_api.go
@@ -22,7 +22,7 @@ func (s *Server) SetOpenApiPath(path string) {
 	s.config.OpenApiPath = path
 }
 
-// GetOpenApiPath get the OpenApiPath for server.
+// GetOpenApiPath returns the configuration of `OpenApiPath` of server.
 func (s *Server) GetOpenApiPath() string {
 	return s.config.OpenApiPath
 }


### PR DESCRIPTION
#3898 