### PR TITLE
chore(util/gvalid): using `64` instead of `10` bitsize parameter for function `strconv.ParseFloat` although it treats `10` as `64` internally

### DIFF
--- a/util/gconv/gconv_z_unit_scan_test.go
+++ b/util/gconv/gconv_z_unit_scan_test.go
@@ -126,7 +126,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(maps, &mss)
 			t.AssertNil(err)
 			t.Assert(len(mss), len(maps))
-			for k, _ := range maps {
+			for k := range maps {
 				t.Assert(maps[k]["Name"], mss[k]["Name"])
 				t.Assert(maps[k]["Place"], mss[k]["Place"])
 			}
@@ -135,7 +135,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(maps, &msa)
 			t.AssertNil(err)
 			t.Assert(len(msa), len(maps))
-			for k, _ := range maps {
+			for k := range maps {
 				t.Assert(maps[k]["Name"], msa[k]["Name"])
 				t.Assert(maps[k]["Place"], msa[k]["Place"])
 			}
@@ -144,7 +144,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(maps, &maa)
 			t.AssertNil(err)
 			t.Assert(len(maa), len(maps))
-			for k, _ := range maps {
+			for k := range maps {
 				t.Assert(maps[k]["Name"], maa[k]["Name"])
 				t.Assert(maps[k]["Place"], maa[k]["Place"])
 			}
@@ -153,7 +153,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(maps, &ss)
 			t.AssertNil(err)
 			t.Assert(len(ss), len(maps))
-			for k, _ := range maps {
+			for k := range maps {
 				t.Assert(maps[k]["Name"], ss[k].Name)
 				t.Assert(maps[k]["Place"], ss[k].Place)
 			}
@@ -162,7 +162,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(maps, &ssp)
 			t.AssertNil(err)
 			t.Assert(len(ssp), len(maps))
-			for k, _ := range maps {
+			for k := range maps {
 				t.Assert(maps[k]["Name"], ssp[k].Name)
 				t.Assert(maps[k]["Place"], ssp[k].Place)
 			}
@@ -219,7 +219,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(structs, &mss)
 			t.AssertNil(err)
 			t.Assert(len(mss), len(structs))
-			for k, _ := range structs {
+			for k := range structs {
 				t.Assert(structs[k].Name, mss[k]["Name"])
 				t.Assert(structs[k].Place, mss[k]["Place"])
 			}
@@ -228,7 +228,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(structs, &msa)
 			t.AssertNil(err)
 			t.Assert(len(msa), len(structs))
-			for k, _ := range structs {
+			for k := range structs {
 				t.Assert(structs[k].Name, msa[k]["Name"])
 				t.Assert(structs[k].Place, msa[k]["Place"])
 			}
@@ -237,7 +237,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(structs, &maa)
 			t.AssertNil(err)
 			t.Assert(len(maa), len(structs))
-			for k, _ := range structs {
+			for k := range structs {
 				t.Assert(structs[k].Name, maa[k]["Name"])
 				t.Assert(structs[k].Place, maa[k]["Place"])
 			}
@@ -246,7 +246,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(structs, &ss)
 			t.AssertNil(err)
 			t.Assert(len(ss), len(structs))
-			for k, _ := range structs {
+			for k := range structs {
 				t.Assert(structs[k].Name, ss[k].Name)
 				t.Assert(structs[k].Place, ss[k].Place)
 			}
@@ -255,7 +255,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(structs, &ssp)
 			t.AssertNil(err)
 			t.Assert(len(ssp), len(structs))
-			for k, _ := range structs {
+			for k := range structs {
 				t.Assert(structs[k].Name, ssp[k].Name)
 				t.Assert(structs[k].Place, ssp[k].Place)
 			}
@@ -312,7 +312,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(jsons, &mss)
 			t.AssertNil(err)
 			t.Assert(len(mss), 2)
-			for k, _ := range mss {
+			for k := range mss {
 				t.Assert("Mars", mss[k]["Name"])
 				t.Assert("奥林帕斯山", mss[k]["Place"])
 			}
@@ -321,7 +321,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(jsons, &msa)
 			t.AssertNil(err)
 			t.Assert(len(msa), 2)
-			for k, _ := range msa {
+			for k := range msa {
 				t.Assert("Mars", msa[k]["Name"])
 				t.Assert("奥林帕斯山", msa[k]["Place"])
 			}
@@ -336,7 +336,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(jsons, &ss)
 			t.AssertNil(err)
 			t.Assert(len(ss), 2)
-			for k, _ := range ss {
+			for k := range ss {
 				t.Assert("Mars", ss[k].Name)
 				t.Assert("奥林帕斯山", ss[k].Place)
 			}
@@ -345,7 +345,7 @@ func TestScan(t *testing.T) {
 			err = gconv.Scan(jsons, &ssp)
 			t.AssertNil(err)
 			t.Assert(len(ssp), 2)
-			for k, _ := range ssp {
+			for k := range ssp {
 				t.Assert("Mars", ssp[k].Name)
 				t.Assert("奥林帕斯山", ssp[k].Place)
 			}

--- a/util/gvalid/internal/builtin/builtin_between.go
+++ b/util/gvalid/internal/builtin/builtin_between.go
@@ -39,16 +39,16 @@ func (r RuleBetween) Run(in RunInput) error {
 		max   = float64(0)
 	)
 	if len(array) > 0 {
-		if v, err := strconv.ParseFloat(strings.TrimSpace(array[0]), 10); err == nil {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(array[0]), 64); err == nil {
 			min = v
 		}
 	}
 	if len(array) > 1 {
-		if v, err := strconv.ParseFloat(strings.TrimSpace(array[1]), 10); err == nil {
+		if v, err := strconv.ParseFloat(strings.TrimSpace(array[1]), 64); err == nil {
 			max = v
 		}
 	}
-	valueF, err := strconv.ParseFloat(in.Value.String(), 10)
+	valueF, err := strconv.ParseFloat(in.Value.String(), 64)
 	if valueF < min || valueF > max || err != nil {
 		return errors.New(gstr.ReplaceByMap(in.Message, map[string]string{
 			"{min}": strconv.FormatFloat(min, 'f', -1, 64),

--- a/util/gvalid/internal/builtin/builtin_float.go
+++ b/util/gvalid/internal/builtin/builtin_float.go
@@ -30,7 +30,7 @@ func (r RuleFloat) Message() string {
 }
 
 func (r RuleFloat) Run(in RunInput) error {
-	if _, err := strconv.ParseFloat(in.Value.String(), 10); err == nil {
+	if _, err := strconv.ParseFloat(in.Value.String(), 64); err == nil {
 		return nil
 	}
 	return errors.New(in.Message)

--- a/util/gvalid/internal/builtin/builtin_gt.go
+++ b/util/gvalid/internal/builtin/builtin_gt.go
@@ -37,8 +37,8 @@ func (r RuleGT) Message() string {
 func (r RuleGT) Run(in RunInput) error {
 	var (
 		fieldName, fieldValue = gutil.MapPossibleItemByKey(in.Data.Map(), in.RulePattern)
-		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 10)
-		valueN, err2          = strconv.ParseFloat(in.Value.String(), 10)
+		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 64)
+		valueN, err2          = strconv.ParseFloat(in.Value.String(), 64)
 	)
 
 	if valueN <= fieldValueN || err1 != nil || err2 != nil {

--- a/util/gvalid/internal/builtin/builtin_gte.go
+++ b/util/gvalid/internal/builtin/builtin_gte.go
@@ -37,8 +37,8 @@ func (r RuleGTE) Message() string {
 func (r RuleGTE) Run(in RunInput) error {
 	var (
 		fieldName, fieldValue = gutil.MapPossibleItemByKey(in.Data.Map(), in.RulePattern)
-		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 10)
-		valueN, err2          = strconv.ParseFloat(in.Value.String(), 10)
+		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 64)
+		valueN, err2          = strconv.ParseFloat(in.Value.String(), 64)
 	)
 
 	if valueN < fieldValueN || err1 != nil || err2 != nil {

--- a/util/gvalid/internal/builtin/builtin_lt.go
+++ b/util/gvalid/internal/builtin/builtin_lt.go
@@ -37,8 +37,8 @@ func (r RuleLT) Message() string {
 func (r RuleLT) Run(in RunInput) error {
 	var (
 		fieldName, fieldValue = gutil.MapPossibleItemByKey(in.Data.Map(), in.RulePattern)
-		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 10)
-		valueN, err2          = strconv.ParseFloat(in.Value.String(), 10)
+		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 64)
+		valueN, err2          = strconv.ParseFloat(in.Value.String(), 64)
 	)
 
 	if valueN >= fieldValueN || err1 != nil || err2 != nil {

--- a/util/gvalid/internal/builtin/builtin_lte.go
+++ b/util/gvalid/internal/builtin/builtin_lte.go
@@ -37,8 +37,8 @@ func (r RuleLTE) Message() string {
 func (r RuleLTE) Run(in RunInput) error {
 	var (
 		fieldName, fieldValue = gutil.MapPossibleItemByKey(in.Data.Map(), in.RulePattern)
-		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 10)
-		valueN, err2          = strconv.ParseFloat(in.Value.String(), 10)
+		fieldValueN, err1     = strconv.ParseFloat(gconv.String(fieldValue), 64)
+		valueN, err2          = strconv.ParseFloat(in.Value.String(), 64)
 	)
 
 	if valueN > fieldValueN || err1 != nil || err2 != nil {

--- a/util/gvalid/internal/builtin/builtin_max.go
+++ b/util/gvalid/internal/builtin/builtin_max.go
@@ -33,8 +33,8 @@ func (r RuleMax) Message() string {
 
 func (r RuleMax) Run(in RunInput) error {
 	var (
-		max, err1    = strconv.ParseFloat(in.RulePattern, 10)
-		valueN, err2 = strconv.ParseFloat(in.Value.String(), 10)
+		max, err1    = strconv.ParseFloat(in.RulePattern, 64)
+		valueN, err2 = strconv.ParseFloat(in.Value.String(), 64)
 	)
 	if valueN > max || err1 != nil || err2 != nil {
 		return errors.New(gstr.Replace(in.Message, "{max}", strconv.FormatFloat(max, 'f', -1, 64)))

--- a/util/gvalid/internal/builtin/builtin_min.go
+++ b/util/gvalid/internal/builtin/builtin_min.go
@@ -33,8 +33,8 @@ func (r RuleMin) Message() string {
 
 func (r RuleMin) Run(in RunInput) error {
 	var (
-		min, err1    = strconv.ParseFloat(in.RulePattern, 10)
-		valueN, err2 = strconv.ParseFloat(in.Value.String(), 10)
+		min, err1    = strconv.ParseFloat(in.RulePattern, 64)
+		valueN, err2 = strconv.ParseFloat(in.Value.String(), 64)
 	)
 	if valueN < min || err1 != nil || err2 != nil {
 		return errors.New(gstr.Replace(in.Message, "{min}", strconv.FormatFloat(min, 'f', -1, 64)))


### PR DESCRIPTION
when I run `staticcheck ./...` in `util` dir it show warning message:
`
gvalid/internal/builtin/builtin_between.go:42:64: 'bitSize' argument is invalid, must be either 32 or 64 (SA1030)
`