### PR TITLE
fix(gendao): Added support for UUID types

### DIFF
--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -104,6 +104,10 @@ var (
 		"smallmoney": {
 			Type: "float64",
 		},
+		"uuid": {
+			Type:   "uuid.UUID",
+			Import: "github.com/google/uuid",
+		},
 	}
 
 	// tablewriter Options


### PR DESCRIPTION
`gf gen dao`生成`entity`时支持数据库`uuid`类型字段生成`github.com/google/uuid`的`uuid.UUID`类型字段