### PR TITLE
fix(tracing): set database span kind to client

### DIFF
--- a/contrib/nosql/redis/redis_conn.go
+++ b/contrib/nosql/redis/redis_conn.go
@@ -80,7 +80,7 @@ func (c *Conn) Do(ctx context.Context, command string, args ...interface{}) (rep
 
 	// Trace span start.
 	tr := otel.GetTracerProvider().Tracer(traceInstrumentName, trace.WithInstrumentationVersion(gf.VERSION))
-	_, span := tr.Start(ctx, "Redis."+command, trace.WithSpanKind(trace.SpanKindInternal))
+	_, span := tr.Start(ctx, "Redis."+command, trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	timestampMilli1 := gtime.TimestampMilli()

--- a/database/gdb/gdb_core_underlying.go
+++ b/database/gdb/gdb_core_underlying.go
@@ -168,7 +168,7 @@ func (c *Core) DoCommit(ctx context.Context, in DoCommitInput) (out DoCommitOutp
 
 	// Trace span start.
 	tr := otel.GetTracerProvider().Tracer(traceInstrumentName, trace.WithInstrumentationVersion(gf.VERSION))
-	ctx, span := tr.Start(ctx, string(in.Type), trace.WithSpanKind(trace.SpanKindInternal))
+	ctx, span := tr.Start(ctx, string(in.Type), trace.WithSpanKind(trace.SpanKindClient))
 	defer span.End()
 
 	// Execution by type.


### PR DESCRIPTION
In [OpenTelemetry spec](https://opentelemetry.io/docs/specs/semconv/database/database-spans/), the span kind of database should be `client`.
