### PR TITLE
fix(net/ghttp): `MiddlewareHandlerResponse` writes additional information after custom response wrote

### DIFF
--- a/net/ghttp/ghttp_middleware_handler_response.go
+++ b/net/ghttp/ghttp_middleware_handler_response.go
@@ -37,7 +37,7 @@ func MiddlewareHandlerResponse(r *Request) {
 	r.Middleware.Next()
 
 	// There's custom buffer content, it then exits current handler.
-	if r.Response.BufferLength() > 0 {
+	if r.Response.BufferLength() > 0 || r.Response.Writer.BytesWritten() > 0 {
 		return
 	}
 

--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -9,6 +9,7 @@ package ghttp_test
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -628,5 +629,30 @@ func Test_Issue4047(t *testing.T) {
 		})
 		t.AssertNil(err)
 		t.Assert(s.Logger(), nil)
+	})
+}
+
+// https://github.com/gogf/gf/issues/4108
+func Test_Issue4108(t *testing.T) {
+	s := g.Server(guid.S())
+	s.Group("/", func(group *ghttp.RouterGroup) {
+		group.Middleware(ghttp.MiddlewareHandlerResponse)
+		group.GET("/", func(r *ghttp.Request) {
+			r.Response.Writer.Write([]byte("hello"))
+		})
+	})
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
+	time.Sleep(100 * time.Millisecond)
+
+	gtest.C(t, func(t *gtest.T) {
+		client := g.Client()
+		client.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+
+		rsp, err := client.Get(ctx, "/")
+		t.AssertNil(err)
+		t.Assert(rsp.StatusCode, http.StatusOK)
+		t.Assert(rsp.ReadAllString(), "hello")
 	})
 }


### PR DESCRIPTION
fix https://github.com/gogf/gf/issues/4108