### PR TITLE
test(cmd/gf): enhance unit tests for fix command

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_fix_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_fix_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/text/gstr"
 )
 
 func Test_Fix_doFixV25Content(t *testing.T) {
@@ -20,5 +21,84 @@ func Test_Fix_doFixV25Content(t *testing.T) {
 		)
 		_, err := f.doFixV25Content(content)
 		t.AssertNil(err)
+	})
+}
+
+func Test_Fix_doFixV25Content_WithReplacement(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			f       = cFix{}
+			content = `s.BindHookHandlerByMap("/path", map[string]ghttp.HandlerFunc{
+				ghttp.HookBeforeServe: func(r *ghttp.Request) {},
+			})`
+		)
+		newContent, err := f.doFixV25Content(content)
+		t.AssertNil(err)
+		// Verify the replacement was made
+		t.Assert(gstr.Contains(newContent, "map[ghttp.HookName]ghttp.HandlerFunc"), true)
+		t.Assert(gstr.Contains(newContent, "map[string]ghttp.HandlerFunc"), false)
+	})
+}
+
+func Test_Fix_doFixV25Content_NoMatch(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			f       = cFix{}
+			content = `package main
+
+func main() {
+	fmt.Println("Hello World")
+}
+`
+		)
+		newContent, err := f.doFixV25Content(content)
+		t.AssertNil(err)
+		// Content should remain unchanged
+		t.Assert(newContent, content)
+	})
+}
+
+func Test_Fix_doFixV25Content_MultipleMatches(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			f       = cFix{}
+			content = `
+s.BindHookHandlerByMap("/path1", map[string]ghttp.HandlerFunc{})
+s.BindHookHandlerByMap("/path2", map[string]ghttp.HandlerFunc{})
+`
+		)
+		newContent, err := f.doFixV25Content(content)
+		t.AssertNil(err)
+		// Both should be replaced
+		count := gstr.Count(newContent, "map[ghttp.HookName]ghttp.HandlerFunc")
+		t.Assert(count, 2)
+	})
+}
+
+func Test_Fix_doFixV25Content_EmptyContent(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			f       = cFix{}
+			content = ""
+		)
+		newContent, err := f.doFixV25Content(content)
+		t.AssertNil(err)
+		t.Assert(newContent, "")
+	})
+}
+
+func Test_Fix_doFixV25Content_ComplexPath(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			f       = cFix{}
+			content = `s.BindHookHandlerByMap("/api/v1/user/{id}/profile", map[string]ghttp.HandlerFunc{
+				ghttp.HookBeforeServe: func(r *ghttp.Request) {
+					r.Response.Write("before")
+				},
+			})`
+		)
+		newContent, err := f.doFixV25Content(content)
+		t.AssertNil(err)
+		t.Assert(gstr.Contains(newContent, "map[ghttp.HookName]ghttp.HandlerFunc"), true)
 	})
 }


### PR DESCRIPTION
## Summary
- Enhance unit tests for the `fix` command's `doFixV25Content` function
- 5 new test cases added (total: 6)

## New Test Cases

| Test | Description |
|------|-------------|
| Test_Fix_doFixV25Content_WithReplacement | Verify actual replacement is made |
| Test_Fix_doFixV25Content_NoMatch | Handle content without patterns |
| Test_Fix_doFixV25Content_MultipleMatches | Handle multiple occurrences |
| Test_Fix_doFixV25Content_EmptyContent | Handle empty content |
| Test_Fix_doFixV25Content_ComplexPath | Handle complex URL paths |

## Test plan
- [x] All 6 tests pass locally
- [x] Only added new test cases to existing test file
- [x] No modifications to non-test code