### PR TITLE
fix(contrib/drivers/pgsql): Fixed table field call issue in primary key acquisition logic

### DIFF
--- a/contrib/drivers/pgsql/pgsql_do_insert.go
+++ b/contrib/drivers/pgsql/pgsql_do_insert.go
@@ -75,7 +75,7 @@ func (d *Driver) DoInsert(
 // getPrimaryKeys retrieves the primary key field list of the table.
 // This method extracts primary key information from TableFields.
 func (d *Driver) getPrimaryKeys(ctx context.Context, table string) ([]string, error) {
-	tableFields, err := d.TableFields(ctx, table)
+	tableFields, err := d.GetCore().GetDB().TableFields(ctx, table)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`pgsql driver`中`getPrimaryKeys`未使用现有缓存，导致每次`insert`都会重新查询表字段