### PR TITLE
feat(cmd/gf): gen dao suppport for dm database

### DIFF
--- a/cmd/gf/go.mod
+++ b/cmd/gf/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/gogf/gf/contrib/drivers/clickhouse/v2 v2.10.2
+	github.com/gogf/gf/contrib/drivers/dm/v2 v2.10.2
 	github.com/gogf/gf/contrib/drivers/mssql/v2 v2.10.2
 	github.com/gogf/gf/contrib/drivers/mysql/v2 v2.10.2
 	github.com/gogf/gf/contrib/drivers/oracle/v2 v2.10.2
@@ -19,6 +20,7 @@ require (
 
 require (
 	aead.dev/minisign v0.2.0 // indirect
+	gitee.com/chunanyong/dm v1.8.12 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/ClickHouse/clickhouse-go/v2 v2.0.15 // indirect
 	github.com/clbanning/mxj/v2 v2.7.0 // indirect
@@ -32,6 +34,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grokify/html-strip-tags-go v0.1.0 // indirect

--- a/cmd/gf/go.sum
+++ b/cmd/gf/go.sum
@@ -1,5 +1,7 @@
 aead.dev/minisign v0.2.0 h1:kAWrq/hBRu4AARY6AlciO83xhNnW9UaC8YipS2uhLPk=
 aead.dev/minisign v0.2.0/go.mod h1:zdq6LdSd9TbuSxchxwhpA9zEb9YXcVGoE8JakuiGaIQ=
+gitee.com/chunanyong/dm v1.8.12 h1:WupbFZL0MRNIIiCPaLDHgFi5jkdkjzjPReuWPaInGwk=
+gitee.com/chunanyong/dm v1.8.12/go.mod h1:EPRJnuPFgbyOFgJ0TRYCTGzhq+ZT4wdyaj/GW/LLcNg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1 h1:lGlwhPtrX6EVml1hO0ivjkUxsSyl4dsiw9qcA1k/3IQ=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.1/go.mod h1:RKUqNu35KJYcVG/fqTRqmuXJZYNhYkBrnC/hX7yGbTA=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1 h1:sO0/P7g68FrryJzljemN+6GTssUXdANk6aJ7T1ZxnsQ=
@@ -48,6 +50,8 @@ github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrt
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/gogf/gf/contrib/drivers/clickhouse/v2 v2.10.2 h1:K9MuyxpkwbQFRypXZnqZm06l0N2p3urM8PEqH45IYXo=
 github.com/gogf/gf/contrib/drivers/clickhouse/v2 v2.10.2/go.mod h1:Pr/klQ7g0l0qx/MtnFqu9sgeMfVul8ntj/kvGuopJcM=
+github.com/gogf/gf/contrib/drivers/dm/v2 v2.10.2 h1:jgppTDbSMW/zMRrhvmYFvvArfHQyy556dujwjFRdtUw=
+github.com/gogf/gf/contrib/drivers/dm/v2 v2.10.2/go.mod h1:FsEjU9SLF4ZSuN8YVkMzCxmFFjEBTbzvXw7D9SzK6IU=
 github.com/gogf/gf/contrib/drivers/mssql/v2 v2.10.2 h1:7V+23ohcOWvT4Fgf/79uEs51VLfESbhgntkdLL9IPyA=
 github.com/gogf/gf/contrib/drivers/mssql/v2 v2.10.2/go.mod h1:8mQd1INT1l7c8gYnUdfqlbDdTyq9ZqjkdvlLFdPD6RE=
 github.com/gogf/gf/contrib/drivers/mysql/v2 v2.10.2 h1:UdUV+7GhwYLpkwz7VrwIVO/1ZYodyzSL5is25NET24A=
@@ -70,6 +74,8 @@ github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2V
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
 github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EOqtpKwwwHI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -214,6 +220,7 @@ golang.org/x/term v0.24.0/go.mod h1:lOBK/LVxemqiMij05LGJ0tzNr8xlmwBRJ81PX6wVLH8=
 golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
 golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
 golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=

--- a/cmd/gf/internal/cmd/cmd_gen_dao.go
+++ b/cmd/gf/internal/cmd/cmd_gen_dao.go
@@ -14,9 +14,6 @@ import (
 	_ "github.com/gogf/gf/contrib/drivers/pgsql/v2"
 	_ "github.com/gogf/gf/contrib/drivers/sqlite/v2"
 
-	// do not add dm in cli pre-compilation,
-	// the dm driver does not support certain target platforms.
-	// _ "github.com/gogf/gf/contrib/drivers/dm/v2"
 	"github.com/gogf/gf/cmd/gf/v2/internal/cmd/gendao"
 )
 

--- a/cmd/gf/internal/cmd/cmd_gen_dao_dm.go
+++ b/cmd/gf/internal/cmd/cmd_gen_dao_dm.go
@@ -1,0 +1,13 @@
+// Copyright GoFrame gf Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+//go:build dm
+
+package cmd
+
+import (
+	_ "github.com/gogf/gf/contrib/drivers/dm/v2"
+)


### PR DESCRIPTION
```
将来合并后直接指定tag
go run -tags dm github.com/gogf/gf/cmd/gf/v2@latest
go install -tags dm github.com/gogf/gf/cmd/gf/v2@latest

测试
go run -tags dm github.com/gogf/gf/cmd/gf/v2@a7f551c40f3c83b00eae15a65fd4463332b1ed2e
go install -tags dm github.com/gogf/gf/cmd/gf/v2@a7f551c40f3c83b00eae15a65fd4463332b1ed2e
```