### PR TITLE
fix(database/gdb): Resolve the bug where AllAndCount and ScanAndCount use the same specified cache key when enabling caching features, resulting in both count and select using the same cache

### DIFF
--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -702,6 +702,7 @@ const (
 	defaultMaxConnLifeTime                = 30 * time.Second // Max lifetime for per connection in pool in seconds.
 	cachePrefixTableFields                = `TableFields:`
 	cachePrefixSelectCache                = `SelectCache:`
+	cachePrefixCountCache                 = `CountCache:`
 	commandEnvKeyForDryRun                = "gf.gdb.dryrun"
 	modelForDaoSuffix                     = `ForDao`
 	dbRoleSlave                           = `slave`

--- a/database/gdb/gdb_model_select.go
+++ b/database/gdb/gdb_model_select.go
@@ -56,7 +56,9 @@ func (m *Model) AllAndCount(useFieldForCount bool) (result Result, totalCount in
 	if !useFieldForCount {
 		countModel.fields = []any{Raw("1")}
 	}
-
+	if countModel.cacheEnabled && m.cacheOption.Name != "" {
+		countModel.cacheOption.Name = fmt.Sprintf(`%s%s`, cachePrefixCountCache, m.cacheOption.Name)
+	}
 	// Get the total count of records
 	totalCount, err = countModel.Count()
 	if err != nil {
@@ -337,7 +339,9 @@ func (m *Model) ScanAndCount(pointer interface{}, totalCount *int, useFieldForCo
 	if !useFieldForCount {
 		countModel.fields = []any{Raw("1")}
 	}
-
+	if countModel.cacheEnabled && m.cacheOption.Name != "" {
+		countModel.cacheOption.Name = fmt.Sprintf(`%s%s`, cachePrefixCountCache, m.cacheOption.Name)
+	}
 	// Get the total count of records
 	*totalCount, err = countModel.Count()
 	if err != nil {


### PR DESCRIPTION
```
func main() {
	adapter := gcache.NewAdapterRedis(g.Redis())
	g.DB().GetCache().SetAdapter(adapter)
	result, count, err := g.Model("TBL_USER").Cache(gdb.CacheOption{
		Duration: 100 * time.Minute,
		Name:     "VIP",
	}).AllAndCount(false)
	g.DumpJson(result)
	fmt.Println(count, err)
}
```
执行这段查询后`g.DumpJson(result)`的结果是`[
    {
        "COUNT(1)": 5
    }
]`,但是正确结果应该是五条用户信息，查看源代码后发现先执行的count查询和后来select查询都是直接使用了`VIP`这个缓存key，在redis中实际缓存key是`SelectCache:VIP`，第二步查询select获得的是count查询的缓存，所以查询结果是错的。因此在`AllAndCount`和`ScanAndCount`中包含的count应该使用`SelectCache:CountCache:VIP`这个缓存作为区分。仅仅只在这两种查询时使用前缀`SelectCache:CountCache:`避免和其他单独查询使用的缓存产生冲突
<img width="1108" height="748" alt="SCR-20250711-onhp" src="https://github.com/user-attachments/assets/1a92e8dc-2808-470b-bcf4-b9f5ef5adb63" />

