### PR TITLE
fix(cmd/gendao): fix overlapping shardingPattern matching issue

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_dao_sharding_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_dao_sharding_test.go
@@ -18,6 +18,92 @@ import (
 	"github.com/gogf/gf/cmd/gf/v2/internal/cmd/gendao"
 )
 
+// Test_Gen_Dao_Sharding_Overlapping tests the fix for issue #4603.
+// When sharding patterns have overlapping prefixes (like "a_?", "a_b_?", "a_c_?"),
+// longer (more specific) patterns should be matched first.
+// https://github.com/gogf/gf/issues/4603
+func Test_Gen_Dao_Sharding_Overlapping(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			err         error
+			db          = testDB
+			tableA1     = "a_1"
+			tableA2     = "a_2"
+			tableAB1    = "a_b_1"
+			tableAB2    = "a_b_2"
+			tableAC1    = "a_c_1"
+			tableAC2    = "a_c_2"
+			sqlFilePath = gtest.DataPath(`gendao`, `sharding`, `sharding_overlapping.sql`)
+		)
+		dropTableWithDb(db, tableA1)
+		dropTableWithDb(db, tableA2)
+		dropTableWithDb(db, tableAB1)
+		dropTableWithDb(db, tableAB2)
+		dropTableWithDb(db, tableAC1)
+		dropTableWithDb(db, tableAC2)
+		t.AssertNil(execSqlFile(db, sqlFilePath))
+		defer dropTableWithDb(db, tableA1)
+		defer dropTableWithDb(db, tableA2)
+		defer dropTableWithDb(db, tableAB1)
+		defer dropTableWithDb(db, tableAB2)
+		defer dropTableWithDb(db, tableAC1)
+		defer dropTableWithDb(db, tableAC2)
+
+		var (
+			path  = gfile.Temp(guid.S())
+			group = "test"
+			in    = gendao.CGenDaoInput{
+				Path:   path,
+				Link:   link,
+				Group:  group,
+				Prefix: "",
+				// Patterns with overlapping prefixes - order should not matter due to sorting fix
+				ShardingPattern: []string{
+					`a_?`,   // shortest, matches a_1, a_2 but also a_b_1, a_c_1 without fix
+					`a_b_?`, // longer, should match a_b_1, a_b_2
+					`a_c_?`, // longer, should match a_c_1, a_c_2
+				},
+			}
+		)
+		err = gutil.FillStructWithDefault(&in)
+		t.AssertNil(err)
+
+		err = gfile.Mkdir(path)
+		t.AssertNil(err)
+
+		pwd := gfile.Pwd()
+		err = gfile.Chdir(path)
+		t.AssertNil(err)
+		defer gfile.Chdir(pwd)
+		defer gfile.RemoveAll(path)
+
+		_, err = gendao.CGenDao{}.Dao(ctx, in)
+		t.AssertNil(err)
+
+		// Should generate 3 dao files: a.go, a_b.go, a_c.go (plus internal versions)
+		generatedFiles, err := gfile.ScanDir(path, "*.go", true)
+		t.AssertNil(err)
+		// 3 sharding groups * 4 files each (dao, internal, do, entity) = 12 files
+		t.Assert(len(generatedFiles), 12)
+
+		var (
+			daoAContent  = gfile.GetContents(gfile.Join(path, "dao", "a.go"))
+			daoABContent = gfile.GetContents(gfile.Join(path, "dao", "a_b.go"))
+			daoACContent = gfile.GetContents(gfile.Join(path, "dao", "a_c.go"))
+		)
+
+		// Verify each sharding group has correct dao file generated
+		t.Assert(gstr.Contains(daoAContent, "aShardingHandler"), true)
+		t.Assert(gstr.Contains(daoAContent, "m.Sharding(gdb.ShardingConfig{"), true)
+
+		t.Assert(gstr.Contains(daoABContent, "aBShardingHandler"), true)
+		t.Assert(gstr.Contains(daoABContent, "m.Sharding(gdb.ShardingConfig{"), true)
+
+		t.Assert(gstr.Contains(daoACContent, "aCShardingHandler"), true)
+		t.Assert(gstr.Contains(daoACContent, "m.Sharding(gdb.ShardingConfig{"), true)
+	})
+}
+
 func Test_Gen_Dao_Sharding(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (

--- a/cmd/gf/internal/cmd/testdata/gendao/sharding/sharding_overlapping.sql
+++ b/cmd/gf/internal/cmd/testdata/gendao/sharding/sharding_overlapping.sql
@@ -1,0 +1,47 @@
+-- Test case for issue #4603: overlapping sharding patterns
+-- https://github.com/gogf/gf/issues/4603
+--
+-- Patterns: "a_?", "a_b_?", "a_c_?"
+-- Expected: a_1/a_2 -> "a", a_b_1/a_b_2 -> "a_b", a_c_1/a_c_2 -> "a_c"
+
+CREATE TABLE `a_1`
+(
+    `id`        int unsigned NOT NULL AUTO_INCREMENT,
+    `name`      varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `a_2`
+(
+    `id`        int unsigned NOT NULL AUTO_INCREMENT,
+    `name`      varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `a_b_1`
+(
+    `id`        int unsigned NOT NULL AUTO_INCREMENT,
+    `name`      varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `a_b_2`
+(
+    `id`        int unsigned NOT NULL AUTO_INCREMENT,
+    `name`      varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `a_c_1`
+(
+    `id`        int unsigned NOT NULL AUTO_INCREMENT,
+    `name`      varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `a_c_2`
+(
+    `id`        int unsigned NOT NULL AUTO_INCREMENT,
+    `name`      varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- Fix overlapping shardingPattern matching issue where shorter patterns incorrectly match tables meant for longer patterns
- Sort shardingPattern by length descending so longer (more specific) patterns are matched first
- Add break after successful pattern match to prevent tables from matching multiple patterns

## Problem
When `shardingPattern` contains overlapping prefixes like `["a_?", "a_b_?", "a_c_?"]`:
- Tables `a_b_1`, `a_b_2` should match `a_b_?` and generate `a_b.go`
- Tables `a_c_1`, `a_c_2` should match `a_c_?` and generate `a_c.go`
- Tables `a_1`, `a_2` should match `a_?` and generate `a.go`

But without this fix, `a_?` (converted to regex `a_(.+)`) would match `a_b_1` first, causing `a_b_?` and `a_c_?` patterns to fail to generate their respective dao files.

## Solution
1. Sort `shardingPattern` by length descending before matching
2. Add `break` after a table matches a pattern to prevent multiple matches

## Test plan
- [x] Added integration test `Test_Gen_Dao_Sharding_Overlapping` with overlapping patterns
- [x] Added SQL test data file `sharding_overlapping.sql`
- [x] Verified 3 separate dao files are generated: `a.go`, `a_b.go`, `a_c.go`

Fixes #4603