### PR TITLE
fix:修复了如果gerror.Error 的text字段如果带有符号" 导致的序列化失败的问题

### DIFF
--- a/errors/gerror/gerror_error_json.go
+++ b/errors/gerror/gerror_error_json.go
@@ -6,8 +6,11 @@
 
 package gerror
 
+import "html"
+
 // MarshalJSON implements the interface MarshalJSON for json.Marshal.
 // Note that do not use pointer as its receiver here.
 func (err Error) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + err.Error() + `"`), nil
+	errMsg := html.EscapeString(err.Error())
+	return []byte(`"` + errMsg + `"`), nil
 }

--- a/internal/json/gerror_json_test.go
+++ b/internal/json/gerror_json_test.go
@@ -1,0 +1,20 @@
+package json
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/errors/gerror"
+)
+
+func TestError_MarshalJSON(t *testing.T) {
+	errNormal := gerror.New("test")
+	errWithSign := gerror.New("test \"\"")
+	_, err := Marshal(errNormal)
+	if err != nil {
+		t.Fail()
+	}
+	_, err = Marshal(errWithSign)
+	if err != nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
如果调用internal 下的json.Marshal时 参数如果是gerror.Error 并且 字段中带有符号" 会导致序列化失败 原因是原gerror.Error 的MarshalJson方法只对字符串做了简单的处理 如果err.Error 返回的字符串中有符号" 这个符号会在序列化的时候被认为是字符串的终止导致序列化失败
<img width="854" height="186" alt="image" src="https://github.com/user-attachments/assets/9a1e6d72-943f-41ad-a487-8a3c0f28f9f0" />
