### PR TITLE
fix(net/goai): add openapi uuid.UUID type support

### DIFF
--- a/net/goai/goai.go
+++ b/net/goai/goai.go
@@ -144,24 +144,26 @@ func (oai *OpenApiV3) golangTypeToOAIType(t reflect.Type) string {
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
+
+	switch t.String() {
+	case `time.Time`, `gtime.Time`:
+		return TypeString
+	case `ghttp.UploadFile`:
+		return TypeFile
+	case `[]uint8`:
+		return TypeString
+	case `uuid.UUID`:
+		return TypeString
+	}
+
 	switch t.Kind() {
 	case reflect.String:
 		return TypeString
 
 	case reflect.Struct:
-		switch t.String() {
-		case `time.Time`, `gtime.Time`:
-			return TypeString
-		case `ghttp.UploadFile`:
-			return TypeFile
-		}
 		return TypeObject
 
 	case reflect.Slice, reflect.Array:
-		switch t.String() {
-		case `[]uint8`:
-			return TypeString
-		}
 		return TypeArray
 
 	case reflect.Bool:


### PR DESCRIPTION
This pull request updates the logic in `golangTypeToOAIType` to improve how Go types are mapped to OpenAPI types. The most important changes are focused on handling specific struct and slice types more accurately, ensuring better compatibility with OpenAPI specifications.

Type mapping improvements:

* Added explicit handling for `[]uint8` and `uuid.UUID` types, mapping both to `TypeString`. This ensures these commonly used types are correctly represented in OpenAPI schemas.
* Refactored the switch statement to check for specific struct types (`time.Time`, `gtime.Time`, `ghttp.UploadFile`, `[]uint8`, and `uuid.UUID`) before falling back to the kind-based mapping. This improves accuracy for special-case types.