### PR TITLE
fix(os/gtime): 添加对nil时间指针的处理，避免引发panic

### DIFF
--- a/os/gtime/gtime_time.go
+++ b/os/gtime/gtime_time.go
@@ -36,8 +36,11 @@ func New(param ...interface{}) *Time {
 		switch r := param[0].(type) {
 		case time.Time:
 			return NewFromTime(r)
+
 		case *time.Time:
-			return NewFromTime(*r)
+			if r != nil {
+				return NewFromTime(*r)
+			}
 
 		case Time:
 			return &r

--- a/os/gtime/gtime_z_unit_issue_test.go
+++ b/os/gtime/gtime_z_unit_issue_test.go
@@ -71,3 +71,13 @@ func Test_Issue3558(t *testing.T) {
 		t.Assert(gfTimeFormat, stdTimeFormat)
 	})
 }
+
+// Test_Issue4307 https://github.com/gogf/gf/issues/4307
+func Test_Issue4307(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var timeNil *time.Time = nil
+		// This should not panic.
+		gfTime := gtime.New(timeNil)
+		t.AssertNil(gfTime)
+	})
+}


### PR DESCRIPTION
Fixes #4307