### PR TITLE
fix(‎database/gdb): fix iTableName interface detection when using WithAll with .Scan on reflect.Value objects

### DIFF
--- a/database/gdb/gdb_func.go
+++ b/database/gdb/gdb_func.go
@@ -151,7 +151,7 @@ func isDoStruct(object any) bool {
 // getTableNameFromOrmTag retrieves and returns the table name from struct object.
 func getTableNameFromOrmTag(object any) string {
 	var tableName string
-	var actualObj any = object
+	var actualObj = object
 
 	if rv, ok := object.(reflect.Value); ok {
 		// Check if reflect.Value is valid


### PR DESCRIPTION
fix(gdb/getTableNameFromOrmTag): 修复在使用WithAll, 并且使用.Scan传入对象的情况下, 无法识别该对象字段是否实现了iTableName的接口. 因为该情况下, 传入的object是reflect.Value.

示例如下: 

type MaterialDetail struct {
*entity.Material
SourceFile MaterialSourceFileDetail json:"source_file" orm:"with:id=source_file_id"
}

type MaterialSourceFileDetail struct {
*entity.MaterialSourceFile
}

func (MaterialSourceFileDetail) TableName() string {
return dao.MaterialSourceFile.Table()
}

func foo(ctx context.Context) {

err = dao.Material.Ctx(ctx).WithAll().
	Where(dao.Material.Columns().MaterialId, materialId).
	Scan(&material)
}

这种情况下, 传入getTableNameFromOrmTag的object是reflect.Value, 而不是对象本身. 这会导致识别出MaterialSourceFileDetail已经实现了iTableName接口, 无法获取到正确的表名.