### PR TITLE
Update pgsql_format_upsert.go

### DIFF
--- a/contrib/drivers/pgsql/pgsql_format_upsert.go
+++ b/contrib/drivers/pgsql/pgsql_format_upsert.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 
 	"github.com/gogf/gf/v2/database/gdb"
-	"github.com/gogf/gf/v2/errors/gcode"
-	"github.com/gogf/gf/v2/errors/gerror"
+	// "github.com/gogf/gf/v2/errors/gcode"
+	// "github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/text/gstr"
 	"github.com/gogf/gf/v2/util/gconv"
 )
@@ -20,9 +20,12 @@ import (
 // For example: ON CONFLICT (id) DO UPDATE SET ...
 func (d *Driver) FormatUpsert(columns []string, list gdb.List, option gdb.DoInsertOption) (string, error) {
 	if len(option.OnConflict) == 0 {
-		return "", gerror.NewCode(
-			gcode.CodeMissingParameter, `Please specify conflict columns`,
-		)
+		// Should not simply return an error, as the parent class's FormatUpsert
+		// This allows other database drivers (e.g., My pgSQL) to handle the upsert operation in their own way.
+		return d.Core.FormatUpsert(columns, list, option)
+		// return "", gerror.NewCode(
+		// 	gcode.CodeMissingParameter, `Please specify conflict columns`,
+		// )
 	}
 
 	var onDuplicateStr string


### PR DESCRIPTION
**What changes were proposed?**
Modified the `FormatUpsert` method in the PostgreSQL driver (`driver_pgsql.go`). Previously, when the `option.OnConflict` slice was empty, the method could return an error. Now, it delegates the call to the parent class's `FormatUpsert` method (`d.Core.FormatUpsert`) instead.

**Why are these changes needed?**
This fix ensures consistency and extensibility. The original behavior prevented the generic upsert logic (which may be implemented differently by other database drivers like My custom pgSQL with `ON DUPLICATE KEY UPDATE`) from being executed. The parent class should have the opportunity to handle cases where PostgreSQL-specific conflict columns are not specified.