### PR TITLE
fix(cmd/gf): 修复当前运行安装的二进制文件名以版本号结束导致识别后缀名异常的问题

### DIFF
--- a/cmd/gf/internal/service/install.go
+++ b/cmd/gf/internal/service/install.go
@@ -162,8 +162,14 @@ func (s serviceInstall) getGoPathBin() string {
 func (s serviceInstall) getAvailablePaths() []serviceInstallAvailablePath {
 	var (
 		folderPaths    []serviceInstallAvailablePath
-		binaryFileName = "gf" + gfile.Ext(gfile.SelfPath())
+		binaryFileName = "gf"
 	)
+
+	// Windows binary file name suffix.
+	if runtime.GOOS == "windows" {
+		binaryFileName += ".exe"
+	}
+
 	// $GOPATH/bin
 	if goPathBin := s.getGoPathBin(); goPathBin != "" {
 		folderPaths = s.checkAndAppendToAvailablePath(


### PR DESCRIPTION
https://github.com/gogf/gf/issues/4190