### PR TITLE
Improve the typeMap check logic of "gf gen dao"

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_pb_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_pb_test.go
@@ -55,7 +55,7 @@ func TestGenPbIssue3882(t *testing.T) {
 func TestGenPbIssue3953(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (
-			outputPath     = gfile.Temp(guid.S())
+			outputPath     = gfile.Temp("f" + guid.S())
 			outputApiPath  = filepath.Join(outputPath, "api")
 			outputCtrlPath = filepath.Join(outputPath, "controller")
 

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -67,7 +67,7 @@ func getTypeMappingInfo(
 		importStr = typeMapping.Import
 		return
 	}
-	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)(.*)`, fieldType)
+	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)([^\s]*)`, fieldType)
 	var (
 		tryTypeName string
 		moreTry     bool

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -67,13 +67,13 @@ func getTypeMappingInfo(
 		importStr = typeMapping.Import
 		return
 	}
-	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)([^\s]*)`, fieldType)
+	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)([\s\)]*)`, fieldType)
 	var (
 		tryTypeName string
 		moreTry     bool
 	)
 	if len(tryTypeMatch) == 4 {
-		tryTypeMatch3 := gstr.Trim(tryTypeMatch[3])
+		tryTypeMatch3, _ := gregex.ReplaceString(`\s+`, "", tryTypeMatch[3])
 		tryTypeName = gstr.Trim(tryTypeMatch[1]) + tryTypeMatch3
 		moreTry = tryTypeMatch3 != ""
 	} else {

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -70,14 +70,22 @@ func getTypeMappingInfo(
 	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)(.*)`, fieldType)
 	var (
 		tryTypeName string
+		moreTry     bool
 	)
 	if len(tryTypeMatch) == 4 {
-		tryTypeName = gstr.Trim(tryTypeMatch[1]) + gstr.Trim(tryTypeMatch[3])
+		tryTypeMatch3 := gstr.Trim(tryTypeMatch[3])
+		tryTypeName = gstr.Trim(tryTypeMatch[1]) + tryTypeMatch3
+		moreTry = tryTypeMatch3 != ""
 	} else {
 		tryTypeName = gstr.Split(fieldType, " ")[0]
 	}
 	if tryTypeName != "" {
-		typeNameStr, importStr = getTypeMappingInfo(ctx, tryTypeName, inTypeMapping)
+		if typeMapping, ok := inTypeMapping[strings.ToLower(tryTypeName)]; ok {
+			typeNameStr = typeMapping.Type
+			importStr = typeMapping.Import
+		} else if moreTry {
+			typeNameStr, importStr = getTypeMappingInfo(ctx, tryTypeName, inTypeMapping)
+		}
 	}
 	return
 }

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -59,6 +59,37 @@ func generateStructDefinition(ctx context.Context, in generateStructDefinitionIn
 	return buffer.String(), appendImports
 }
 
+func getTypeMappingInfo(
+	ctx context.Context, fieldType string, inTypeMapping map[DBFieldTypeName]CustomAttributeType,
+) (typeNameStr, importStr string) {
+	if typeMapping, ok := inTypeMapping[strings.ToLower(fieldType)]; ok {
+		typeNameStr = typeMapping.Type
+		importStr = typeMapping.Import
+		return
+	}
+	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)(.*)`, fieldType)
+	var (
+		tryTypeName string
+		moreTry     bool
+	)
+	if len(tryTypeMatch) == 4 {
+		tryTypeMatch3 := gstr.Trim(tryTypeMatch[3])
+		tryTypeName = gstr.Trim(tryTypeMatch[1]) + tryTypeMatch3
+		moreTry = tryTypeMatch3 != ""
+	} else {
+		tryTypeName = gstr.Split(fieldType, " ")[0]
+	}
+	if tryTypeName != "" {
+		if typeMapping, ok := inTypeMapping[strings.ToLower(tryTypeName)]; ok {
+			typeNameStr = typeMapping.Type
+			importStr = typeMapping.Import
+		} else if moreTry {
+			typeNameStr, importStr = getTypeMappingInfo(ctx, tryTypeName, inTypeMapping)
+		}
+	}
+	return
+}
+
 // generateStructFieldDefinition generates and returns the attribute definition for specified field.
 func generateStructFieldDefinition(
 	ctx context.Context, field *gdb.TableField, in generateStructDefinitionInput,
@@ -71,21 +102,7 @@ func generateStructFieldDefinition(
 	)
 
 	if in.TypeMapping != nil && len(in.TypeMapping) > 0 {
-		var (
-			tryTypeName string
-		)
-		tryTypeMatch, _ := gregex.MatchString(`(.+?)\((.+)\)`, field.Type)
-		if len(tryTypeMatch) == 3 {
-			tryTypeName = gstr.Trim(tryTypeMatch[1])
-		} else {
-			tryTypeName = gstr.Split(field.Type, " ")[0]
-		}
-		if tryTypeName != "" {
-			if typeMapping, ok := in.TypeMapping[strings.ToLower(tryTypeName)]; ok {
-				localTypeNameStr = typeMapping.Type
-				appendImport = typeMapping.Import
-			}
-		}
+		localTypeNameStr, appendImport = getTypeMappingInfo(ctx, field.Type, in.TypeMapping)
 	}
 
 	if localTypeNameStr == "" {

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -70,22 +70,14 @@ func getTypeMappingInfo(
 	tryTypeMatch, _ := gregex.MatchString(`(.+?)\(([^\(\)]+)\)(.*)`, fieldType)
 	var (
 		tryTypeName string
-		moreTry     bool
 	)
 	if len(tryTypeMatch) == 4 {
-		tryTypeMatch3 := gstr.Trim(tryTypeMatch[3])
-		tryTypeName = gstr.Trim(tryTypeMatch[1]) + tryTypeMatch3
-		moreTry = tryTypeMatch3 != ""
+		tryTypeName = gstr.Trim(tryTypeMatch[1]) + gstr.Trim(tryTypeMatch[3])
 	} else {
 		tryTypeName = gstr.Split(fieldType, " ")[0]
 	}
 	if tryTypeName != "" {
-		if typeMapping, ok := inTypeMapping[strings.ToLower(tryTypeName)]; ok {
-			typeNameStr = typeMapping.Type
-			importStr = typeMapping.Import
-		} else if moreTry {
-			typeNameStr, importStr = getTypeMappingInfo(ctx, tryTypeName, inTypeMapping)
-		}
+		typeNameStr, importStr = getTypeMappingInfo(ctx, tryTypeName, inTypeMapping)
 	}
 	return
 }


### PR DESCRIPTION
Let it can support such as "Array(UInt256)", "Array(FixedString(25))".
Now we can typeMap as:
"array(uint256)": []big.Int
"array(fixedstring(25))": [25]string
"array(fixedstring)": []string
"array": []any

Now it will first match more precise rules. So it will match array(uint256) and array(fixedstring(25)) first. Then the "array(fixedstring)", the last is "array"
