### PR TITLE
feat(os/gtime): SetStringLayout

### DIFF
--- a/os/gtime/gtime_time_wrapper.go
+++ b/os/gtime/gtime_time_wrapper.go
@@ -7,8 +7,35 @@
 package gtime
 
 import (
+	"sync"
 	"time"
 )
+
+var (
+	setStringLayoutMu sync.Mutex
+	setStringLayout   = "2006-01-02 15:04:05"
+)
+
+// SetStringLayout sets the default string layout for function String.
+// The default string layout is "2006-01-02 15:04:05".
+// It's used for overwriting the default string layout for time.Time.String.
+//
+// You can set it to time.RFC3339 for example.
+func SetStringLayout(layout string) {
+	setStringLayoutMu.Lock()
+	defer setStringLayoutMu.Unlock()
+	setStringLayout = layout
+}
+
+// SetStringISO8601 sets the default string layout to ISO8601 for function String.
+func SetStringISO8601() {
+	SetStringLayout("2006-01-02T15:04:05-07:00")
+}
+
+// SetStringRFC822 sets the default string layout to RFC822 for function String.
+func SetStringRFC822() {
+	SetStringLayout("Mon, 02 Jan 06 15:04 MST")
+}
 
 // wrapper is a wrapper for stdlib struct time.Time.
 // It's used for overwriting some functions of time.Time, for example: String.
@@ -25,5 +52,5 @@ func (t wrapper) String() string {
 		// Only time.
 		return t.Format("15:04:05")
 	}
-	return t.Format("2006-01-02 15:04:05")
+	return t.Format(setStringLayout)
 }

--- a/os/gtime/gtime_z_example_wrapper_test.go
+++ b/os/gtime/gtime_z_example_wrapper_test.go
@@ -1,0 +1,31 @@
+package gtime_test
+
+import (
+	"fmt"
+	"github.com/gogf/gf/v2/os/gtime"
+	"time"
+)
+
+func ExampleSetStringLayout() {
+	gtime.SetStringLayout(time.RFC3339)
+	fmt.Println(gtime.New("2025-01-21 14:08:05").String())
+
+	// Output:
+	// 2025-01-21T14:08:05+08:00
+}
+
+func ExampleSetStringISO8601() {
+	gtime.SetStringISO8601()
+	fmt.Println(gtime.New("2025-01-21 14:10:12").String())
+
+	// Output:
+	// 2025-01-21T14:10:12+08:00
+}
+
+func ExampleSetStringRFC822() {
+	gtime.SetStringRFC822()
+	fmt.Println(gtime.New("2025-01-21 14:11:32").String())
+
+	// Output:
+	// Tue, 21 Jan 25 14:11 CST
+}

--- a/os/gtime/gtime_z_example_wrapper_test.go
+++ b/os/gtime/gtime_z_example_wrapper_test.go
@@ -2,8 +2,9 @@ package gtime_test
 
 import (
 	"fmt"
-	"github.com/gogf/gf/v2/os/gtime"
 	"time"
+
+	"github.com/gogf/gf/v2/os/gtime"
 )
 
 func ExampleSetStringLayout() {


### PR DESCRIPTION
```go
func ExampleSetStringLayout() {
	gtime.SetStringLayout(time.RFC3339)
	fmt.Println(gtime.New("2025-01-21 14:08:05").String())

	// Output:
	// 2025-01-21T14:08:05+08:00
}

func ExampleSetStringISO8601() {
	gtime.SetStringISO8601()
	fmt.Println(gtime.New("2025-01-21 14:10:12").String())

	// Output:
	// 2025-01-21T14:10:12+08:00
}

func ExampleSetStringRFC822() {
	gtime.SetStringRFC822()
	fmt.Println(gtime.New("2025-01-21 14:11:32").String())

	// Output:
	// Tue, 21 Jan 25 14:11 CST
}
```