### PR TITLE
fix(database/gdb): regular expression pattern for link configuration to be compitable with tidbcloud

### DIFF
--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -708,7 +708,7 @@ const (
 	ctxKeyCatchSQL            gctx.StrKey = `CtxKeyCatchSQL`
 	ctxKeyInternalProducedSQL gctx.StrKey = `CtxKeyInternalProducedSQL`
 
-	linkPattern            = `(\w+):([\w\-\$]*):(.*?)@(\w+?)\((.+?)\)/{0,1}([^\?]*)\?{0,1}(.*)`
+	linkPattern            = `^(\w+):(.*?):(.*?)@(\w+?)\((.+?)\)/{0,1}([^\?]*)\?{0,1}(.*?)$`
 	linkPatternDescription = `type:username:password@protocol(host:port)/dbname?param1=value1&...&paramN=valueN`
 )
 

--- a/database/gdb/gdb_z_mysql_internal_test.go
+++ b/database/gdb/gdb_z_mysql_internal_test.go
@@ -295,6 +295,40 @@ func Test_parseConfigNodeLink_WithType(t *testing.T) {
 		t.Assert(newNode.Charset, `utf8`)
 		t.Assert(newNode.Protocol, `unix`)
 	})
+	// https://github.com/gogf/gf/issues/4059
+	gtest.C(t, func(t *gtest.T) {
+		node := &ConfigNode{
+			Link: "tidb:2hcmRccccxxx9Fizz.root:wP3xxxxPIDc@tcp(xxxx.tidbcloud.com:4000)/db_name?tls=true",
+		}
+		newNode, err := parseConfigNodeLink(node)
+		t.AssertNil(err)
+		t.Assert(newNode.Type, `tidb`)
+		t.Assert(newNode.User, `2hcmRccccxxx9Fizz.root`)
+		t.Assert(newNode.Pass, `wP3xxxxPIDc`)
+		t.Assert(newNode.Host, `xxxx.tidbcloud.com`)
+		t.Assert(newNode.Port, `4000`)
+		t.Assert(newNode.Name, `db_name`)
+		t.Assert(newNode.Extra, `tls=true`)
+		t.Assert(newNode.Charset, `utf8`)
+		t.Assert(newNode.Protocol, `tcp`)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		node := &ConfigNode{
+			Type: "tidb",
+			Link: "2hcmRccccxxx9Fizz.root:wP3xxxxPIDc@tcp(xxxx.tidbcloud.com:4000)/db_name?tls=true",
+		}
+		newNode, err := parseConfigNodeLink(node)
+		t.AssertNil(err)
+		t.Assert(newNode.Type, `tidb`)
+		t.Assert(newNode.User, `2hcmRccccxxx9Fizz.root`)
+		t.Assert(newNode.Pass, `wP3xxxxPIDc`)
+		t.Assert(newNode.Host, `xxxx.tidbcloud.com`)
+		t.Assert(newNode.Port, `4000`)
+		t.Assert(newNode.Name, `db_name`)
+		t.Assert(newNode.Extra, `tls=true`)
+		t.Assert(newNode.Charset, `utf8`)
+		t.Assert(newNode.Protocol, `tcp`)
+	})
 }
 
 func Test_Func_doQuoteWord(t *testing.T) {


### PR DESCRIPTION
Fixes #4059