### PR TITLE
feat(config/nacos): 变更回调增加变更前的配置对象，可以用来判断哪些配置变更进行特殊处理

### DIFF
--- a/contrib/config/nacos/nacos.go
+++ b/contrib/config/nacos/nacos.go
@@ -23,11 +23,11 @@ import (
 
 // Config is the configuration object for nacos client.
 type Config struct {
-	ServerConfigs  []constant.ServerConfig                                         `v:"required"` // See constant.ServerConfig
-	ClientConfig   constant.ClientConfig                                           `v:"required"` // See constant.ClientConfig
-	ConfigParam    vo.ConfigParam                                                  `v:"required"` // See vo.ConfigParam
-	Watch          bool                                                            // Watch watches remote configuration updates, which updates local configuration in memory immediately when remote configuration changes.
-	OnConfigChange func(beforeValue *g.Var, namespace, group, dataId, data string) // Configure change callback function
+	ServerConfigs  []constant.ServerConfig                                       `v:"required"` // See constant.ServerConfig
+	ClientConfig   constant.ClientConfig                                         `v:"required"` // See constant.ClientConfig
+	ConfigParam    vo.ConfigParam                                                `v:"required"` // See vo.ConfigParam
+	Watch          bool                                                          // Watch watches remote configuration updates, which updates local configuration in memory immediately when remote configuration changes.
+	OnConfigChange func(beforeCfg *g.Var, namespace, group, dataId, data string) // Configure change callback function
 }
 
 // Client implements gcfg.Adapter implementing using nacos service.
@@ -128,9 +128,9 @@ func (c *Client) addWatcher() error {
 	}
 	c.config.ConfigParam.OnChange = func(namespace, group, dataId, data string) {
 		if c.config.OnConfigChange != nil {
-			beforeValue := g.NewVar(gjson.New(c.value.Val().(*gjson.Json).String()))
+			beforeCfg := g.NewVar(gjson.New(c.value.Val().(*gjson.Json).String()))
 			c.doUpdate(data)
-			go c.config.OnConfigChange(beforeValue, namespace, group, dataId, data)
+			go c.config.OnConfigChange(beforeCfg, namespace, group, dataId, data)
 		} else {
 			_ = c.doUpdate(data)
 		}

--- a/contrib/config/nacos/nacos.go
+++ b/contrib/config/nacos/nacos.go
@@ -23,11 +23,11 @@ import (
 
 // Config is the configuration object for nacos client.
 type Config struct {
-	ServerConfigs  []constant.ServerConfig                     `v:"required"` // See constant.ServerConfig
-	ClientConfig   constant.ClientConfig                       `v:"required"` // See constant.ClientConfig
-	ConfigParam    vo.ConfigParam                              `v:"required"` // See vo.ConfigParam
-	Watch          bool                                        // Watch watches remote configuration updates, which updates local configuration in memory immediately when remote configuration changes.
-	OnConfigChange func(namespace, group, dataId, data string) // Configure change callback function
+	ServerConfigs  []constant.ServerConfig                                         `v:"required"` // See constant.ServerConfig
+	ClientConfig   constant.ClientConfig                                           `v:"required"` // See constant.ClientConfig
+	ConfigParam    vo.ConfigParam                                                  `v:"required"` // See vo.ConfigParam
+	Watch          bool                                                            // Watch watches remote configuration updates, which updates local configuration in memory immediately when remote configuration changes.
+	OnConfigChange func(beforeValue *g.Var, namespace, group, dataId, data string) // Configure change callback function
 }
 
 // Client implements gcfg.Adapter implementing using nacos service.
@@ -127,9 +127,12 @@ func (c *Client) addWatcher() error {
 		return nil
 	}
 	c.config.ConfigParam.OnChange = func(namespace, group, dataId, data string) {
-		c.doUpdate(data)
 		if c.config.OnConfigChange != nil {
-			go c.config.OnConfigChange(namespace, group, dataId, data)
+			beforeValue := g.NewVar(gjson.New(c.value.Val().(*gjson.Json).String()))
+			c.doUpdate(data)
+			go c.config.OnConfigChange(beforeValue, namespace, group, dataId, data)
+		} else {
+			_ = c.doUpdate(data)
 		}
 	}
 

--- a/contrib/config/nacos/nacos_test.go
+++ b/contrib/config/nacos/nacos_test.go
@@ -69,7 +69,7 @@ func TestNacosOnConfigChangeFunc(t *testing.T) {
 			ClientConfig:  clientConfig,
 			ConfigParam:   configParam,
 			Watch:         true,
-			OnConfigChange: func(beforeValue *g.Var, namespace, group, dataId, data string) {
+			OnConfigChange: func(beforeCfg *g.Var, namespace, group, dataId, data string) {
 				gtest.Assert("public", namespace)
 				gtest.Assert("test", group)
 				gtest.Assert("config.toml", dataId)

--- a/contrib/config/nacos/nacos_test.go
+++ b/contrib/config/nacos/nacos_test.go
@@ -69,7 +69,7 @@ func TestNacosOnConfigChangeFunc(t *testing.T) {
 			ClientConfig:  clientConfig,
 			ConfigParam:   configParam,
 			Watch:         true,
-			OnConfigChange: func(namespace, group, dataId, data string) {
+			OnConfigChange: func(beforeValue *g.Var, namespace, group, dataId, data string) {
 				gtest.Assert("public", namespace)
 				gtest.Assert("test", group)
 				gtest.Assert("config.toml", dataId)


### PR DESCRIPTION
变更回调增加变更前的配置对象，可以用来判断哪些配置变更进行特殊处理。目前是只能获取更新后的配置，无法获取之前的配置，有些特殊配置无法感知是否变更。