### PR TITLE
test(contrib/drivers/mysql): add nil check in Test_DB_Ctx

### DIFF
--- a/contrib/drivers/mysql/mysql_z_unit_core_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_core_test.go
@@ -1570,6 +1570,7 @@ func Test_DB_Ctx(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		_, err := db.Query(ctx, "SELECT SLEEP(10)")
+		t.AssertNE(err, nil)
 		t.Assert(gstr.Contains(err.Error(), "deadline"), true)
 	})
 }


### PR DESCRIPTION
## Summary

Add `t.AssertNE(err, nil)` before `err.Error()` in `Test_DB_Ctx` to prevent potential nil pointer panic if the context-timeout query unexpectedly succeeds.

## Changes

- `contrib/drivers/mysql/mysql_z_unit_core_test.go`: Add nil check for err before accessing err.Error() in Test_DB_Ctx

ref #4689