### PR TITLE
feat(i18n/gi18n): decoding and loading i18n files content by automatic file extension check

### DIFF
--- a/i18n/gi18n/gi18n_manager.go
+++ b/i18n/gi18n/gi18n_manager.go
@@ -267,7 +267,8 @@ func (m *Manager) init(ctx context.Context) {
 				if m.data[lang] == nil {
 					m.data[lang] = make(map[string]string)
 				}
-				if j, err := gjson.LoadContent(file.Content()); err == nil {
+				options := gjson.Options{Type: gfile.ExtName(name)}
+				if j, err := gjson.LoadWithOptions(file.Content(), options); err == nil {
 					for k, v := range j.Var().Map() {
 						m.data[lang][k] = gconv.String(v)
 					}

--- a/i18n/gi18n/gi18n_z_unit_test.go
+++ b/i18n/gi18n/gi18n_z_unit_test.go
@@ -159,6 +159,10 @@ func Test_Resource(t *testing.T) {
 
 		m.SetLanguage("zh-CN")
 		t.Assert(m.T(context.Background(), "{#hello}{#world}"), "你好世界")
+
+		m.SetLanguage("ja")
+		const key = "The year is 2128. AI has taken over the world, and all forms of racing is done by these DNA driven machines ; they are alive, and they have a will to win."
+		t.Assert(m.T(context.Background(), "{#"+key+"}"), "2128年です。AIが世界を支配し、あらゆる形式のレースはDNA駆動の機械によって行われています。彼らは生きており、勝つ意志を持っています。")
 	})
 }
 
@@ -215,6 +219,9 @@ func Test_PathInResource(t *testing.T) {
 		t.AssertNil(err)
 		i18n.SetLanguage("ja")
 		t.Assert(i18n.T(context.Background(), "{#hello}{#world}"), "こんにちは世界")
+
+		const key = "The year is 2128. AI has taken over the world, and all forms of racing is done by these DNA driven machines ; they are alive, and they have a will to win."
+		t.Assert(i18n.T(context.Background(), "{#"+key+"}"), "2128年です。AIが世界を支配し、あらゆる形式のレースはDNA駆動の機械によって行われています。彼らは生きており、勝つ意志を持っています。")
 	})
 }
 

--- a/i18n/gi18n/testdata/i18n-dir/ja/world.yaml
+++ b/i18n/gi18n/testdata/i18n-dir/ja/world.yaml
@@ -1,1 +1,3 @@
 world: "世界"
+
+"The year is 2128. AI has taken over the world, and all forms of racing is done by these DNA driven machines ; they are alive, and they have a will to win.": "2128年です。AIが世界を支配し、あらゆる形式のレースはDNA駆動の機械によって行われています。彼らは生きており、勝つ意志を持っています。"

--- a/i18n/gi18n/testdata/i18n/ja.toml
+++ b/i18n/gi18n/testdata/i18n/ja.toml
@@ -1,3 +1,5 @@
 
 hello = "こんにちは"
 world = "世界"
+
+"The year is 2128. AI has taken over the world, and all forms of racing is done by these DNA driven machines ; they are alive, and they have a will to win." = "2128年です。AIが世界を支配し、あらゆる形式のレースはDNA駆動の機械によって行われています。彼らは生きており、勝つ意志を持っています。"


### PR DESCRIPTION
The i18n file handling now checks file extensions instead of content. If no extension info is found, it reverts to checking the file content.