### PR TITLE
fix(ci): update ubuntu version in main ci

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -43,7 +43,7 @@ jobs:
         go-version: [ "1.22", "1.23" ]
         goarch: [ "386", "amd64" ]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     # Service containers to run with `code-test`
     services:


### PR DESCRIPTION
Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101