### PR TITLE
refactor(cmd/gf): Optimize run command to reload only on actual file changes

### DIFF
--- a/cmd/gf/internal/cmd/cmd_run.go
+++ b/cmd/gf/internal/cmd/cmd_run.go
@@ -117,7 +117,7 @@ func (c cRun) Index(ctx context.Context, in cRunInput) (out *cRunOutput, err err
 
 	outputPath := app.genOutputPath()
 	callbackFunc := func(event *gfsnotify.Event) {
-		if !event.IsWrite() {
+		if !event.IsWrite() && !event.IsCreate() && !event.IsRemove() && !event.IsRename() {
 			return
 		}
 


### PR DESCRIPTION
优化run命令使得只在文件有写入事件时才触发reload:
gf run 的文件监控逻辑之前会对所有文件系统事件做出响应，包括非内容修改的事件（如文件access time变化），这会导致开发过程中不必要的频繁重载。本次修改在文件监控回调中增加了event.IsWrite()的判断，确保只有在文件内容被实际写入时才触发重载逻辑，优化了开发体验。

