### PR TITLE
fix(registry/etcd): etcd.NewWithClient() has no DialTimeout

### DIFF
--- a/contrib/registry/etcd/etcd.go
+++ b/contrib/registry/etcd/etcd.go
@@ -122,9 +122,13 @@ func NewWithClient(client *etcd3.Client, option ...Option) *Registry {
 		client: client,
 		kv:     etcd3.NewKV(client),
 	}
+	r.etcdConfig.DialTimeout = DefaultDialTimeout
 	if len(option) > 0 {
 		r.logger = option[0].Logger
 		r.keepaliveTTL = option[0].KeepaliveTTL
+		if option[0].DialTimeout > 0 {
+			r.etcdConfig.DialTimeout = option[0].DialTimeout
+		}
 	}
 	if r.logger == nil {
 		r.logger = g.Log()


### PR DESCRIPTION
# Description

The `etcd.NewWithClient()` function internally does not set a `DialTimeout` value, which causes it to default to 0. This leads to all `context.WithTimeout(context.Background(), r.etcdConfig.DialTimeout)` calls immediately timing out, as a timeout of 0 results in instant expiration.

# Example

```go
package main

import (
	"context"
	"testing"
	"time"

	"github.com/gogf/gf/contrib/registry/etcd/v2"
	"github.com/gogf/gf/v2/errors/gerror"
	"github.com/gogf/gf/v2/net/gsvc"
	clientv3 "go.etcd.io/etcd/client/v3"
)

func TestEtcdWithClient(t *testing.T) {
	cli, _ := clientv3.New(clientv3.Config{
		Endpoints:   []string{"http://127.0.0.1:2379"},
		DialTimeout: 2 * time.Second,
	})
	defer cli.Close()

	registry := etcd.NewWithClient(cli)
	_, err := registry.Register(context.Background(), &gsvc.LocalService{
		Name:      "test",
		Endpoints: gsvc.NewEndpoints("127.0.0.1:8888"),
	})
	if err != nil {
		t.Error(gerror.Stack(err))
		return
	}
}
```

Running tool: /opt/homebrew/bin/go test -test.fullpath=true -timeout 30s -run ^TestEtcdWithClient$ etop.roommanageserver

=== RUN   TestEtcdWithClient
{"level":"warn","ts":"2026-01-31T09:59:06.994867+0800","logger":"etcd-client","caller":"v3@v3.6.7/retry_interceptor.go:65","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0x14000262f00/127.0.0.1:2379","method":"/etcdserverpb.Lease/LeaseGrant","attempt":0,"error":"rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
    /Users/guolihui/projects/mpl-poker/room-manage-server/main_test.go:27: 1. etcd grant failed with keepalive ttl "10s"
           1).  github.com/gogf/gf/contrib/registry/etcd/v2.(*Registry).doRegisterLease
                /Users/guolihui/projects/mpl-poker/room-manage-server/gfv2/contrib/registry/etcd/etcd_registrar.go:38
           2).  github.com/gogf/gf/contrib/registry/etcd/v2.(*Registry).Register
                /Users/guolihui/projects/mpl-poker/room-manage-server/gfv2/contrib/registry/etcd/etcd_registrar.go:24
           3).  etop%2eroommanageserver.TestEtcdWithClient
                /Users/guolihui/projects/mpl-poker/room-manage-server/main_test.go:22
        2. context deadline exceeded

--- FAIL: TestEtcdWithClient (0.00s)
