### PR TITLE
fix: the use of the deprecated variable {format} in the file util/gval…

### DIFF
--- a/util/gvalid/testdata/i18n/cn/validation.toml
+++ b/util/gvalid/testdata/i18n/cn/validation.toml
@@ -7,7 +7,7 @@
 "gf.gvalid.rule.required-without-all" = "{field}字段不能为空"
 "gf.gvalid.rule.date"                 = "{field}字段值`{value}`日期格式不满足Y-m-d格式，例如: 2001-02-03"
 "gf.gvalid.rule.datetime"             = "{field}字段值`{value}`日期格式不满足Y-m-d H:i:s格式，例如: 2001-02-03 12:00:00"
-"gf.gvalid.rule.date-format"          = "{field}字段值`{value}`日期格式不满足{format}"
+"gf.gvalid.rule.date-format"          = "{field}字段值`{value}`日期格式不满足{pattern}"
 "gf.gvalid.rule.email"                = "{field}字段值`{value}`邮箱地址格式不正确"
 "gf.gvalid.rule.phone"                = "{field}字段值`{value}`手机号码格式不正确"
 "gf.gvalid.rule.phone-loose"          = "{field}字段值`{value}`手机号码格式不正确"


### PR DESCRIPTION
Fix the use of the deprecated variable {format} in the file util/gvalid/testdata/i18n/cn/validation.toml.