### PR TITLE
feat(net/goai): add configurable type mapping for oai type

### DIFF
--- a/net/goai/goai.go
+++ b/net/goai/goai.go
@@ -144,6 +144,9 @@ func (oai *OpenApiV3) golangTypeToOAIType(t reflect.Type) string {
 	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
+	if customType, ok := oai.getCustomOAITypeByGolangType(t); ok {
+		return customType
+	}
 
 	switch t.String() {
 	case `time.Time`, `gtime.Time`:
@@ -182,6 +185,22 @@ func (oai *OpenApiV3) golangTypeToOAIType(t reflect.Type) string {
 	default:
 		return TypeObject
 	}
+}
+
+func (oai *OpenApiV3) getCustomOAITypeByGolangType(t reflect.Type) (string, bool) {
+	if len(oai.Config.TypeMapping) == 0 || t == nil {
+		return "", false
+	}
+	if customType, ok := oai.Config.TypeMapping[t.String()]; ok {
+		return customType, true
+	}
+	if t.PkgPath() != "" && t.Name() != "" {
+		typeId := fmt.Sprintf(`%s.%s`, t.PkgPath(), t.Name())
+		if customType, ok := oai.Config.TypeMapping[typeId]; ok {
+			return customType, true
+		}
+	}
+	return "", false
 }
 
 // golangTypeToOAIFormat converts and returns OpenAPI parameter format for given golang type `t`.

--- a/net/goai/goai_config.go
+++ b/net/goai/goai_config.go
@@ -15,6 +15,11 @@ type Config struct {
 	CommonResponse          any      // Common response structure for all paths.
 	CommonResponseDataField string   // Common response field name to be replaced with certain business response structure. Eg: `Data`, `Response.`.
 	IgnorePkgPath           bool     // Ignores package name for schema name.
+	// TypeMapping customizes OpenAPI type mapping for given golang types.
+	// Map key supports both short type name and full type id:
+	// 1. `carbon.Carbon`
+	// 2. `github.com/golang-module/carbon/v2.Carbon`
+	TypeMapping map[string]string
 }
 
 // fillWithDefaultValue fills configuration object of `oai` with default values if these are not configured.

--- a/net/goai/goai_z_unit_test.go
+++ b/net/goai/goai_z_unit_test.go
@@ -1377,3 +1377,35 @@ func Test_ValidationRules(t *testing.T) {
 		t.Assert(schema.Properties.Get("Address").Value.MaxLength, 64)
 	})
 }
+
+func Test_TypeMapping(t *testing.T) {
+	type Carbon struct {
+		Timestamp int64 `json:"timestamp"`
+	}
+	type Req struct {
+		gmeta.Meta `path:"/CreateResourceReq" method:"POST" tags:"default"`
+		At         Carbon `dc:"time value" json:"at"`
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			err error
+			oai = goai.New()
+			req = new(Req)
+		)
+		oai.Config.TypeMapping = map[string]string{
+			"goai_test.Carbon": goai.TypeString,
+		}
+
+		err = oai.Add(goai.AddInput{
+			Object: req,
+		})
+		t.AssertNil(err)
+
+		var reqKey = "github.com.gogf.gf.v2.net.goai_test.Req"
+		t.Assert(
+			oai.Components.Schemas.Get(reqKey).Value.Properties.Get("at").Value.Type,
+			goai.TypeString,
+		)
+	})
+}


### PR DESCRIPTION
### Summary
This PR adds a configurable type mapping mechanism in `goai` so specific Go types can be generated as custom OpenAPI schema types.  
This solves cases like `carbon.Carbon`, which should be emitted as `string` instead of `object`.

### Changes
- added `Config.TypeMapping map[string]string` in `net/goai`
- applied type mapping in `golangTypeToOAIType` before default type inference
- supported both mapping key formats:
  - short type name, e.g. `carbon.Carbon`
  - full type id, e.g. `github.com/golang-module/carbon/v2.Carbon`
- added unit test `Test_TypeMapping` to verify mapped struct type is emitted as `string`

### Usage Example
```go
oai := goai.New()
oai.Config.TypeMapping = map[string]string{
	"carbon.Carbon":                              goai.TypeString,
	"github.com/golang-module/carbon/v2.Carbon": goai.TypeString,
}