### PR TITLE
fix(util/gconv): Fix 'gocnv. Floats()' correctly converting '[1,2,3,4]' to '[] float64 {1,2,3,4}'

### DIFF
--- a/util/gconv/gconv_slice_float.go
+++ b/util/gconv/gconv_slice_float.go
@@ -167,11 +167,6 @@ func Float64s(any interface{}) []float64 {
 		array []float64 = nil
 	)
 	switch value := any.(type) {
-	case string:
-		if value == "" {
-			return []float64{}
-		}
-		return []float64{Float64(value)}
 	case []string:
 		array = make([]float64, len(value))
 		for k, v := range value {

--- a/util/gconv/gconv_z_unit_float_test.go
+++ b/util/gconv/gconv_z_unit_float_test.go
@@ -223,3 +223,10 @@ func TestFloats(t *testing.T) {
 		}
 	})
 }
+
+// test string to []floats uses gconv.Floats.
+func TestStringToFloats(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		t.AssertEQ(gconv.Floats("[1,2,3,4]"), []float64{1, 2, 3, 4})
+	})
+}


### PR DESCRIPTION
fix: #4139 
"gconv. Ints()" works fine
```
gconv.Int64s("[1,2,3,4]") 
result: [1,2,3,4]
```
"gconv. Floats()"  and "gconv.Float64s()" wrong work
```
gconv.Floats("[1,2,3,4]")
result: [0]
gconv.Float64s("[1,2,3,4]")
result: [0]
```
So, referring to the logic of "gconv. Ints()", revise the work of "gconv. Float()" and "gconv. Float64s()"
```
gconv.Floats("[1,2,3,4]")
result: [1,2,3,4]
gconv.Float64s("[1,2,3,4]")
result: [1,2,3,4]
```
