### PR TITLE
fix(contrib/drivers/mssql): update tables SQL query for better compatibility

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_dao_issue_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_dao_issue_test.go
@@ -23,6 +23,38 @@ import (
 	"github.com/gogf/gf/cmd/gf/v2/internal/cmd/gendao"
 )
 
+// https://github.com/gogf/gf/issues/1761
+func Test_Gen_Dao_Issue_1761(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		db, err := gdb.New(gdb.ConfigNode{
+			Link: "mssql:sa:test.123456@tcp(127.0.0.1:1433)/test?encrypt=disable",
+		})
+		t.AssertNil(err)
+		var (
+			table      = "user1"
+			sqlContent = `
+				CREATE TABLE [user1] (
+					[id] INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+					[name] VARCHAR(45) NOT NULL,
+				);
+			`
+		)
+		if _, err := db.Exec(ctx, sqlContent); err != nil {
+			gtest.Error(err)
+		}
+		defer func(db gdb.DB, table string) {
+			dropTableStmt := fmt.Sprintf("DROP TABLE IF EXISTS [%s]", table)
+			if _, err := db.Exec(ctx, dropTableStmt); err != nil {
+				gtest.Error(err)
+			}
+		}(db, table)
+		tables, err := db.Tables(ctx)
+		t.AssertNil(err)
+		t.Assert(len(tables), 1)
+		t.Assert(tables[0], table)
+	})
+}
+
 // https://github.com/gogf/gf/issues/2572
 func Test_Gen_Dao_Issue2572(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {

--- a/contrib/drivers/mssql/mssql_tables.go
+++ b/contrib/drivers/mssql/mssql_tables.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	tablesSqlTmp = `SELECT NAME FROM SYSOBJECTS WHERE XTYPE='U' AND STATUS >= 0 ORDER BY NAME`
+	tablesSqlTmp = `SELECT name FROM sys.objects WHERE type='U' AND is_ms_shipped = 0 ORDER BY name`
 )
 
 // Tables retrieves and returns the tables of current schema.


### PR DESCRIPTION
修复gf gen在sqlserver上的异常问题：

1. https://github.com/gogf/gf/issues/1722
2. https://github.com/gogf/gf/issues/1761

```powershell
> gf gen dao
fetching tables failed: SELECT NAME FROM SYSOBJECTS WHERE XTYPE='U' AND STATUS >= 0 ORDER BY NAME: mssql: 对象名 
'SYSOBJECTS' 无效。
1. SELECT NAME FROM SYSOBJECTS WHERE XTYPE='U' AND STATUS >= 0 ORDER BY NAME
2. mssql: 对象名 'SYSOBJECTS' 无效。
```

在SqlServer 2022已测试通过：

![image](https://github.com/user-attachments/assets/9f6b7326-c790-4458-93dd-04782b617692)
