### PR TITLE
fix(database/gdb): skip field filtering when table/alias is unknown in FieldsPrefix

### DIFF
--- a/database/gdb/gdb_model_utility.go
+++ b/database/gdb/gdb_model_utility.go
@@ -68,6 +68,11 @@ func (m *Model) mappingAndFilterToTableFields(table string, fields []any, filter
 	if fieldsTable != "" {
 		hasTable, _ := m.db.GetCore().HasTable(fieldsTable)
 		if !hasTable {
+			if fieldsTable != m.tablesInit {
+				// Table/alias unknown (e.g., FieldsPrefix called before LeftJoin), skip filtering.
+				return fields
+			}
+			// HasTable cache miss for main table, fallback to use main table for field mapping.
 			fieldsTable = m.tablesInit
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix FieldsPrefix silently dropping fields when called before LeftJoin
- When table/alias is unknown, skip filtering and return fields directly

## Test plan
- [x] Added unit test Test_Issue4595 in pgsql driver
- [x] Test covers: FieldsPrefix before LeftJoin, Fields with prefix, FieldsPrefix after LeftJoin

Closes #4595