### PR TITLE
fix(database/gdb): use the database sharding feature to output schema errors in SQL logs

### DIFF
--- a/contrib/drivers/mysql/mysql_z_unit_model_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_model_test.go
@@ -1141,7 +1141,7 @@ func Test_Model_StructsWithOrmTag(t *testing.T) {
 		t.Assert(
 			gstr.Contains(
 				buffer.String(),
-				"SELECT `id`,`passport`,`password`,`nickname`,`create_time` FROM `user",
+				"SELECT `id`,`Passport`,`password`,`nick_name`,`create_time` FROM `user",
 			),
 			true,
 		)

--- a/contrib/drivers/mysql/mysql_z_unit_model_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_model_test.go
@@ -1141,7 +1141,7 @@ func Test_Model_StructsWithOrmTag(t *testing.T) {
 		t.Assert(
 			gstr.Contains(
 				buffer.String(),
-				"SELECT `id`,`Passport`,`password`,`nick_name`,`create_time` FROM `user",
+				"SELECT `id`,`passport`,`password`,`nickname`,`create_time` FROM `user",
 			),
 			true,
 		)

--- a/database/gdb/gdb_core_config.go
+++ b/database/gdb/gdb_core_config.go
@@ -381,6 +381,13 @@ func (c *Core) GetSchema() string {
 	return schema
 }
 
+// SetSchema set the schema configured.
+func (c *Core) SetSchema(schema string) {
+	if schema != "" {
+		c.schema = schema
+	}
+}
+
 func parseConfigNodeLink(node *ConfigNode) (*ConfigNode, error) {
 	var (
 		link  = node.Link

--- a/database/gdb/gdb_model_hook.go
+++ b/database/gdb/gdb_model_hook.go
@@ -125,6 +125,7 @@ func (h *HookSelectInput) Next(ctx context.Context) (result Result, err error) {
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
+	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -174,6 +175,7 @@ func (h *HookInsertInput) Next(ctx context.Context) (result sql.Result, err erro
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
+	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -210,6 +212,7 @@ func (h *HookUpdateInput) Next(ctx context.Context) (result sql.Result, err erro
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
+	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -253,6 +256,7 @@ func (h *HookDeleteInput) Next(ctx context.Context) (result sql.Result, err erro
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
+	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}

--- a/database/gdb/gdb_model_hook.go
+++ b/database/gdb/gdb_model_hook.go
@@ -125,7 +125,6 @@ func (h *HookSelectInput) Next(ctx context.Context) (result Result, err error) {
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
-	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +159,7 @@ func (h *HookSelectInput) Next(ctx context.Context) (result Result, err error) {
 		if err != nil {
 			return
 		}
+		h.Model.db.GetCore().SetSchema(h.Schema)
 	}
 	return h.Model.db.DoSelect(ctx, h.link, toBeCommittedSql, h.Args...)
 }
@@ -175,7 +175,6 @@ func (h *HookInsertInput) Next(ctx context.Context) (result sql.Result, err erro
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
-	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +196,7 @@ func (h *HookInsertInput) Next(ctx context.Context) (result sql.Result, err erro
 		if err != nil {
 			return
 		}
+		h.Model.db.GetCore().SetSchema(h.Schema)
 	}
 	return h.Model.db.DoInsert(ctx, h.link, h.Table, h.Data, h.Option)
 }
@@ -212,7 +212,6 @@ func (h *HookUpdateInput) Next(ctx context.Context) (result sql.Result, err erro
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
-	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -241,6 +240,7 @@ func (h *HookUpdateInput) Next(ctx context.Context) (result sql.Result, err erro
 		if err != nil {
 			return
 		}
+		h.Model.db.GetCore().SetSchema(h.Schema)
 	}
 	return h.Model.db.DoUpdate(ctx, h.link, h.Table, h.Data, h.Condition, h.Args...)
 }
@@ -256,7 +256,6 @@ func (h *HookDeleteInput) Next(ctx context.Context) (result sql.Result, err erro
 
 	// Sharding feature.
 	h.Schema, err = h.Model.getActualSchema(ctx, h.Schema)
-	h.Model.db.GetCore().SetSchema(h.Schema)
 	if err != nil {
 		return nil, err
 	}
@@ -285,6 +284,7 @@ func (h *HookDeleteInput) Next(ctx context.Context) (result sql.Result, err erro
 		if err != nil {
 			return
 		}
+		h.Model.db.GetCore().SetSchema(h.Schema)
 	}
 	return h.Model.db.DoDelete(ctx, h.link, h.Table, h.Condition, h.Args...)
 }


### PR DESCRIPTION
error log
```
2025-06-18T15:36:08.315+08:00 [DEBU] {10a3b0cfd9124a186b89b07f50e67ce6} [  0 ms] [default] [db_0] [rows:1  ] SELECT `id`,`custom_name` FROM `custom` WHERE `id`=1 LIMIT 1

2025-06-18T15:36:09.259+08:00 [DEBU] {10a3b0cfd9124a186b89b07f50e67ce6} [  1 ms] [default] [db_0] [rows:1  ] SELECT `id`,`custom_name`,`remark`FROM `custom` WHERE `id`=2 LIMIT 1

```
right log
```
2025-06-18T15:36:08.315+08:00 [DEBU] {10a3b0cfd9124a186b89b07f50e67ce6} [  0 ms] [default] [db_0] [rows:1  ] SELECT `id`,`custom_name` FROM `custom` WHERE `id`=1 LIMIT 1

2025-06-18T15:36:09.259+08:00 [DEBU] {10a3b0cfd9124a186b89b07f50e67ce6} [  1 ms] [default] [db_1] [rows:1  ] SELECT `id`,`custom_name`,`remark`FROM `custom` WHERE `id`=2 LIMIT 1
```

```

type DbShardingRule struct {
}

func (d *DbShardingRule) SchemaName(ctx context.Context, config gdb.ShardingSchemaConfig, value any) (string, error) {
	if name, ok := value.(string); ok && (len(name) > 0) && gstr.HasPrefix(name, config.Prefix) {
		return name, nil
	}
	return "default", nil
}

func (d *DbShardingRule) TableName(ctx context.Context, config gdb.ShardingTableConfig, value any) (string, error) {
	return "", nil
}
```

```
config := gdb.ShardingConfig{
		Schema: gdb.ShardingSchemaConfig{
			Enable: true,
			Prefix: "db_",
			Rule:   &DbShardingRule{},
		},
	}
dao.Custom.Ctx(ctx).Sharding(config).ShardingValue("db_0").Where("id", 1).One()
dao.Custom.Ctx(ctx).Sharding(config).ShardingValue("db_1").Where("id", 2).One()
```
我有两个完全一样的数据库db_0和db_1，两个custom表里都只有一条数据，id是1和2，执行上面两条查询得的结果是正确的，
输出日志中应该分别是`[default] [db_0]`和`[default] [db_1]`，但是实际输出的都是`[default] [db_0]`，
查看具体代码实现，该日志由Core实例中获取group和schema构成，而实际执行sql时如果使用了分库特性那么执行sql的link会使用当前面schema重新生成，但是没有重新赋给Core实例，所以输出日志的时候还是错的，只需要在生成link后生成日志前把schema赋给Core就行
![SCR-20250618-ovoc](https://github.com/user-attachments/assets/815c364e-939f-4a2c-9669-d5b7d2742511)
![SCR-20250618-ovvk](https://github.com/user-attachments/assets/e7d0e375-78e6-4748-90ac-d02dba18720f)
![SCR-20250618-ozsu](https://github.com/user-attachments/assets/faa6d69b-331e-476b-8bf8-f62e564b04d3)
![SCR-20250618-ozwj](https://github.com/user-attachments/assets/15c524dc-dc19-4499-a3d3-32bf1d918a3a)


