### PR TITLE
feat(encoding/gjson): add OmitEmpty option to respect omitempty tag

### DIFF
--- a/encoding/gjson/gjson.go
+++ b/encoding/gjson/gjson.go
@@ -52,6 +52,7 @@ type Options struct {
 	Tags      string      // Custom priority tags for decoding, eg: "json,yaml,MyTag". This is especially for struct parsing into Json object.
 	Type      ContentType // Type specifies the data content type, eg: json, xml, yaml, toml, ini.
 	StrNumber bool        // StrNumber causes the Decoder to unmarshal a number into an any as a string instead of as a float64.
+	OmitEmpty bool        // OmitEmpty ignores struct fields with `omitempty` tag when the field value is empty.
 }
 
 // iInterfaces is used for type assert api for Interfaces().

--- a/encoding/gjson/gjson_api_new_load.go
+++ b/encoding/gjson/gjson_api_new_load.go
@@ -78,7 +78,7 @@ func NewWithOptions(data any, options Options) *Json {
 		case reflect.Map:
 			pointedData = gconv.Map(data, gconv.MapOption{
 				Deep:            true,
-				OmitEmpty:       false,
+				OmitEmpty:       options.OmitEmpty,
 				Tags:            []string{options.Tags},
 				ContinueOnError: true,
 			})
@@ -89,7 +89,7 @@ func NewWithOptions(data any, options Options) *Json {
 			}
 			pointedData = gconv.Map(data, gconv.MapOption{
 				Deep:            true,
-				OmitEmpty:       false,
+				OmitEmpty:       options.OmitEmpty,
 				Tags:            []string{options.Tags},
 				ContinueOnError: true,
 			})

--- a/encoding/gjson/gjson_z_unit_feature_new_test.go
+++ b/encoding/gjson/gjson_z_unit_feature_new_test.go
@@ -120,3 +120,39 @@ func Test_LoadContentType(t *testing.T) {
 		t.Assert(value, 79937385836643329)
 	})
 }
+
+// https://github.com/gogf/gf/issues/4450
+func Test_NewWithOptions_OmitEmpty(t *testing.T) {
+	type User struct {
+		Name   string `json:"name"`
+		Age    int    `json:"age,omitempty"`
+		Height int    `json:"height,omitempty"`
+	}
+
+	// Without OmitEmpty option (default behavior)
+	gtest.C(t, func(t *gtest.T) {
+		user := User{Name: "john", Age: 18, Height: 0}
+		j := gjson.New(user)
+		t.Assert(j.Get("name"), "john")
+		t.Assert(j.Get("age"), 18)
+		t.Assert(j.Get("height"), 0)
+	})
+
+	// With OmitEmpty option enabled
+	gtest.C(t, func(t *gtest.T) {
+		user := User{Name: "john", Age: 18, Height: 0}
+		j := gjson.NewWithOptions(user, gjson.Options{OmitEmpty: true})
+		t.Assert(j.Get("name"), "john")
+		t.Assert(j.Get("age"), 18)
+		t.Assert(j.Get("height"), nil) // Height should be omitted
+	})
+
+	// All empty values with OmitEmpty
+	gtest.C(t, func(t *gtest.T) {
+		user := User{Name: "john", Age: 0, Height: 0}
+		j := gjson.NewWithOptions(user, gjson.Options{OmitEmpty: true})
+		t.Assert(j.Get("name"), "john")
+		t.Assert(j.Get("age"), nil)    // Age should be omitted
+		t.Assert(j.Get("height"), nil) // Height should be omitted
+	})
+}


### PR DESCRIPTION
## Summary
- Add `OmitEmpty` option to `gjson.Options` struct
- Pass `OmitEmpty` value to `gconv.Map()` instead of hardcoding `false`
- Add unit tests to verify the new option

## Background
When using `gjson.New()` to convert a struct to JSON, fields with `omitempty` tag were not being omitted even when their values were empty. This was inconsistent with the standard library `json.Marshal()` behavior.

**Before:**
```go
type User struct {
    Age    int `json:"age,omitempty"`
    Height int `json:"height,omitempty"`
}
user := User{Age: 1}
gjson.New(user).String() // {"age":1,"height":0}  - height not omitted
json.Marshal(user)       // {"age":1}             - height omitted
```

**After:**
```go
gjson.NewWithOptions(user, gjson.Options{OmitEmpty: true}).String() // {"age":1}
```

## Test plan
- [x] Add unit test `Test_NewWithOptions_OmitEmpty` covering:
  - Default behavior (OmitEmpty: false) - empty fields included
  - With OmitEmpty: true - empty fields omitted
  - All empty values scenario

Closes #4450