### PR TITLE
test(cmd/gf): enhance integration tests for gen pb command

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_pb_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_pb_test.go
@@ -88,3 +88,76 @@ func TestGenPbIssue3953(t *testing.T) {
 		t.Assert(gstr.Contains(genContent, notExceptText), false)
 	})
 }
+
+func TestGenPb_MultipleTags(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			outputPath     = gfile.Temp(guid.S())
+			outputApiPath  = filepath.Join(outputPath, "api")
+			outputCtrlPath = filepath.Join(outputPath, "controller")
+
+			protobufFolder = gtest.DataPath("genpb")
+			in             = genpb.CGenPbInput{
+				Path:       protobufFolder,
+				OutputApi:  outputApiPath,
+				OutputCtrl: outputCtrlPath,
+			}
+			err error
+		)
+		err = gfile.Mkdir(outputApiPath)
+		t.AssertNil(err)
+		err = gfile.Mkdir(outputCtrlPath)
+		t.AssertNil(err)
+		defer gfile.Remove(outputPath)
+
+		_, err = genpb.CGenPb{}.Pb(ctx, in)
+		t.AssertNil(err)
+
+		// Test multiple_tags.proto output
+		genContent := gfile.GetContents(filepath.Join(outputApiPath, "multiple_tags.pb.go"))
+		// Id field should have combined validation tags: v:"required#Id > 0"
+		t.Assert(gstr.Contains(genContent, `v:"required#Id > 0"`), true)
+		// Name field should have dc tag from plain comment
+		t.Assert(gstr.Contains(genContent, `dc:"User name for login"`), true)
+		// Email field should have combined validation and dc tag
+		t.Assert(gstr.Contains(genContent, `v:"requiredemail"`), true)
+		t.Assert(gstr.Contains(genContent, `dc:"User email address"`), true)
+	})
+}
+
+func TestGenPb_NestedMessage(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			outputPath     = gfile.Temp(guid.S())
+			outputApiPath  = filepath.Join(outputPath, "api")
+			outputCtrlPath = filepath.Join(outputPath, "controller")
+
+			protobufFolder = gtest.DataPath("genpb")
+			in             = genpb.CGenPbInput{
+				Path:       protobufFolder,
+				OutputApi:  outputApiPath,
+				OutputCtrl: outputCtrlPath,
+			}
+			err error
+		)
+		err = gfile.Mkdir(outputApiPath)
+		t.AssertNil(err)
+		err = gfile.Mkdir(outputCtrlPath)
+		t.AssertNil(err)
+		defer gfile.Remove(outputPath)
+
+		_, err = genpb.CGenPb{}.Pb(ctx, in)
+		t.AssertNil(err)
+
+		// Test nested_message.proto output
+		genContent := gfile.GetContents(filepath.Join(outputApiPath, "nested_message.pb.go"))
+		// Order.OrderId should have v:"required"
+		t.Assert(gstr.Contains(genContent, `v:"required"`), true)
+		// Order.Detail should have dc:"Order details"
+		t.Assert(gstr.Contains(genContent, `dc:"Order details"`), true)
+		// OrderDetail.Quantity should have v:"min:1"
+		t.Assert(gstr.Contains(genContent, `v:"min:1"`), true)
+		// OrderDetail.Price should have v:"min:0.01"
+		t.Assert(gstr.Contains(genContent, `v:"min:0.01"`), true)
+	})
+}

--- a/cmd/gf/internal/cmd/testdata/genpb/multiple_tags.proto
+++ b/cmd/gf/internal/cmd/testdata/genpb/multiple_tags.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package genpb;
+
+option go_package = "genpb/v1";
+
+message UserReq {
+  // v:required
+  // v:#Id > 0
+  int64 Id = 1;
+  // User name for login
+  string Name = 2;
+  // v:required
+  // v:email
+  string Email = 3; // User email address
+}
+
+message UserResp {
+  int64 Id = 1;
+  string Name = 2;
+  string Email = 3;
+}

--- a/cmd/gf/internal/cmd/testdata/genpb/nested_message.proto
+++ b/cmd/gf/internal/cmd/testdata/genpb/nested_message.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package genpb;
+
+option go_package = "genpb/v1";
+
+message Order {
+  // v:required
+  int64 OrderId = 1;
+  // Order details
+  OrderDetail Detail = 2;
+}
+
+message OrderDetail {
+  // v:required
+  string ProductName = 1;
+  // v:min:1
+  int32 Quantity = 2;
+  // v:min:0.01
+  double Price = 3;
+}


### PR DESCRIPTION
## Summary
- Add 2 new integration test cases for `gf gen pb` command
- `TestGenPb_MultipleTags`: tests multiple validation tags (v:required, v:#Id > 0, v:email) and dc tags
- `TestGenPb_NestedMessage`: tests nested message structures with various tag types

## Test Data
- Add `testdata/genpb/multiple_tags.proto` - proto file with multiple tag annotations
- Add `testdata/genpb/nested_message.proto` - proto file with nested message structures

## Test Plan
- [x] Run `go test -v -run "TestGenPb" ./...` - all 4 tests pass (2 existing + 2 new)