### PR TITLE
fix(contrib/drivers/mysql): Fix unit test issue for batch insert in MySQL driver

### DIFF
--- a/contrib/drivers/mysql/mysql_z_unit_issue_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_issue_test.go
@@ -1002,11 +1002,11 @@ func Test_Issue3086(t *testing.T) {
 		}
 		data := g.Slice{
 			User{
-				Id:       nil,
+				Id:       1,
 				Passport: "user_1",
 			},
 			User{
-				Id:       2,
+				Id:       1,
 				Passport: "user_2",
 			},
 		}
@@ -1024,11 +1024,11 @@ func Test_Issue3086(t *testing.T) {
 		}
 		data := g.Slice{
 			User{
-				Id:       1,
+				Id:       3,
 				Passport: "user_1",
 			},
 			User{
-				Id:       2,
+				Id:       4,
 				Passport: "user_2",
 			},
 		}


### PR DESCRIPTION
Resolve a temporary issue in the unit tests for batch insertion by adjusting user IDs.

因为底层的插入随机性，会导致单元测试偶发失败。