### PR TITLE
fix(net/ghttp):check parameter existence to determine using default or front-end value.

### DIFF
--- a/net/ghttp/ghttp_request_param_request.go
+++ b/net/ghttp/ghttp_request_param_request.go
@@ -204,8 +204,11 @@ func (r *Request) mergeDefaultStructValue(data map[string]interface{}, pointer i
 				if foundKey == "" {
 					data[field.Name()] = tagValue
 				} else {
-					if empty.IsEmpty(foundValue) {
+					// Check parameter existence to determine using default or front-end value.
+					if foundValue == nil || foundValue == "" {
 						data[foundKey] = tagValue
+					} else {
+						data[foundKey] = foundValue
 					}
 				}
 			}
@@ -228,8 +231,11 @@ func (r *Request) mergeDefaultStructValue(data map[string]interface{}, pointer i
 			if foundKey == "" {
 				data[field.Name()] = field.TagValue
 			} else {
-				if empty.IsEmpty(foundValue) {
+				// Check parameter existence to determine using default or front-end value.
+				if foundValue == nil || foundValue == "" {
 					data[foundKey] = field.TagValue
+				} else {
+					data[foundKey] = foundValue
 				}
 			}
 		}


### PR DESCRIPTION
- Fixes #4093 
The results of frontend-passed values are ultimately converted into key-value pairs. When a key exists, the value has only two possible states: present or absent.

For non-existent keys, there are two scenarios:
1. The value might inherently not exist for that key.
2. A default value (e.g., from the default/d tag) is provided.

Implementation logic:
 - If the key does NOT exist: Use the default value.
 - If the key EXISTS:
  1. Value is absent: Fall back to the default value.
  2. Value is present: Directly use the frontend-provided value without additional checks (e.g., no IsEmpty() validation as in previous versions).