### PR TITLE
fix(databse/gdb): use COUNT(1) if fields number is greater than 1 even when parameter `useFieldForCount` is true in AllAndCount/ScanAndCount

### DIFF
--- a/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
+++ b/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/gogf/gf/v2/container/gvar"
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/encoding/gjson"
-	"github.com/gogf/gf/v2/errors/gcode"
-	"github.com/gogf/gf/v2/errors/gerror"
 	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/os/glog"
 	"github.com/gogf/gf/v2/os/gtime"
@@ -698,17 +696,17 @@ func Test_Model_AllAndCount(t *testing.T) {
 		t.Assert(all[0]["passport"], "user_1")
 		t.Assert(count, 1)
 	})
-	// AllAndCount with Join return CodeDbOperationError
+	// AllAndCount with Join and multiple fields
+	// Regression test for #4698 - should use COUNT(1) not COUNT(field1, field2, ...)
 	gtest.C(t, func(t *gtest.T) {
 		all, count, err := db.Model(table).As("u1").
 			LeftJoin(tableName2, "u2", "u2.id=u1.id").
 			Fields("u1.passport,u1.id,u2.name,u2.age").
 			Where("u1.id<2").
 			AllAndCount(true)
-		t.AssertNE(err, nil)
-		t.AssertEQ(gerror.Code(err), gcode.CodeDbOperationError)
-		t.Assert(count, 0)
-		t.Assert(all, nil)
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+		t.Assert(count, 1)
 	})
 }
 
@@ -1390,10 +1388,10 @@ func Test_Model_ScanAndCount(t *testing.T) {
 			Fields("u1.passport,u1.id,u2.name,u2.age").
 			Where("u1.id<2").
 			ScanAndCount(&users, &count, true)
-		t.AssertNE(err, nil)
-		t.Assert(gerror.Code(err), gcode.CodeDbOperationError)
-		t.Assert(count, 0)
-		t.AssertEQ(users, nil)
+		// Regression test for #4698 - should use COUNT(1) not COUNT(field1, field2, ...)
+		t.AssertNil(err)
+		t.Assert(len(users), 1)
+		t.Assert(count, 1)
 	})
 }
 


### PR DESCRIPTION
## Summary
Fix bug where `AllAndCount(true)` with multiple fields generates invalid SQL `COUNT(field1, field2, ...)` causing syntax error.

## Root Cause
When `useFieldForCount=true`, the COUNT query inherits the fields configuration from the model:
```go
// Before (buggy code)
if !useFieldForCount {
    countModel.fields = []any{Raw("1")}
}
// When useFieldForCount=true, fields remain as ["id", "nickname"]
// Generates: SELECT COUNT(id, nickname) FROM table ❌
```

## Fix
Always use `COUNT(1)` regardless of `useFieldForCount` parameter since COUNT() accepts only one argument:
```go
// After (fixed code)
// Always use COUNT(1) for counting, regardless of useFieldForCount.
// COUNT() accepts only one argument, so we can't use multiple fields.
countModel.fields = []any{Raw("1")}
```

Applied to both `AllAndCount()` and `ScanAndCount()` methods.

## Tests
Added `Test_Issue4698` with 5 test cases:
1. AllAndCount(true) with multiple fields
2. AllAndCount(false) with multiple fields (baseline)
3. ScanAndCount with multiple fields
4. AllAndCount with single field
5. AllAndCount with WHERE condition

All tests verify that COUNT generates valid SQL and returns correct count.

## Related
Fixes #4698
Ref #4703 (discovered during pagination test development)