### PR TITLE
fix(gstr): collect repeated query params into slice

### DIFF
--- a/text/gstr/gstr_parse.go
+++ b/text/gstr/gstr_parse.go
@@ -105,7 +105,16 @@ func build(result map[string]any, keys []string, value any) error {
 		key    = strings.Trim(keys[0], "'\"")
 	)
 	if length == 1 {
-		result[key] = value
+		existing, ok := result[key]
+		if !ok {
+			result[key] = value
+			return nil
+		}
+		if children, ok := existing.([]any); ok {
+			result[key] = append(children, value)
+		} else {
+			result[key] = []any{existing, value}
+		}
 		return nil
 	}
 

--- a/text/gstr/gstr_z_unit_parse_test.go
+++ b/text/gstr/gstr_z_unit_parse_test.go
@@ -96,11 +96,11 @@ func Test_Parse(t *testing.T) {
 		t.Assert(m["name"], "john")
 		t.Assert(m["score"], "100")
 
-		// name overwrite
+		// repeated key accumulates into slice
 		m, err = gstr.Parse("a=1&a=2")
 		t.AssertNil(err)
 		t.Assert(m, g.Map{
-			"a": 2,
+			"a": g.Slice{"1", "2"},
 		})
 		// slice
 		m, err = gstr.Parse("a[]=1&a[]=2")
@@ -119,7 +119,7 @@ func Test_Parse(t *testing.T) {
 		m, err = gstr.Parse("a=1&a=2&c=3")
 		t.AssertNil(err)
 		t.Assert(m, g.Map{
-			"a": "2",
+			"a": g.Slice{"1", "2"},
 			"c": "3",
 		})
 		// map
@@ -136,7 +136,7 @@ func Test_Parse(t *testing.T) {
 		t.AssertNil(err)
 		t.Assert(m, g.Map{
 			"m": g.Map{
-				"a": "2",
+				"a": g.Slice{"1", "2"},
 				"b": "3",
 			},
 		})


### PR DESCRIPTION
Fixes #4751

Parse was dropping earlier values when a query parameter appeared more than once, only keeping the last one. Changed the logic in build() to accumulate duplicate keys into a slice instead of overwriting. Updated the tests.