### PR TITLE
feat(test/gtest): add map type support for `AssertNI/AssertIN`

### DIFF
--- a/test/gtest/gtest_util.go
+++ b/test/gtest/gtest_util.go
@@ -220,7 +220,6 @@ func AssertLE(value, expect interface{}) {
 // AssertIN checks `value` is IN `expect`.
 // The `expect` should be a slice,
 // but the `value` can be a slice or a basic type variable.
-// TODO map support.
 // TODO: gconv.Strings(0) is not [0]
 func AssertIN(value, expect interface{}) {
 	var (
@@ -268,7 +267,6 @@ func AssertIN(value, expect interface{}) {
 // AssertNI checks `value` is NOT IN `expect`.
 // The `expect` should be a slice,
 // but the `value` can be a slice or a basic type variable.
-// TODO map support.
 func AssertNI(value, expect interface{}) {
 	var (
 		passed     = true
@@ -295,6 +293,14 @@ func AssertNI(value, expect interface{}) {
 			expectStr = gconv.String(expect)
 		)
 		passed = !gstr.Contains(expectStr, valueStr)
+	case reflect.Map:
+		expectMap := gconv.Map(expect)
+		for _, v1 := range gconv.Strings(value) {
+			if _, exists := expectMap[v1]; exists {
+				passed = false
+				break
+			}
+		}
 	default:
 		panic(fmt.Sprintf(`[ASSERT] INVALID EXPECT VALUE TYPE: %v`, expectKind))
 	}

--- a/test/gtest/gtest_util.go
+++ b/test/gtest/gtest_util.go
@@ -249,6 +249,14 @@ func AssertIN(value, expect interface{}) {
 			expectStr = gconv.String(expect)
 		)
 		passed = gstr.Contains(expectStr, valueStr)
+	case reflect.Map:
+		expectMap := gconv.Map(expect)
+		for _, v1 := range gconv.Strings(value) {
+			if _, exists := expectMap[v1]; !exists {
+				passed = false
+				break
+			}
+		}
 	default:
 		panic(fmt.Sprintf(`[ASSERT] INVALID EXPECT VALUE TYPE: %v`, expectKind))
 	}

--- a/test/gtest/gtest_z_unit_test.go
+++ b/test/gtest/gtest_z_unit_test.go
@@ -325,12 +325,14 @@ func TestAssertIN(t *testing.T) {
 func TestAssertIN_Map(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.AssertIN("k1", map[string]string{"k1": "v1", "k2": "v2"})
+		t.AssertIN(1, map[int64]string{1: "v1", 2: "v2"})
 	})
 }
 
 func TestAssertNI_Map(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.AssertNI("k3", map[string]string{"k1": "v1", "k2": "v2"})
+		t.AssertNI(3, map[int64]string{1: "v1", 2: "v2"})
 	})
 }
 

--- a/test/gtest/gtest_z_unit_test.go
+++ b/test/gtest/gtest_z_unit_test.go
@@ -322,6 +322,18 @@ func TestAssertIN(t *testing.T) {
 	})
 }
 
+func TestAssertIN_Map(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		t.AssertIN("k1", map[string]string{"k1": "v1", "k2": "v2"})
+	})
+}
+
+func TestAssertNI_Map(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		t.AssertNI("k3", map[string]string{"k1": "v1", "k2": "v2"})
+	})
+}
+
 func TestAssertNI(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.AssertNI("d", []string{"a", "b", "c"})

--- a/test/gtest/gtest_z_unit_test.go
+++ b/test/gtest/gtest_z_unit_test.go
@@ -326,6 +326,7 @@ func TestAssertIN_Map(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.AssertIN("k1", map[string]string{"k1": "v1", "k2": "v2"})
 		t.AssertIN(1, map[int64]string{1: "v1", 2: "v2"})
+		t.AssertIN([]string{"k1", "k2"}, map[string]string{"k1": "v1", "k2": "v2"})
 	})
 }
 
@@ -333,6 +334,7 @@ func TestAssertNI_Map(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		t.AssertNI("k3", map[string]string{"k1": "v1", "k2": "v2"})
 		t.AssertNI(3, map[int64]string{1: "v1", 2: "v2"})
+		t.AssertNI([]string{"k3", "k4"}, map[string]string{"k1": "v1", "k2": "v2"})
 	})
 }
 


### PR DESCRIPTION
AssertNI/AssertIN func support map type
```go
func TestAssertIN_Map(t *testing.T) {
	gtest.C(t, func(t *gtest.T) {
		t.AssertIN("k1", map[string]string{"k1": "v1", "k2": "v2"})
		t.AssertIN(1, map[int64]string{1: "v1", 2: "v2"})
		t.AssertIN([]string{"k1", "k2"}, map[string]string{"k1": "v1", "k2": "v2"})
	})
}

func TestAssertNI_Map(t *testing.T) {
	gtest.C(t, func(t *gtest.T) {
		t.AssertNI("k3", map[string]string{"k1": "v1", "k2": "v2"})
		t.AssertNI(3, map[int64]string{1: "v1", 2: "v2"})
		t.AssertNI([]string{"k3", "k4"}, map[string]string{"k1": "v1", "k2": "v2"})
	})
}
``` 