### PR TITLE
perf(contrib/drivers/pgsql): improve conversion performace for slice string

### DIFF
--- a/contrib/drivers/pgsql/pgsql_convert.go
+++ b/contrib/drivers/pgsql/pgsql_convert.go
@@ -128,7 +128,7 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 		if err := result.Scan(fieldValue); err != nil {
 			return nil, err
 		}
-		return result, nil
+		return []string(result), nil
 
 	default:
 		return d.Core.ConvertValueForLocal(ctx, fieldType, fieldValue)


### PR DESCRIPTION
enhance #4000，One line change, Return basic types instead of pq.StringArray to reduce one reflection assignment when calling gconv.Strings in doStruct, minimizing performance overhead.


