### PR TITLE
fix(contrib/registry/zk): fix multi svc instance, instance info is deleted.

### DIFF
--- a/contrib/registry/zookeeper/zookeeper_discovery.go
+++ b/contrib/registry/zookeeper/zookeeper_discovery.go
@@ -19,6 +19,9 @@ import (
 
 // Search searches and returns services with specified condition.
 func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Service, error) {
+	if in.Prefix == "" && in.Name != "" {
+		in.Prefix = gsvc.NewServiceWithName(in.Name).GetPrefix()
+	}
 	prefix := strings.Trim(strings.ReplaceAll(in.Prefix, "/", "-"), "-")
 	instances, err, _ := r.group.Do(prefix, func() (any, error) {
 		serviceNamePath := path.Join(r.opts.namespace, prefix)
@@ -65,8 +68,9 @@ func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Servic
 			"Error with group do",
 		)
 	}
-	// Service filter.
-	filteredServices := make([]gsvc.Service, 0)
+	// Service filter and merge instances with the same prefix into one service.
+	mergedMap := make(map[string]*gsvc.LocalService)
+	mergedOrder := make([]string, 0)
 	for _, service := range instances.([]gsvc.Service) {
 		if in.Prefix != "" && !gstr.HasPrefix(service.GetKey(), in.Prefix) {
 			continue
@@ -84,8 +88,28 @@ func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Servic
 				continue
 			}
 		}
-		resultItem := service
-		filteredServices = append(filteredServices, resultItem)
+		servicePrefix := service.GetPrefix()
+		if merged, ok := mergedMap[servicePrefix]; ok {
+			merged.Endpoints = append(merged.Endpoints, service.GetEndpoints()...)
+		} else {
+			ls := &gsvc.LocalService{
+				Name:      service.GetName(),
+				Version:   service.GetVersion(),
+				Endpoints: append(gsvc.Endpoints{}, service.GetEndpoints()...),
+				Metadata:  service.GetMetadata(),
+			}
+			if localSvc, ok2 := service.(*gsvc.LocalService); ok2 {
+				ls.Head = localSvc.Head
+				ls.Deployment = localSvc.Deployment
+				ls.Namespace = localSvc.Namespace
+			}
+			mergedMap[servicePrefix] = ls
+			mergedOrder = append(mergedOrder, servicePrefix)
+		}
+	}
+	filteredServices := make([]gsvc.Service, 0, len(mergedOrder))
+	for _, key := range mergedOrder {
+		filteredServices = append(filteredServices, mergedMap[key])
 	}
 	return filteredServices, nil
 }

--- a/contrib/registry/zookeeper/zookeeper_registrar.go
+++ b/contrib/registry/zookeeper/zookeeper_registrar.go
@@ -18,6 +18,13 @@ import (
 	"github.com/gogf/gf/v2/net/gsvc"
 )
 
+// serviceInstanceLeaf returns a unique ZooKeeper leaf node name for the service instance.
+// It is derived from the service's endpoints so that multiple instances of the same service
+// can coexist as separate children under the service prefix path.
+func serviceInstanceLeaf(service gsvc.Service) string {
+	return strings.NewReplacer(":", "-", ",", "_").Replace(service.GetEndpoints().String())
+}
+
 // Register registers `service` to Registry.
 // Note that it returns a new Service if it changes the input Service with custom one.
 func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Service, error) {
@@ -51,7 +58,7 @@ func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Servi
 			"Error with marshal Content to Json string",
 		)
 	}
-	servicePath := path.Join(servicePrefixPath, service.GetName())
+	servicePath := path.Join(servicePrefixPath, serviceInstanceLeaf(service))
 	if err = r.ensureName(servicePath, data, zk.FlagEphemeral); err != nil {
 		return service, gerror.Wrapf(
 			err,
@@ -67,7 +74,7 @@ func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Servi
 func (r *Registry) Deregister(ctx context.Context, service gsvc.Service) error {
 	ch := make(chan error, 1)
 	prefix := strings.Trim(strings.ReplaceAll(service.GetPrefix(), "/", "-"), "-")
-	servicePath := path.Join(r.opts.namespace, prefix, service.GetName())
+	servicePath := path.Join(r.opts.namespace, prefix, serviceInstanceLeaf(service))
 	go func() {
 		err := r.conn.Delete(servicePath, -1)
 		ch <- err
@@ -94,8 +101,10 @@ func (r *Registry) ensureName(path string, data []byte, flags int32) error {
 		)
 	}
 	// ephemeral nodes handling after restart
-	// fixes a race condition if the server crashes without using CreateProtectedEphemeralSequential()
-	if flags&zk.FlagEphemeral == zk.FlagEphemeral {
+	// fixes a race condition if the server crashes without using CreateProtectedEphemeralSequential().
+	// Only delete when the node already exists to avoid nil dereference on stat and to prevent
+	// a new instance from deleting a sibling instance's node registered at the same path.
+	if exists && flags&zk.FlagEphemeral == zk.FlagEphemeral {
 		err = r.conn.Delete(path, stat.Version)
 		if err != nil && err != zk.ErrNoNode {
 			return gerror.Wrapf(err,

--- a/contrib/registry/zookeeper/zookeeper_z_test.go
+++ b/contrib/registry/zookeeper/zookeeper_z_test.go
@@ -154,6 +154,7 @@ func TestServiceInstanceLeaf(t *testing.T) {
 
 // TestRegistryMultiInstance verifies that multiple instances of the same service
 // can be registered simultaneously without overwriting each other (issue #4149).
+// Search merges instances sharing the same prefix into one LocalService with all endpoints combined.
 func TestRegistryMultiInstance(t *testing.T) {
 	r := New([]string{"127.0.0.1:2181"}, WithRootPath("/gogf"))
 	ctx := context.Background()
@@ -194,10 +195,14 @@ func TestRegistryMultiInstance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Search failed: %v", err)
 	}
-	if len(services) != 2 {
-		t.Fatalf("expected 2 instances after multi-instance registration, got %d", len(services))
+	if len(services) != 1 {
+		t.Fatalf("expected 1 merged service entry, got %d", len(services))
 	}
-	g.Log().Infof(ctx, "Found %d service instances (expected 2)", len(services))
+	endpoints := services[0].GetEndpoints()
+	if len(endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints after multi-instance registration, got %d", len(endpoints))
+	}
+	g.Log().Infof(ctx, "Found %d endpoints in merged service (expected 2)", len(endpoints))
 
 	if err = r.Deregister(ctx, s1); err != nil {
 		t.Fatalf("Deregister svc1 failed: %v", err)

--- a/contrib/registry/zookeeper/zookeeper_z_test.go
+++ b/contrib/registry/zookeeper/zookeeper_z_test.go
@@ -129,6 +129,84 @@ func TestGetService(t *testing.T) {
 	}
 }
 
+// TestServiceInstanceLeaf verifies that serviceInstanceLeaf produces a valid,
+// unique ZooKeeper node name from endpoint information.
+func TestServiceInstanceLeaf(t *testing.T) {
+	cases := []struct {
+		endpoints string
+		expected  string
+	}{
+		{"127.0.0.1:9000", "127.0.0.1-9000"},
+		{"10.0.0.1:8080", "10.0.0.1-8080"},
+	}
+	for _, c := range cases {
+		svc := &gsvc.LocalService{
+			Name:      "leaf-test-svc",
+			Version:   "v1.0.0",
+			Endpoints: gsvc.NewEndpoints(c.endpoints),
+		}
+		got := serviceInstanceLeaf(svc)
+		if got != c.expected {
+			t.Fatalf("serviceInstanceLeaf(%q) = %q, want %q", c.endpoints, got, c.expected)
+		}
+	}
+}
+
+// TestRegistryMultiInstance verifies that multiple instances of the same service
+// can be registered simultaneously without overwriting each other (issue #4149).
+func TestRegistryMultiInstance(t *testing.T) {
+	r := New([]string{"127.0.0.1:2181"}, WithRootPath("/gogf"))
+	ctx := context.Background()
+
+	// Two instances of the same service on different ports.
+	svc1 := &gsvc.LocalService{
+		Name:      "multi-instance-svc",
+		Version:   "v1.0.0",
+		Metadata:  map[string]any{"app": "goframe", gsvc.MDProtocol: "tcp"},
+		Endpoints: gsvc.NewEndpoints("127.0.0.1:19001"),
+	}
+	svc2 := &gsvc.LocalService{
+		Name:      "multi-instance-svc",
+		Version:   "v1.0.0",
+		Metadata:  map[string]any{"app": "goframe", gsvc.MDProtocol: "tcp"},
+		Endpoints: gsvc.NewEndpoints("127.0.0.1:19002"),
+	}
+
+	s1, err := r.Register(ctx, svc1)
+	if err != nil {
+		t.Fatalf("Register svc1 failed: %v", err)
+	}
+
+	s2, err := r.Register(ctx, svc2)
+	if err != nil {
+		t.Fatalf("Register svc2 failed: %v", err)
+	}
+
+	// Allow ZK to settle.
+	time.Sleep(200 * time.Millisecond)
+
+	// Both instances should be discoverable.
+	services, err := r.Search(ctx, gsvc.SearchInput{
+		Prefix:  svc1.GetPrefix(),
+		Name:    svc1.Name,
+		Version: svc1.Version,
+	})
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if len(services) != 2 {
+		t.Fatalf("expected 2 instances after multi-instance registration, got %d", len(services))
+	}
+	g.Log().Infof(ctx, "Found %d service instances (expected 2)", len(services))
+
+	if err = r.Deregister(ctx, s1); err != nil {
+		t.Fatalf("Deregister svc1 failed: %v", err)
+	}
+	if err = r.Deregister(ctx, s2); err != nil {
+		t.Fatalf("Deregister svc2 failed: %v", err)
+	}
+}
+
 // TestWatch Test Watch
 func TestWatch(t *testing.T) {
 	r := New([]string{"127.0.0.1:2181"}, WithRootPath("/gogf"))


### PR DESCRIPTION
- For #4717 


## Demo

### Client

```go
package main

import (
	"fmt"
	"time"

	"github.com/gogf/gf/contrib/registry/zookeeper/v2"
	"github.com/gogf/gf/v2/frame/g"
	"github.com/gogf/gf/v2/net/gsel"
	"github.com/gogf/gf/v2/net/gsvc"
	"github.com/gogf/gf/v2/os/gctx"
)

func main() {
	r := zookeeper.New(
		[]string{"zookeeper.zookeeper.orb.local"}, zookeeper.WithRootPath("/gogf"),
	)
	gsvc.SetRegistry(r)
	gsel.SetBuilder(gsel.NewBuilderRoundRobin())

	var (
		ctx    = gctx.New()
		client = g.Client()
	)
	client.SetDiscovery(r)

	for i := 0; i < 15; i++ {
		res, err := client.Get(ctx, `http://hello.svc/`)
		if err != nil {
			panic(err)
		}
		fmt.Println(res.ReadAllString())
		res.Close()
		time.Sleep(time.Second)
	}
}
```

### Server1

```go
package main

import (
	"github.com/gogf/gf/contrib/registry/zookeeper/v2"
	"github.com/gogf/gf/v2/frame/g"
	"github.com/gogf/gf/v2/net/ghttp"
	"github.com/gogf/gf/v2/net/gsvc"
)

func main() {
	gsvc.SetRegistry(zookeeper.New(
		[]string{"zookeeper.zookeeper.orb.local"}, zookeeper.WithRootPath("/gogf"),
	))

	s := g.Server(`hello.svc`)
	s.SetAddr("192.168.148.229:0")
	s.BindHandler("/", func(r *ghttp.Request) {
		g.Log().Info(r.Context(), `request received`)
		r.Response.Write(`Hello world`)
	})
	s.Run()
}
```

### Server 2

```go
package main

import (
	"github.com/gogf/gf/contrib/registry/zookeeper/v2"
	"github.com/gogf/gf/v2/frame/g"
	"github.com/gogf/gf/v2/net/ghttp"
	"github.com/gogf/gf/v2/net/gsvc"
)

func main() {
	gsvc.SetRegistry(zookeeper.New(
		[]string{"zookeeper.zookeeper.orb.local"}, zookeeper.WithRootPath("/gogf"),
	))

	s := g.Server(`hello.svc`)
	s.SetAddr("192.168.148.229:0")
	s.BindHandler("/", func(r *ghttp.Request) {
		g.Log().Info(r.Context(), `request received`)
		r.Response.Write(`Hello world`)
	})
	s.Run()
}
```

## Run test

### Client

```
API server listening at: 127.0.0.1:49777
WARNING: undefined behavior - version of Delve is too old for Go version go1.25.2 (maximum supported version 1.24)
2026/03/01 21:15:56 connected to [fd07:b51a:cc66:0:a617:db5e:c0a8:8a06]:2181
2026/03/01 21:15:56 authenticated: id=72057704388624412, timeout=40000
2026/03/01 21:15:56 re-submitting `0` credentials after reconnect
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world
Hello world

Debugger finished with the exit code 0
```

### Server1

```
API server listening at: 127.0.0.1:49759
WARNING: undefined behavior - version of Delve is too old for Go version go1.25.2 (maximum supported version 1.24)
2026/03/01 21:15:50 connected to 192.168.138.6:2181
2026-03-01T21:15:50.237+08:00 [INFO] pid[47505]: http server started listening on [192.168.148.229:49767]
2026-03-01T21:15:50.237+08:00 [INFO] openapi specification is disabled
2026-03-01T21:15:50.237+08:00 [DEBU] service register: &{Head: Deployment: Namespace: Name:hello.svc Version: Endpoints:192.168.148.229:49767 Metadata:map[insecure:true protocol:http]}
2026/03/01 21:15:50 authenticated: id=72057704388624410, timeout=40000
2026/03/01 21:15:50 re-submitting `0` credentials after reconnect

------------|---------|-----------------------|--------|-------|-----------------|-------------
|  SERVER   | DOMAIN  |        ADDRESS        | METHOD | ROUTE |     HANDLER     | MIDDLEWARE |
------------|---------|-----------------------|--------|-------|-----------------|-------------
| hello.svc | default | 192.168.148.229:49767 | ALL    | /     | main.main.func1 |            |
------------|---------|-----------------------|--------|-------|-----------------|-------------

2026-03-01T21:15:56.433+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:15:58.439+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:16:00.444+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:16:02.448+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:16:04.453+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:16:06.459+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:16:08.463+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
2026-03-01T21:16:10.468+08:00 [INFO] {008a0093feb998182b7049109b9be5a2} request received
```

### Server2

```
API server listening at: 127.0.0.1:49810
WARNING: undefined behavior - version of Delve is too old for Go version go1.25.2 (maximum supported version 1.24)
2026/03/01 21:16:53 connected to [fd07:b51a:cc66:0:a617:db5e:c0a8:8a06]:2181
2026/03/01 21:16:53 authenticated: id=72057704388624413, timeout=40000
2026/03/01 21:16:53 re-submitting `0` credentials after reconnect
2026-03-01T21:16:53.506+08:00 [INFO] pid[47549]: http server started listening on [192.168.148.229:49820]
2026-03-01T21:16:53.506+08:00 [INFO] openapi specification is disabled
2026-03-01T21:16:53.506+08:00 [DEBU] service register: &{Head: Deployment: Namespace: Name:hello.svc Version: Endpoints:192.168.148.229:49820 Metadata:map[insecure:true protocol:http]}

------------|---------|-----------------------|--------|-------|-----------------|-------------
|  SERVER   | DOMAIN  |        ADDRESS        | METHOD | ROUTE |     HANDLER     | MIDDLEWARE |
------------|---------|-----------------------|--------|-------|-----------------|-------------
| hello.svc | default | 192.168.148.229:49820 | ALL    | /     | main.main.func1 |            |
------------|---------|-----------------------|--------|-------|-----------------|-------------

2026-03-01T21:16:57.437+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
2026-03-01T21:16:59.441+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
2026-03-01T21:17:01.447+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
2026-03-01T21:17:03.451+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
2026-03-01T21:17:05.456+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
2026-03-01T21:17:07.460+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
2026-03-01T21:17:09.465+08:00 [INFO] {705de48a0cba98181bcbcc58bf739171} request received
```

## Check zk svc

```go
package main

import (
	"fmt"
	"time"

	"github.com/go-zookeeper/zk"
)

func listAll(c *zk.Conn, path string) {
	children, _, err := c.Children(path)
	if err != nil {
		fmt.Printf("[ERR] %s: %v\n", path, err)
		return
	}
	fmt.Printf("[DIR] %s => %v\n", path, children)
	for _, child := range children {
		var full string
		if path == "/" {
			full = "/" + child
		} else {
			full = path + "/" + child
		}
		data, _, _ := c.Get(full)
		if len(data) > 0 {
			fmt.Printf("  [DATA] %s = %s\n", full, string(data))
		}
		listAll(c, full)
	}
}

func main() {
	c, _, err := zk.Connect([]string{"192.168.138.6:2181"}, 10*time.Second)
	if err != nil {
		panic(err)
	}
	defer c.Close()
	time.Sleep(time.Second)
	listAll(c, "/gogf")
}
```

```
2026/03/01 21:04:06 connected to 192.168.138.6:2181
2026/03/01 21:04:06 authenticated: id=72057704388624399, timeout=10000
2026/03/01 21:04:06 re-submitting `0` credentials after reconnect
[DIR] /gogf => [service-default-default-hello.svc-latest service-default-default-multi-instance-svc-v1.0.0]
[DIR] /gogf/service-default-default-hello.svc-latest => [192.168.148.229-65462_192.168.139.3-65462_192.168.164.0-65462 192.168.148.229-65470_192.168.139.3-65470_192.168.164.0-65470]
  [DATA] /gogf/service-default-default-hello.svc-latest/192.168.148.229-65462_192.168.139.3-65462_192.168.164.0-65462 = {"Key":"/service/default/default/hello.svc/latest/192.168.148.229:65462,192.168.139.3:65462,192.168.164.0:65462","Value":"{\"insecure\":true,\"protocol\":\"http\"}"}
[DIR] /gogf/service-default-default-hello.svc-latest/192.168.148.229-65462_192.168.139.3-65462_192.168.164.0-65462 => []
  [DATA] /gogf/service-default-default-hello.svc-latest/192.168.148.229-65470_192.168.139.3-65470_192.168.164.0-65470 = {"Key":"/service/default/default/hello.svc/latest/192.168.148.229:65470,192.168.139.3:65470,192.168.164.0:65470","Value":"{\"insecure\":true,\"protocol\":\"http\"}"}
[DIR] /gogf/service-default-default-hello.svc-latest/192.168.148.229-65470_192.168.139.3-65470_192.168.164.0-65470 => []
[DIR] /gogf/service-default-default-multi-instance-svc-v1.0.0 => []
2026/03/01 21:04:07 recv loop terminated: EOF
```
