### PR TITLE
Fix code scanning alert no. 9: Reflected cross-site scripting

### DIFF
--- a/net/ghttp/ghttp_response_view.go
+++ b/net/ghttp/ghttp_response_view.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogf/gf/v2/util/gconv"
 	"github.com/gogf/gf/v2/util/gmode"
 	"github.com/gogf/gf/v2/util/gutil"
+	"html"
 )
 
 // WriteTpl parses and responses given template file.
@@ -26,7 +27,7 @@ func (r *Response) WriteTpl(tpl string, params ...gview.Params) error {
 		}
 		return err
 	}
-	r.Write(b)
+	r.Write(html.EscapeString(b))
 	return nil
 }
 
@@ -41,7 +42,7 @@ func (r *Response) WriteTplDefault(params ...gview.Params) error {
 		}
 		return err
 	}
-	r.Write(b)
+	r.Write(html.EscapeString(b))
 	return nil
 }
 
@@ -56,7 +57,7 @@ func (r *Response) WriteTplContent(content string, params ...gview.Params) error
 		}
 		return err
 	}
-	r.Write(b)
+	r.Write(html.EscapeString(b))
 	return nil
 }
 


### PR DESCRIPTION
Fixes [https://github.com/houseme/gf/security/code-scanning/9](https://github.com/houseme/gf/security/code-scanning/9)

To fix the reflected cross-site scripting vulnerability, we need to ensure that any user-provided data included in the HTTP response is properly escaped. This can be achieved by using the `html.EscapeString` function from the `html` package to escape user-provided data before writing it to the response.

- Modify the `WriteTpl`, `WriteTplDefault`, and `WriteTplContent` methods in `net/ghttp/ghttp_response_view.go` to escape the parsed template content before writing it to the response.
- Import the `html` package to use the `html.EscapeString` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
