### PR TITLE
feat(database/gdb): add MaxIdleConnTime configuration for SetConnMaxIdleTime support

### DIFF
--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -294,6 +294,9 @@ type DB interface {
 	// SetMaxConnLifeTime sets the maximum amount of time a connection may be reused.
 	SetMaxConnLifeTime(d time.Duration)
 
+	// SetMaxIdleConnTime sets the maximum amount of time a connection may be idle before being closed.
+	SetMaxIdleConnTime(d time.Duration)
+
 	// ===========================================================================
 	// Utility methods.
 	// ===========================================================================
@@ -528,6 +531,7 @@ type dynamicConfig struct {
 	MaxIdleConnCount int
 	MaxOpenConnCount int
 	MaxConnLifeTime  time.Duration
+	MaxIdleConnTime  time.Duration
 }
 
 // DoCommitInput is the input parameters for function DoCommit.
@@ -965,6 +969,7 @@ func newDBByConfigNode(node *ConfigNode, group string) (db DB, err error) {
 			MaxIdleConnCount: node.MaxIdleConnCount,
 			MaxOpenConnCount: node.MaxOpenConnCount,
 			MaxConnLifeTime:  node.MaxConnLifeTime,
+			MaxIdleConnTime:  node.MaxIdleConnTime,
 		},
 	}
 	if v, ok := driverMap[node.Type]; ok {
@@ -1143,6 +1148,9 @@ func (c *Core) getSqlDb(master bool, schema ...string) (sqlDb *sql.DB, err error
 				sqlDb.SetConnMaxLifetime(c.dynamicConfig.MaxConnLifeTime)
 			} else {
 				sqlDb.SetConnMaxLifetime(defaultMaxConnLifeTime)
+			}
+			if c.dynamicConfig.MaxIdleConnTime > 0 {
+				sqlDb.SetConnMaxIdleTime(c.dynamicConfig.MaxIdleConnTime)
 			}
 			return sqlDb
 		}

--- a/database/gdb/gdb_core_config.go
+++ b/database/gdb/gdb_core_config.go
@@ -108,6 +108,11 @@ type ConfigNode struct {
 	// Optional field
 	MaxConnLifeTime time.Duration `json:"maxLifeTime"`
 
+	// MaxIdleConnTime specifies the maximum idle time of a connection before being closed
+	// This is Go 1.15+ feature: sql.DB.SetConnMaxIdleTime
+	// Optional field
+	MaxIdleConnTime time.Duration `json:"maxIdleTime"`
+
 	// QueryTimeout specifies the maximum execution time for DQL operations
 	// Optional field
 	QueryTimeout time.Duration `json:"queryTimeout"`
@@ -351,6 +356,16 @@ func (c *Core) SetMaxOpenConnCount(n int) {
 // If d <= 0, connections are not closed due to a connection's age.
 func (c *Core) SetMaxConnLifeTime(d time.Duration) {
 	c.dynamicConfig.MaxConnLifeTime = d
+}
+
+// SetMaxIdleConnTime sets the maximum amount of time a connection may be idle before being closed.
+//
+// Idle connections may be closed lazily before reuse.
+//
+// If d <= 0, connections are not closed due to a connection's idle time.
+// This is Go 1.15+ feature: sql.DB.SetConnMaxIdleTime.
+func (c *Core) SetMaxIdleConnTime(d time.Duration) {
+	c.dynamicConfig.MaxIdleConnTime = d
 }
 
 // GetConfig returns the current used node configuration.

--- a/database/gdb/gdb_z_core_config_external_test.go
+++ b/database/gdb/gdb_z_core_config_external_test.go
@@ -8,6 +8,7 @@ package gdb_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/test/gtest"
@@ -1187,5 +1188,42 @@ func Test_IsConfigured(t *testing.T) {
 
 		result := gdb.IsConfigured()
 		t.Assert(result, true)
+	})
+}
+
+func Test_ConfigNode_ConnectionPoolSettings(t *testing.T) {
+	// Test connection pool configuration fields
+	gtest.C(t, func(t *gtest.T) {
+		// Save original config and restore after test
+		originalConfig := gdb.GetAllConfig()
+		defer func() {
+			gdb.SetConfig(originalConfig)
+		}()
+
+		// Reset config
+		gdb.SetConfig(make(gdb.Config))
+
+		testNode := gdb.ConfigNode{
+			Host:             "127.0.0.1",
+			Port:             "3306",
+			User:             "root",
+			Pass:             "123456",
+			Name:             "test_db",
+			Type:             "mysql",
+			MaxIdleConnCount: 10,
+			MaxOpenConnCount: 100,
+			MaxConnLifeTime:  30 * time.Second,
+			MaxIdleConnTime:  10 * time.Second,
+		}
+
+		err := gdb.AddConfigNode("pool_test", testNode)
+		t.AssertNil(err)
+
+		result := gdb.GetAllConfig()
+		t.Assert(len(result), 1)
+		t.Assert(result["pool_test"][0].MaxIdleConnCount, 10)
+		t.Assert(result["pool_test"][0].MaxOpenConnCount, 100)
+		t.Assert(result["pool_test"][0].MaxConnLifeTime, 30*time.Second)
+		t.Assert(result["pool_test"][0].MaxIdleConnTime, 10*time.Second)
 	})
 }

--- a/database/gdb/gdb_z_core_config_test.go
+++ b/database/gdb/gdb_z_core_config_test.go
@@ -142,6 +142,11 @@ func Test_Core_SetMaxConnections(t *testing.T) {
 		testDuration := time.Hour
 		core.SetMaxConnLifeTime(testDuration)
 		t.Assert(core.dynamicConfig.MaxConnLifeTime, testDuration)
+
+		// Test SetMaxIdleConnTime
+		idleTimeDuration := 30 * time.Minute
+		core.SetMaxIdleConnTime(idleTimeDuration)
+		t.Assert(core.dynamicConfig.MaxIdleConnTime, idleTimeDuration)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `MaxIdleConnTime` configuration field to support Go 1.15+ `sql.DB.SetConnMaxIdleTime()` method
- Add `SetMaxIdleConnTime()` method to DB interface and Core implementation
- Apply configuration during connection pool initialization
- Add unit tests for the new configuration option

## Related Issue
Closes #4596

## Changes
| File | Change |
|------|--------|
| `database/gdb/gdb_core_config.go` | Add `MaxIdleConnTime` field to `ConfigNode`, add `SetMaxIdleConnTime()` method |
| `database/gdb/gdb.go` | Add interface method, `dynamicConfig` field, initialization logic |
| `database/gdb/gdb_z_core_config_test.go` | Add unit test for `SetMaxIdleConnTime` |
| `database/gdb/gdb_z_core_config_external_test.go` | Add `ConfigNode` connection pool settings test |

## Usage
**Configuration file:**
```yaml
database:
  default:
    maxIdleTime: "10s"  # Close idle connections after 10 seconds
```

**Code:**
```go
db.SetMaxIdleConnTime(10 * time.Second)
```

## Test Plan
- [x] Unit tests pass (`go test -run "Test_Core_SetMaxConnections|Test_ConfigNode_ConnectionPoolSettings"`)
- [x] All database drivers compile successfully (mysql, pgsql, sqlite, clickhouse, dm, mssql, oracle, etc.)
- [x] No breaking changes - follows Go's default behavior (0 = no idle time limit)