### PR TITLE
fix(ghttp): resolve the issue where the GetCertificate callback in TLS listener gets overwritten

### DIFF
--- a/net/ghttp/internal/graceful/graceful.go
+++ b/net/ghttp/internal/graceful/graceful.go
@@ -222,7 +222,7 @@ func (s *Server) CreateListenerTLS(certFile, keyFile string, tlsConfig ...*tls.C
 		config.NextProtos = []string{"http/1.1"}
 	}
 	var err error
-	if len(config.Certificates) == 0 {
+	if len(config.Certificates) == 0 && config.GetCertificate == nil {
 		config.Certificates = make([]tls.Certificate, 1)
 		if gres.Contains(certFile) {
 			config.Certificates[0], err = tls.X509KeyPair(


### PR DESCRIPTION
tls.Config.Certificates 不为空时， tls.Config.GetCertificates 不生效。
