### PR TITLE
feat(os/glog)add-slog-attrs【glog支持slog.Attr属性】

### DIFF
--- a/os/glog/glog.go
+++ b/os/glog/glog.go
@@ -9,6 +9,7 @@ package glog
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/gogf/gf/v2/internal/command"
 	"github.com/gogf/gf/v2/os/grpool"
@@ -17,6 +18,7 @@ import (
 
 // ILogger is the API interface for logger.
 type ILogger interface {
+	Attrs(attrs ...slog.Attr) ILogger
 	Print(ctx context.Context, v ...any)
 	Printf(ctx context.Context, format string, v ...any)
 	Debug(ctx context.Context, v ...any)

--- a/os/glog/glog_api.go
+++ b/os/glog/glog_api.go
@@ -6,7 +6,15 @@
 
 package glog
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
+
+func Attrs(attrs ...slog.Attr) ILogger {
+	defaultLogger.Attrs(attrs...)
+	return defaultLogger
+}
 
 // Print prints `v` with newline using fmt.Sprintln.
 // The parameter `v` can be multiple variables.

--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -115,7 +115,7 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 				index: -1,
 			},
 			Logger:   l,
-			AllAttrs: append([]slog.Attr(nil), l.attrs[:]...),
+			AllAttrs: append([]slog.Attr(nil), l.attrs...),
 			Buffer:   bytes.NewBuffer(nil),
 			Time:     now,
 			Color:    defaultLevelColor[level],

--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -115,7 +115,7 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 				index: -1,
 			},
 			Logger:   l,
-			AllAttrs: l.attrs,
+			AllAttrs: append([]slog.Attr(nil), l.attrs[:]...),
 			Buffer:   bytes.NewBuffer(nil),
 			Time:     now,
 			Color:    defaultLevelColor[level],

--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -36,6 +37,7 @@ import (
 type Logger struct {
 	parent *Logger // Parent logger, if it is not empty, it means the logger is used in chaining function.
 	config Config  // Logger configuration.
+	attrs  []slog.Attr
 }
 
 const (
@@ -79,6 +81,7 @@ func (l *Logger) Clone() *Logger {
 	return &Logger{
 		config: l.config,
 		parent: l,
+		attrs:  l.attrs,
 	}
 }
 
@@ -112,13 +115,14 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 			internalHandlerInfo: internalHandlerInfo{
 				index: -1,
 			},
-			Logger: l,
-			Buffer: bytes.NewBuffer(nil),
-			Time:   now,
-			Color:  defaultLevelColor[level],
-			Level:  level,
-			Stack:  stack,
-			Values: values,
+			Logger:   l,
+			AllAttrs: l.attrs,
+			Buffer:   bytes.NewBuffer(nil),
+			Time:     now,
+			Color:    defaultLevelColor[level],
+			Level:    level,
+			Stack:    stack,
+			Values:   values,
 		}
 	)
 
@@ -207,6 +211,14 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 			}
 		}
 	}
+	if l.parent != nil {
+		var current = l
+		for current.parent != nil {
+			input.AllAttrs = append(input.AllAttrs, current.parent.attrs...)
+			current = current.parent
+		}
+	}
+
 	if l.config.Flags&F_ASYNC > 0 {
 		input.IsAsync = true
 		err := asyncPool.Add(ctx, func(ctx context.Context) {
@@ -244,6 +256,7 @@ func (l *Logger) doFinalPrint(ctx context.Context, input *HandlerInput) *bytes.B
 			buffer = buf
 		}
 	}
+	l.attrs = nil
 	return buffer
 }
 

--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -81,7 +81,6 @@ func (l *Logger) Clone() *Logger {
 	return &Logger{
 		config: l.config,
 		parent: l,
-		attrs:  l.attrs,
 	}
 }
 

--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fatih/color"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/debug/gdebug"
 	"github.com/gogf/gf/v2/internal/consts"
 	"github.com/gogf/gf/v2/internal/errors"
@@ -37,7 +38,7 @@ import (
 type Logger struct {
 	parent *Logger // Parent logger, if it is not empty, it means the logger is used in chaining function.
 	config Config  // Logger configuration.
-	attrs  []slog.Attr
+	attrs  garray.TArray[*slog.Attr]
 }
 
 const (
@@ -65,6 +66,7 @@ const (
 func New() *Logger {
 	return &Logger{
 		config: DefaultConfig(),
+		attrs:  *garray.NewTArray[*slog.Attr](true),
 	}
 }
 
@@ -81,6 +83,7 @@ func (l *Logger) Clone() *Logger {
 	return &Logger{
 		config: l.config,
 		parent: l,
+		attrs:  *garray.NewTArray[*slog.Attr](true),
 	}
 }
 
@@ -115,7 +118,7 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 				index: -1,
 			},
 			Logger:   l,
-			AllAttrs: append([]slog.Attr(nil), l.attrs...),
+			AllAttrs: l.attrs.Slice(),
 			Buffer:   bytes.NewBuffer(nil),
 			Time:     now,
 			Color:    defaultLevelColor[level],
@@ -213,7 +216,7 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 	if l.parent != nil {
 		var current = l
 		for current.parent != nil {
-			input.AllAttrs = append(input.AllAttrs, current.parent.attrs...)
+			input.AllAttrs = append(input.AllAttrs, current.parent.attrs.Slice()...)
 			current = current.parent
 		}
 	}
@@ -255,7 +258,7 @@ func (l *Logger) doFinalPrint(ctx context.Context, input *HandlerInput) *bytes.B
 			buffer = buf
 		}
 	}
-	l.attrs = nil
+	l.attrs.Clear()
 	return buffer
 }
 

--- a/os/glog/glog_logger_api.go
+++ b/os/glog/glog_logger_api.go
@@ -11,10 +11,17 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 )
 
 func (l *Logger) Attrs(attrs ...slog.Attr) ILogger {
-	l.attrs = append(l.attrs, attrs...)
+	l.attrs.Append(slices.Collect(func(yield func(v *slog.Attr) bool) {
+		for _, attr := range attrs {
+			if !yield(&attr) {
+				return
+			}
+		}
+	})...)
 	return l
 }
 

--- a/os/glog/glog_logger_api.go
+++ b/os/glog/glog_logger_api.go
@@ -9,8 +9,14 @@ package glog
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 )
+
+func (l *Logger) Attrs(attrs ...slog.Attr) ILogger {
+	l.attrs = append(l.attrs, attrs...)
+	return l
+}
 
 // Print prints `v` with newline using fmt.Sprintln.
 // The parameter `v` can be multiple variables.

--- a/os/glog/glog_logger_handler.go
+++ b/os/glog/glog_logger_handler.go
@@ -33,7 +33,7 @@ type HandlerInput struct {
 	Logger *Logger
 
 	// Current Logger Attrs.
-	AllAttrs []slog.Attr
+	AllAttrs []*slog.Attr
 
 	// Buffer for logging content outputs.
 	Buffer *bytes.Buffer
@@ -203,7 +203,7 @@ func (in *HandlerInput) getDefaultBuffer(withColor bool) *bytes.Buffer {
 		in.addStringToBuffer(buffer, in.ValuesContent())
 	}
 
-	for _, attr := range in.Logger.attrs {
+	for _, attr := range in.Logger.attrs.Slice() {
 		in.addStringToBuffer(buffer, fmt.Sprintf("%s=%v", attr.Key, attr.Value.Any()))
 	}
 

--- a/os/glog/glog_logger_handler.go
+++ b/os/glog/glog_logger_handler.go
@@ -9,6 +9,8 @@ package glog
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/gogf/gf/v2/util/gconv"
@@ -29,6 +31,9 @@ type HandlerInput struct {
 
 	// Current Logger object.
 	Logger *Logger
+
+	// Current Logger Attrs.
+	AllAttrs []slog.Attr
 
 	// Buffer for logging content outputs.
 	Buffer *bytes.Buffer
@@ -196,6 +201,10 @@ func (in *HandlerInput) getDefaultBuffer(withColor bool) *bytes.Buffer {
 
 	if len(in.Values) > 0 {
 		in.addStringToBuffer(buffer, in.ValuesContent())
+	}
+
+	for _, attr := range in.Logger.attrs {
+		in.addStringToBuffer(buffer, fmt.Sprintf("%s=%v", attr.Key, attr.Value.Any()))
 	}
 
 	if in.Stack != "" {

--- a/os/glog/glog_logger_handler_json.go
+++ b/os/glog/glog_logger_handler_json.go
@@ -38,7 +38,7 @@ func HandlerJson(ctx context.Context, in *HandlerInput) {
 		Prefix:     in.Prefix,
 		Content:    in.Content,
 		Stack:      in.Stack,
-		Attrs:      make(map[string]any, len(in.Logger.attrs)),
+		Attrs:      make(map[string]any, len(in.AllAttrs)),
 	}
 	if len(in.Values) > 0 {
 		if output.Content != "" {

--- a/os/glog/glog_logger_handler_json.go
+++ b/os/glog/glog_logger_handler_json.go
@@ -14,15 +14,16 @@ import (
 
 // HandlerOutputJson is the structure outputting logging content as single json.
 type HandlerOutputJson struct {
-	Time       string `json:""`           // Formatted time string, like "2016-01-09 12:00:00".
-	TraceId    string `json:",omitempty"` // Trace id, only available if tracing is enabled.
-	CtxStr     string `json:",omitempty"` // The retrieved context value string from context, only available if Config.CtxKeys configured.
-	Level      string `json:""`           // Formatted level string, like "DEBU", "ERRO", etc. Eg: ERRO
-	CallerPath string `json:",omitempty"` // The source file path and its line number that calls logging, only available if F_FILE_SHORT or F_FILE_LONG set.
-	CallerFunc string `json:",omitempty"` // The source function name that calls logging, only available if F_CALLER_FN set.
-	Prefix     string `json:",omitempty"` // Custom prefix string for logging content.
-	Content    string `json:""`           // Content is the main logging content, containing error stack string produced by logger.
-	Stack      string `json:",omitempty"` // Stack string produced by logger, only available if Config.StStatus configured.
+	Time       string         `json:""`           // Formatted time string, like "2016-01-09 12:00:00".
+	TraceId    string         `json:",omitempty"` // Trace id, only available if tracing is enabled.
+	CtxStr     string         `json:",omitempty"` // The retrieved context value string from context, only available if Config.CtxKeys configured.
+	Level      string         `json:""`           // Formatted level string, like "DEBU", "ERRO", etc. Eg: ERRO
+	CallerPath string         `json:",omitempty"` // The source file path and its line number that calls logging, only available if F_FILE_SHORT or F_FILE_LONG set.
+	CallerFunc string         `json:",omitempty"` // The source function name that calls logging, only available if F_CALLER_FN set.
+	Prefix     string         `json:",omitempty"` // Custom prefix string for logging content.
+	Content    string         `json:""`           // Content is the main logging content, containing error stack string produced by logger.
+	Stack      string         `json:",omitempty"` // Stack string produced by logger, only available if Config.StStatus configured.
+	Attrs      map[string]any `json:"attrs,omitempty"`
 }
 
 // HandlerJson is a handler for output logging content as a single json string.
@@ -37,6 +38,7 @@ func HandlerJson(ctx context.Context, in *HandlerInput) {
 		Prefix:     in.Prefix,
 		Content:    in.Content,
 		Stack:      in.Stack,
+		Attrs:      make(map[string]any, len(in.Logger.attrs)),
 	}
 	if len(in.Values) > 0 {
 		if output.Content != "" {
@@ -44,6 +46,10 @@ func HandlerJson(ctx context.Context, in *HandlerInput) {
 		}
 		output.Content += in.ValuesContent()
 	}
+	for _, attr := range in.AllAttrs {
+		output.Attrs[attr.Key] = attr.Value.Any()
+	}
+
 	// Output json content.
 	jsonBytes, err := json.Marshal(output)
 	if err != nil {

--- a/os/glog/glog_logger_handler_structure.go
+++ b/os/glog/glog_logger_handler_structure.go
@@ -194,6 +194,10 @@ func (buf *structuredBuffer) Bytes() []byte {
 	if buf.in.Stack != "" {
 		buf.addValue(structureKeyStack, buf.in.Stack)
 	}
+	for _, attr := range buf.in.AllAttrs {
+		buf.addValue(attr.Key, attr.Value.Any())
+	}
+
 	contentBytes := buf.buffer.Bytes()
 	buf.buffer.Reset()
 	contentBytes = bytes.ReplaceAll(contentBytes, []byte{'\n'}, []byte{' '})

--- a/os/glog/glog_z_unit_test.go
+++ b/os/glog/glog_z_unit_test.go
@@ -491,6 +491,17 @@ func Test_Concurrent(t *testing.T) {
 	})
 }
 
+func Test_Attrs(t *testing.T) {
+	ctx := context.Background()
+	glog.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "attr1")
+	glog.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Info(ctx, "print-any1&any2")
+	glog.Attrs(slog.Int64("int64", 1000))
+	cl := glog.DefaultLogger().Clone()
+	cl.SetHandlers(glog.HandlerJson)
+	cl.Attrs(slog.Any("any", "clone-any-attr")).Error(ctx, "clone-error-text")
+	cl.Attrs(slog.Any("any2", "clone-any2-attr")).Error(ctx, "clone-error-text")
+}
+
 func Test_Attrs_Std(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {

--- a/os/glog/glog_z_unit_test.go
+++ b/os/glog/glog_z_unit_test.go
@@ -9,6 +9,9 @@ package glog_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
@@ -485,5 +488,114 @@ func Test_Concurrent(t *testing.T) {
 		wg.Wait()
 		content := gfile.GetContents(gfile.Join(p, f))
 		t.Assert(gstr.Count(content, s), c)
+	})
+}
+
+func Test_Attrs_Std(t *testing.T) {
+
+	gtest.C(t, func(t *gtest.T) {
+		ctx := context.Background()
+		glog.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "attr1")
+		glog.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Info(ctx, "print-any1&any2")
+
+		glog.SetHandlers(glog.HandlerJson)
+		glog.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "json-handler-attr1")
+		glog.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Warning(ctx, "json-handler-print-any1&any2")
+
+		glog.SetHandlers(glog.HandlerStructure)
+		glog.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "struct-handler-attr1")
+		glog.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Error(ctx, "struct-handler-print-any1&any2")
+	})
+}
+func Test_Attrs_New(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		l := glog.New()
+		ctx := context.Background()
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Info(ctx, "print-any1&any2")
+
+		l.SetHandlers(glog.HandlerJson)
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "json-handler-attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Warning(ctx, "json-handler-print-any1&any2")
+
+		l.SetHandlers(glog.HandlerStructure)
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "struct-handler-attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Error(ctx, "struct-handler-print-any1&any2")
+	})
+
+}
+func Test_Attrs_Default(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		l := glog.DefaultLogger()
+		ctx := context.Background()
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Info(ctx, "print-any1&any2")
+
+		l.SetHandlers(glog.HandlerJson)
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Info(ctx, "json-handler-attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Warning(ctx, "json-handler-print-any1&any2")
+
+		l.SetHandlers(glog.HandlerStructure)
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Info(ctx, "struct-handler-attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Error(ctx, "struct-handler-print-any1&any2")
+
+		l.SetHandlers(glog.HandlerJson)
+		l.Attrs(slog.Int64("int64", 1000))
+		l.Clone().Attrs(slog.Any("any", "clone-any-attr")).Info(ctx, "clone-info-text")
+		l.Info(ctx, "source-info-ctx")
+	})
+
+}
+func Test_Attrs_WithWriter(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		l := glog.NewWithWriter(os.Stdout)
+		l.SetStdoutPrint(false)
+		ctx := context.Background()
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Info(ctx, "print-any1&any2")
+
+		l.SetHandlers(glog.HandlerJson)
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Info(ctx, "json-handler-attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Warning(ctx, "json-handler-warning-any1&any2")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Error(ctx, "struct-handler-error-any1&any2")
+
+		l.SetHandlers(glog.HandlerStructure)
+		l.Attrs(slog.Int("int", 1), slog.String("str", "str")).Info(ctx, "struct-handler-attr1")
+		l.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Error(ctx, "struct-handler-print-any1&any2")
+
+		l.SetHandlers(glog.HandlerJson)
+		l.Attrs(slog.Int64("int64", 1000))
+		l.Clone().Attrs(slog.Any("any", "clone-any-attr")).Info(ctx, "clone-info-text")
+		l.Info(ctx, "source-info-ctx")
+
+		l.SetHandlers(func(ctx context.Context, in *glog.HandlerInput) {
+			var (
+				json_map = map[string]any{
+					"time":  in.Time,
+					"msg":   in.ValuesContent(),
+					"lv":    in.LevelFormat,
+					"stack": in.Stack,
+				}
+				log_others = map[string]any{}
+				josn_bytes []byte
+				err        error
+			)
+			for _, attr := range in.AllAttrs {
+				log_others[attr.Key] = attr.Value.Any()
+			}
+			json_map["other"] = log_others
+
+			if josn_bytes, err = json.Marshal(json_map); err != nil {
+				panic(err)
+			}
+			if _, err = fmt.Fprint(in.Buffer, string(josn_bytes), "\n"); err != nil {
+				panic(err)
+			}
+			in.Next(ctx)
+		})
+		l.Attrs(slog.Int64("int64", 1000))
+		cl := l.Clone()
+		cl.Attrs(slog.Any("any", "clone-any-attr")).Error(ctx, "clone-error-text")
+		cl.Attrs(slog.Any("any2", "clone-any2-attr")).Error(ctx, "clone-error-text")
 	})
 }


### PR DESCRIPTION
`glog` 添加 `Attrs(attrs ...slog.Attr)` 属性，展示为单独的内容/属性，避免和 `Content` 合并
```golang
func Test_Attrs(t *testing.T) {
	ctx := context.Background()
	glog.Attrs(slog.Int("int", 1), slog.String("str", "str")).Print(ctx, "attr1")
	glog.Attrs(slog.Any("any1", "any1")).Attrs(slog.Any("any2", "any2")).Info(ctx, "print-any1&any2")
	glog.Attrs(slog.Int64("int64", 1000))
	cl := glog.DefaultLogger().Clone()
	cl.SetHandlers(glog.HandlerJson)
	cl.Attrs(slog.Any("any", "clone-any-attr")).Error(ctx, "clone-error-text")
	cl.Attrs(slog.Any("any2", "clone-any2-attr")).Error(ctx, "clone-error-text")
}
```