### PR TITLE
fix(genpbentity): enhance type mapping for database fields and add te…

### DIFF
--- a/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_double.proto
+++ b/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_double.proto
@@ -1,0 +1,23 @@
+// ==========================================================================
+// Code generated and maintained by GoFrame CLI tool. DO NOT EDIT.
+// ==========================================================================
+
+syntax = "proto3";
+
+package pbentity;
+
+option go_package = "github.com/gogf/gf/cmd/gf/v2/internal/cmd/api/pbentity";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+message TableUser {
+    int32                     Id       = 1; // User ID
+    string                    Passport = 2; // User Passport
+    string                    Password = 3; // User Password
+    string                    Nickname = 4; // User Nickname
+    double                    Score    = 5; // Total score amount.
+    google.protobuf.Value     Data     = 6; // User Data
+    google.protobuf.Timestamp CreateAt = 7; // Created Time
+    google.protobuf.Timestamp UpdateAt = 8; // Updated Time
+}

--- a/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_double.proto
+++ b/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_double.proto
@@ -12,7 +12,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 message TableUser {
-    int32                     Id       = 1; // User ID
+    uint32                    Id       = 1; // User ID
     string                    Passport = 2; // User Passport
     string                    Password = 3; // User Password
     string                    Nickname = 4; // User Nickname

--- a/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_string.proto
+++ b/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_string.proto
@@ -1,0 +1,23 @@
+// ==========================================================================
+// Code generated and maintained by GoFrame CLI tool. DO NOT EDIT.
+// ==========================================================================
+
+syntax = "proto3";
+
+package pbentity;
+
+option go_package = "github.com/gogf/gf/cmd/gf/v2/internal/cmd/api/pbentity";
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+message TableUser {
+    int32                     Id       = 1; // User ID
+    string                    Passport = 2; // User Passport
+    string                    Password = 3; // User Password
+    string                    Nickname = 4; // User Nickname
+    string                    Score    = 5; // Total score amount.
+    google.protobuf.Value     Data     = 6; // User Data
+    google.protobuf.Timestamp CreateAt = 7; // Created Time
+    google.protobuf.Timestamp UpdateAt = 8; // Updated Time
+}

--- a/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_string.proto
+++ b/cmd/gf/internal/cmd/testdata/issue/4330/issue4330_string.proto
@@ -12,7 +12,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 message TableUser {
-    int32                     Id       = 1; // User ID
+    uint32                    Id       = 1; // User ID
     string                    Passport = 2; // User Passport
     string                    Password = 3; // User Password
     string                    Nickname = 4; // User Nickname

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -328,6 +328,9 @@ type DB interface {
 	// It handles type conversion from database-specific types to Go types.
 	ConvertValueForLocal(ctx context.Context, fieldType string, fieldValue interface{}) (interface{}, error)
 
+	// GetFormattedDBTypeNameForField returns the formatted database type name and pattern for a field type.
+	GetFormattedDBTypeNameForField(fieldType string) (typeName, typePattern string)
+
 	// CheckLocalTypeForField checks if a Go value is compatible with a database field type.
 	// It returns the appropriate LocalType and any conversion errors.
 	CheckLocalTypeForField(ctx context.Context, fieldType string, fieldValue interface{}) (LocalType, error)

--- a/database/gdb/gdb_core_structure.go
+++ b/database/gdb/gdb_core_structure.go
@@ -222,14 +222,9 @@ Default:
 	return convertedValue, nil
 }
 
-// CheckLocalTypeForField checks and returns corresponding type for given db type.
-// The `fieldType` is retrieved from ColumnTypes of db driver, example:
-// UNSIGNED INT
-func (c *Core) CheckLocalTypeForField(ctx context.Context, fieldType string, _ interface{}) (LocalType, error) {
-	var (
-		typeName    string
-		typePattern string
-	)
+// GetFormattedDBTypeNameForField retrieves and returns the formatted database type name
+// eg. `int(10) unsigned` -> `int`, `varchar(100)` -> `varchar`, etc.
+func (c *Core) GetFormattedDBTypeNameForField(fieldType string) (typeName, typePattern string) {
 	match, _ := gregex.MatchString(`(.+?)\((.+)\)`, fieldType)
 	if len(match) == 3 {
 		typeName = gstr.Trim(match[1])
@@ -242,9 +237,19 @@ func (c *Core) CheckLocalTypeForField(ctx context.Context, fieldType string, _ i
 			typeName = array[0]
 		}
 	}
-
 	typeName = strings.ToLower(typeName)
+	return
+}
 
+// CheckLocalTypeForField checks and returns corresponding type for given db type.
+// The `fieldType` is retrieved from ColumnTypes of db driver, example:
+// UNSIGNED INT
+func (c *Core) CheckLocalTypeForField(ctx context.Context, fieldType string, _ interface{}) (LocalType, error) {
+	var (
+		typeName    string
+		typePattern string
+	)
+	typeName, typePattern = c.GetFormattedDBTypeNameForField(fieldType)
 	switch typeName {
 	case
 		fieldTypeBinary,


### PR DESCRIPTION
fix issue #4330 

  ```
if lookGoodForYou { 
  // todo
  // 烦请修正文档：https://goframe.org/docs/cli/gen-pbentity#参数typemapping
  // 参数typeMapping支持配置数据库字段类型对应的Go数据类型，默认值为：

  decimal:
    type: float64
  money:
    type: float64
  numeric:
    type: float64
  smallmoney:
    type: float64
}
  ```
  1. genpbentity 应该支持格式化的数据库类型至proto类型的直接转换，如：decimal 转换为 double；decimal 转换为 float64 如果要支持的话需要进行两重转换 decimal => float64 => double，目前不完善，变更的话破坏性也比较强。
  2. 这四类数据类型的处理按目前默认逻辑是转换为string，本次更新 仅支持手动定义typemapping，不变更默认值的处理以保持兼容性。

Ps. 
请问最近有更新计划吗？
@gqcn @hailaz 
