### PR TITLE
feat(os/gcmd): add default value display for an argument

### DIFF
--- a/os/gcmd/gcmd_command.go
+++ b/os/gcmd/gcmd_command.go
@@ -46,11 +46,12 @@ type FuncWithValue func(ctx context.Context, parser *Parser) (out interface{}, e
 
 // Argument is the command value that are used by certain command.
 type Argument struct {
-	Name   string // Option name.
-	Short  string // Option short.
-	Brief  string // Brief info about this Option, which is used in help info.
-	IsArg  bool   // IsArg marks this argument taking value from command line argument instead of option.
-	Orphan bool   // Whether this Option having or having no value bound to it.
+	Name    string // Option name.
+	Short   string // Option short.
+	Default string // Option default value.
+	Brief   string // Brief info about this Option, which is used in help info.
+	IsArg   bool   // IsArg marks this argument taking value from command line argument instead of option.
+	Orphan  bool   // Whether this Option having or having no value bound to it.
 }
 
 var (

--- a/os/gcmd/gcmd_command_help.go
+++ b/os/gcmd/gcmd_command_help.go
@@ -156,6 +156,9 @@ func (c *Command) PrintTo(writer io.Writer) {
 				spaceLength    = maxSpaceLength - len(nameStr)
 				wordwrapPrefix = gstr.Repeat(" ", len(prefix+nameStr)+spaceLength+4)
 			)
+			if arg.Default != "" {
+				brief = fmt.Sprintf("%s (default: \"%s\")", brief, arg.Default)
+			}
 			c.printLineBrief(printLineBriefInput{
 				Buffer:         buffer,
 				Name:           nameStr,

--- a/os/gcmd/gcmd_command_object.go
+++ b/os/gcmd/gcmd_command_object.go
@@ -378,6 +378,9 @@ func newArgumentsFromInput(object interface{}) (args []Argument, err error) {
 		if arg.Brief == "" {
 			arg.Brief = field.TagDescription()
 		}
+		if arg.Default == "" {
+			arg.Default = field.TagDefault()
+		}
 		if v, ok := metaData[gtag.Arg]; ok {
 			arg.IsArg = gconv.Bool(v)
 		}


### PR DESCRIPTION
the effect is similar to:
old: 
```
    -p, --path       output binary directory path, default is './bin'
```

new:
```
    -p, --path       output binary directory path, default is './bin' (default: "./bin")
```