### PR TITLE
fix(cmd/gf): "unknown time zone" when using "gf gen dao" for clickhouse on windows platform

### DIFF
--- a/cmd/gf/main.go
+++ b/cmd/gf/main.go
@@ -7,6 +7,8 @@
 package main
 
 import (
+	_ "time/tzdata"
+
 	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/os/gctx"
 


### PR DESCRIPTION
fix bug: could not load time location: "unknown time zone Asia/Shanghai"

The bug will appear when I use gf in windows to do "gf gen dao" for clickhouse.
