### PR TITLE
fix(contrib/drivers/pgsql): ensure fields queries are scoped to the specified schema

### DIFF
--- a/contrib/drivers/pgsql/pgsql_table_fields.go
+++ b/contrib/drivers/pgsql/pgsql_table_fields.go
@@ -27,7 +27,8 @@ FROM pg_attribute a
          left join pg_description b ON a.attrelid=b.objoid AND a.attnum = b.objsubid
          left join pg_type t ON a.atttypid = t.oid
          left join information_schema.columns ic on ic.column_name = a.attname and ic.table_name = c.relname
-WHERE c.relname = '%s' and a.attisdropped is false and a.attnum > 0
+         left join pg_namespace n on c.relnamespace = n.oid
+WHERE c.relname = '%s' and n.nspname = '%s' and a.attisdropped is false and a.attnum > 0
 ORDER BY a.attnum`
 )
 
@@ -45,8 +46,9 @@ func (d *Driver) TableFields(ctx context.Context, table string, schema ...string
 		result     gdb.Result
 		link       gdb.Link
 		usedSchema = gutil.GetOrDefaultStr(d.GetSchema(), schema...)
+		namespace  = gutil.GetOrDefaultStr(defaultSchema, d.GetConfig().Namespace)
 		// TODO duplicated `id` result?
-		structureSql = fmt.Sprintf(tableFieldsSqlTmp, table)
+		structureSql = fmt.Sprintf(tableFieldsSqlTmp, table, namespace)
 	)
 	if link, err = d.SlaveLink(usedSchema); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR addresses an issue where database metadata queries, specifically those retrieving table and column information using PostgreSQL catalog views (`pg_attribute`, `pg_class`, etc.), were not correctly scoped by schema.

**Problem:**
When multiple schemas contain tables with the same name (e.g., `schema1.some_table` and `public.some_table`), the previous query would return metadata for all tables, leading to inaccurate or duplicate results.

**Solution:**
The query logic has been updated to explicitly join with `pg_namespace` and filter results based on the schema name (`nspname`).

1.  Joined `pg_class` with `pg_namespace` via `c.relnamespace = n.oid`.
2.  Added a `WHERE` clause condition: `n.nspname = 'public'` (or the target schema name).
3.  Ensured the join to `information_schema.columns` is also filtered by `ic.table_schema = n.nspname` for accurate data retrieval (e.g., `default_value`, `length`).

This ensures that the metadata query correctly retrieves information only for the table within the intended schema.