### PR TITLE
refactor(contrib/rpc/grpcx): optimize server unary interceptor error …

### DIFF
--- a/contrib/rpc/grpcx/grpcx_interceptor_server.go
+++ b/contrib/rpc/grpcx/grpcx_interceptor_server.go
@@ -43,11 +43,16 @@ func (s modServer) UnaryError(
 	ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (any, error) {
 	res, err := handler(ctx, req)
-	if err != nil {
-		code := gerror.Code(err)
-		if code.Code() != -1 {
-			err = status.Error(codes.Code(code.Code()), err.Error())
-		}
+	if err == nil {
+		return res, nil
+	}
+	// Priority 1: Error already implements GRPCStatus, it's already a gRPC standard error
+	if _, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
+		return res, err
+	}
+	// Priority 2: Convert custom business error code to gRPC status error
+	if code := gerror.Code(err); code.Code() != -1 {
+		return res, status.Error(codes.Code(code.Code()), err.Error())
 	}
 	return res, err
 }


### PR DESCRIPTION
## PR 描述

### 修复：在 UnaryError 拦截器中保留错误详情信息

**问题描述**

当前 `UnaryError` 拦截器在将自定义错误转换为 gRPC 标准错误时，会丢失扩展错误信息（protobuf 的 `Details` 字段）。

```go
// ❌ 当前实现 - Details 信息丢失
err = status.Error(codes.Code(code.Code()), err.Error())
```
当错误中包含 Details 扩展信息时（如字段校验失败详情、业务规则违反信息、本地化错误消息等），这些信息会被完全丢弃，导致客户端无法接收到 google.rpc.Status 中定义的丰富错误详情。