### PR TITLE
fix(cmd/gf): Fixed an issue where formatting caused import errors in gf init

### DIFF
--- a/cmd/gf/internal/cmd/geninit/geninit_ast.go
+++ b/cmd/gf/internal/cmd/geninit/geninit_ast.go
@@ -79,7 +79,7 @@ func (r *ASTReplacer) ReplaceInFile(ctx context.Context, filePath string) error 
 	}
 
 	// Write back to file without formatting.
-	// Formatting will be handled by utils.GoFmt after all replacements are done.
+	// Formatting will be handled by formatGoFiles after all replacements are done.
 	var buf bytes.Buffer
 	if err := printer.Fprint(&buf, r.fset, file); err != nil {
 		return err

--- a/cmd/gf/internal/cmd/geninit/geninit_generator.go
+++ b/cmd/gf/internal/cmd/geninit/geninit_generator.go
@@ -9,13 +9,13 @@ package geninit
 import (
 	"context"
 	"fmt"
+	"go/format"
 	"path/filepath"
 
 	"github.com/gogf/gf/v2/os/gfile"
 	"github.com/gogf/gf/v2/text/gstr"
 
 	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 )
 
 // generateProject copies the template to the destination and performs cleanup
@@ -82,8 +82,10 @@ func generateProject(ctx context.Context, srcPath, name, oldModule, newModule st
 		}
 	}
 
-	// 6. Format the generated Go files
-	utils.GoFmt(dstPath)
+	// 6. Format the generated Go files using go/format (not imports.Process)
+	// Note: We use formatGoFiles instead of utils.GoFmt because imports.Process
+	// may incorrectly "fix" local import paths by replacing them with cached module paths.
+	formatGoFiles(dstPath)
 
 	mlog.Print("Project generated successfully!")
 	return nil
@@ -111,4 +113,34 @@ func upgradeDependencies(ctx context.Context, projectDir string) error {
 	}
 	mlog.Print("Dependencies upgraded successfully!")
 	return nil
+}
+
+// formatGoFiles formats all Go files in the directory using go/format.
+// Unlike imports.Process, this only formats code without modifying imports,
+// which prevents incorrect "fixing" of local import paths.
+func formatGoFiles(dir string) {
+	files, err := findGoFiles(dir)
+	if err != nil {
+		mlog.Printf("Failed to find Go files for formatting: %v", err)
+		return
+	}
+
+	for _, file := range files {
+		content := gfile.GetContents(file)
+		if content == "" {
+			continue
+		}
+
+		formatted, err := format.Source([]byte(content))
+		if err != nil {
+			mlog.Debugf("Failed to format %s: %v", file, err)
+			continue
+		}
+
+		if string(formatted) != content {
+			if err := gfile.PutContents(file, string(formatted)); err != nil {
+				mlog.Debugf("Failed to write formatted file %s: %v", file, err)
+			}
+		}
+	}
 }


### PR DESCRIPTION
This pull request refactors the way Go files are formatted after project generation in the `geninit` package. The main change is replacing the previous formatting utility with a new function that uses the standard library's `go/format` package, ensuring that only code formatting is applied and import paths are not inadvertently modified.

**Formatting improvements:**

* Replaced the use of `utils.GoFmt` with a new `formatGoFiles` function that utilizes `go/format` for formatting Go files, avoiding unwanted changes to local import paths. (`cmd/gf/internal/cmd/geninit/geninit_generator.go`)
* Added the `formatGoFiles` function, which recursively formats all Go files in a directory using `go/format` and logs any formatting errors. (`cmd/gf/internal/cmd/geninit/geninit_generator.go`)
* Updated comments and references in the code to clarify that formatting is now handled by `formatGoFiles` instead of `utils.GoFmt`. (`cmd/gf/internal/cmd/geninit/geninit_ast.go`)

**Dependency changes:**

* Removed the import of the custom `utils` package and added the standard `go/format` package to support the new formatting approach. (`cmd/gf/internal/cmd/geninit/geninit_generator.go`)