### PR TITLE
fix(contrib/config/polaris): it only supports json format for configuration contents, add more content formats support

### DIFF
--- a/contrib/config/polaris/polaris.go
+++ b/contrib/config/polaris/polaris.go
@@ -147,7 +147,7 @@ func (c *Client) doUpdate(ctx context.Context) (err error) {
 		return gerror.New("config file is empty")
 	}
 	var j *gjson.Json
-	if j, err = gjson.DecodeToJson([]byte(c.client.GetContent())); err != nil {
+	if j, err = gjson.LoadContent([]byte(c.client.GetContent())); err != nil {
 		return gerror.Wrap(err, `parse config map item from polaris failed`)
 	}
 	c.value.Set(j)


### PR DESCRIPTION
polaris conf update use gjson.LoadContent not gjson.DecodeToJson to support multiple format conf content.

Fixs #4104 4104
