### PR TITLE
revert(os/gcfg): restore config file priority over env/cmd in GetWithEnv and GetWithCmd

### DIFF
--- a/os/gcfg/gcfg.go
+++ b/os/gcfg/gcfg.go
@@ -11,6 +11,8 @@ import (
 	"context"
 
 	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/errors/gcode"
+	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/internal/command"
 	"github.com/gogf/gf/v2/internal/intlog"
 	"github.com/gogf/gf/v2/internal/utils"
@@ -117,10 +119,20 @@ func (c *Config) Get(ctx context.Context, pattern string, def ...any) (*gvar.Var
 //
 // Fetching Rules: Environment arguments are in uppercase format, eg: GF_PACKAGE_VARIABLE.
 func (c *Config) GetWithEnv(ctx context.Context, pattern string, def ...any) (*gvar.Var, error) {
-	if v := genv.Get(utils.FormatEnvKey(pattern)); v != nil {
-		return v, nil
+	value, err := c.Get(ctx, pattern)
+	if err != nil && gerror.Code(err) != gcode.CodeNotFound {
+		return nil, err
 	}
-	return c.Get(ctx, pattern, def...)
+	if value == nil {
+		if v := genv.Get(utils.FormatEnvKey(pattern)); v != nil {
+			return v, nil
+		}
+		if len(def) > 0 {
+			return gvar.New(def[0]), nil
+		}
+		return nil, nil
+	}
+	return value, nil
 }
 
 // GetWithCmd returns the configuration value specified by pattern `pattern`.
@@ -129,10 +141,20 @@ func (c *Config) GetWithEnv(ctx context.Context, pattern string, def ...any) (*g
 //
 // Fetching Rules: Command line arguments are in lowercase format, eg: gf.package.variable.
 func (c *Config) GetWithCmd(ctx context.Context, pattern string, def ...any) (*gvar.Var, error) {
-	if v := command.GetOpt(utils.FormatCmdKey(pattern)); v != "" {
-		return gvar.New(v), nil
+	value, err := c.Get(ctx, pattern)
+	if err != nil && gerror.Code(err) != gcode.CodeNotFound {
+		return nil, err
 	}
-	return c.Get(ctx, pattern, def...)
+	if value == nil {
+		if v := command.GetOpt(utils.FormatCmdKey(pattern)); v != "" {
+			return gvar.New(v), nil
+		}
+		if len(def) > 0 {
+			return gvar.New(def[0]), nil
+		}
+		return nil, nil
+	}
+	return value, nil
 }
 
 // Data retrieves and returns all configuration data as map type.

--- a/os/gcfg/gcfg_z_example_test.go
+++ b/os/gcfg/gcfg_z_example_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/os/gcfg"
 	"github.com/gogf/gf/v2/os/gcmd"
@@ -24,9 +23,10 @@ func ExampleConfig_GetWithEnv() {
 		ctx = gctx.New()
 	)
 	v, err := g.Cfg().GetWithEnv(ctx, key)
-	if err == nil {
-		panic(gerror.New("environment variable is not defined"))
+	if err != nil {
+		panic(err)
 	}
+	fmt.Printf("env:%s\n", v)
 	if err = genv.Set(key, "gf"); err != nil {
 		panic(err)
 	}
@@ -37,6 +37,7 @@ func ExampleConfig_GetWithEnv() {
 	fmt.Printf("env:%s", v)
 
 	// Output:
+	// env:
 	// env:gf
 }
 
@@ -46,9 +47,10 @@ func ExampleConfig_GetWithCmd() {
 		ctx = gctx.New()
 	)
 	v, err := g.Cfg().GetWithCmd(ctx, key)
-	if err == nil {
-		panic(gerror.New("command option is not defined"))
+	if err != nil {
+		panic(err)
 	}
+	fmt.Printf("cmd:%s\n", v)
 	// Re-Initialize custom command arguments.
 	os.Args = append(os.Args, fmt.Sprintf(`--%s=yes`, key))
 	gcmd.Init(os.Args...)
@@ -60,6 +62,7 @@ func ExampleConfig_GetWithCmd() {
 	fmt.Printf("cmd:%s", v)
 
 	// Output:
+	// cmd:
 	// cmd:yes
 }
 


### PR DESCRIPTION
## Summary
- Reverts the behavior change introduced in PR #4587 (commit caea7ea4b)
- Restores v2.9.7 priority behavior:
  - `GetWithEnv`: config file > environment variable > default value
  - `GetWithCmd`: config file > command line option > default value

## Related Issue
Closes #4074

## Changes
- `os/gcfg/gcfg.go`: Restore original logic that checks config file first, then falls back to env/cmd
- `os/gcfg/gcfg_z_example_test.go`: Restore original example test expectations