### PR TITLE
fix(os/glog): JsonHandler outputs flat JSON suitable for ES ingestion (#4790)

### DIFF
--- a/os/glog/glog_logger_handler_json.go
+++ b/os/glog/glog_logger_handler_json.go
@@ -9,47 +9,75 @@ package glog
 import (
 	"context"
 
+	"github.com/gogf/gf/v2/container/gmap"
 	"github.com/gogf/gf/v2/internal/json"
+	"github.com/gogf/gf/v2/os/gctx"
+	"github.com/gogf/gf/v2/util/gconv"
 )
-
-// HandlerOutputJson is the structure outputting logging content as single json.
-type HandlerOutputJson struct {
-	Time       string `json:""`           // Formatted time string, like "2016-01-09 12:00:00".
-	TraceId    string `json:",omitempty"` // Trace id, only available if tracing is enabled.
-	CtxStr     string `json:",omitempty"` // The retrieved context value string from context, only available if Config.CtxKeys configured.
-	Level      string `json:""`           // Formatted level string, like "DEBU", "ERRO", etc. Eg: ERRO
-	CallerPath string `json:",omitempty"` // The source file path and its line number that calls logging, only available if F_FILE_SHORT or F_FILE_LONG set.
-	CallerFunc string `json:",omitempty"` // The source function name that calls logging, only available if F_CALLER_FN set.
-	Prefix     string `json:",omitempty"` // Custom prefix string for logging content.
-	Content    string `json:""`           // Content is the main logging content, containing error stack string produced by logger.
-	Stack      string `json:",omitempty"` // Stack string produced by logger, only available if Config.StStatus configured.
-}
 
 // HandlerJson is a handler for output logging content as a single json string.
 func HandlerJson(ctx context.Context, in *HandlerInput) {
-	output := HandlerOutputJson{
-		Time:       in.TimeFormat,
-		TraceId:    in.TraceId,
-		CtxStr:     in.CtxStr,
-		Level:      in.LevelFormat,
-		CallerFunc: in.CallerFunc,
-		CallerPath: in.CallerPath,
-		Prefix:     in.Prefix,
-		Content:    in.Content,
-		Stack:      in.Stack,
-	}
-	if len(in.Values) > 0 {
-		if output.Content != "" {
-			output.Content += " "
-		}
-		output.Content += in.ValuesContent()
-	}
+	output := gmap.NewStrAnyMap()
+	output.Set("Time", in.TimeFormat)
+	setJsonHandlerOutputValue(output, "TraceId", in.TraceId)
+	setJsonHandlerOutputCtxValues(ctx, in, output)
+	output.Set("Level", in.LevelFormat)
+	setJsonHandlerOutputValue(output, "CallerFunc", in.CallerFunc)
+	setJsonHandlerOutputValue(output, "CallerPath", in.CallerPath)
+	setJsonHandlerOutputContent(output, in)
+	setJsonHandlerOutputValue(output, "Stack", in.Stack)
+
 	// Output json content.
-	jsonBytes, err := json.Marshal(output)
+	jsonBytes, err := json.Marshal(output.Map())
 	if err != nil {
 		panic(err)
 	}
 	in.Buffer.Write(jsonBytes)
 	in.Buffer.Write([]byte("\n"))
 	in.Next(ctx)
+}
+
+// setJsonHandlerOutputValue sets non-empty value to handler output.
+func setJsonHandlerOutputValue(output *gmap.StrAnyMap, key string, value any) {
+	if gconv.String(value) != "" {
+		output.Set(key, value)
+	}
+}
+
+// setJsonHandlerOutputCtxValues appends configured context values to handler output.
+func setJsonHandlerOutputCtxValues(ctx context.Context, in *HandlerInput, output *gmap.StrAnyMap) {
+	if ctx == nil || in.Logger == nil {
+		return
+	}
+	for _, ctxKey := range in.Logger.GetCtxKeys() {
+		ctxValue := ctx.Value(ctxKey)
+		if ctxValue == nil {
+			ctxValue = ctx.Value(gctx.StrKey(gconv.String(ctxKey)))
+		}
+		if ctxValue != nil {
+			output.Set(gconv.String(ctxKey), ctxValue)
+		}
+	}
+}
+
+// setJsonHandlerOutputContent appends logging content or flattens JSON object content.
+func setJsonHandlerOutputContent(output *gmap.StrAnyMap, in *HandlerInput) {
+	content := in.Content
+	if len(in.Values) > 0 {
+		if content != "" {
+			content += " "
+		}
+		content += in.ValuesContent()
+	}
+
+	var contentMap map[string]any
+	if content != "" && json.Unmarshal([]byte(content), &contentMap) == nil {
+		for key, value := range contentMap {
+			if _, found := output.Search(key); !found {
+				output.Set(key, value)
+			}
+		}
+		return
+	}
+	output.Set("Content", content)
 }

--- a/os/glog/glog_logger_handler_json.go
+++ b/os/glog/glog_logger_handler_json.go
@@ -10,10 +10,24 @@ import (
 	"context"
 
 	"github.com/gogf/gf/v2/container/gmap"
+	"github.com/gogf/gf/v2/container/gset"
 	"github.com/gogf/gf/v2/internal/json"
 	"github.com/gogf/gf/v2/os/gctx"
 	"github.com/gogf/gf/v2/util/gconv"
 )
+
+// reservedJsonHandlerKeys defines the reserved keys that cannot be overwritten by context values or content flattening.
+var reservedJsonHandlerKeys = gset.NewStrSetFrom([]string{
+	"Time",
+	"TraceId",
+	"CtxStr",
+	"Level",
+	"CallerFunc",
+	"CallerPath",
+	"Prefix",
+	"Content",
+	"Stack",
+})
 
 // HandlerJson is a handler for output logging content as a single json string.
 func HandlerJson(ctx context.Context, in *HandlerInput) {
@@ -24,6 +38,10 @@ func HandlerJson(ctx context.Context, in *HandlerInput) {
 	output.Set("Level", in.LevelFormat)
 	setJsonHandlerOutputValue(output, "CallerFunc", in.CallerFunc)
 	setJsonHandlerOutputValue(output, "CallerPath", in.CallerPath)
+	setJsonHandlerOutputValue(output, "Prefix", in.Prefix)
+	// Deprecated: CtxStr will be removed in the next major version.
+	// Context values are now exported as individual top-level JSON fields.
+	setJsonHandlerOutputValue(output, "CtxStr", in.CtxStr)
 	setJsonHandlerOutputContent(output, in)
 	setJsonHandlerOutputValue(output, "Stack", in.Stack)
 
@@ -45,22 +63,29 @@ func setJsonHandlerOutputValue(output *gmap.StrAnyMap, key string, value any) {
 }
 
 // setJsonHandlerOutputCtxValues appends configured context values to handler output.
+// It skips reserved keys to prevent overwriting core metadata fields.
 func setJsonHandlerOutputCtxValues(ctx context.Context, in *HandlerInput, output *gmap.StrAnyMap) {
 	if ctx == nil || in.Logger == nil {
 		return
 	}
 	for _, ctxKey := range in.Logger.GetCtxKeys() {
+		key := gconv.String(ctxKey)
+		// Skip reserved keys to prevent overwriting core metadata fields.
+		if reservedJsonHandlerKeys.Contains(key) {
+			continue
+		}
 		ctxValue := ctx.Value(ctxKey)
 		if ctxValue == nil {
-			ctxValue = ctx.Value(gctx.StrKey(gconv.String(ctxKey)))
+			ctxValue = ctx.Value(gctx.StrKey(key))
 		}
 		if ctxValue != nil {
-			output.Set(gconv.String(ctxKey), ctxValue)
+			output.Set(key, ctxValue)
 		}
 	}
 }
 
 // setJsonHandlerOutputContent appends logging content or flattens JSON object content.
+// It skips reserved keys to prevent injecting/spoofing core metadata fields.
 func setJsonHandlerOutputContent(output *gmap.StrAnyMap, in *HandlerInput) {
 	content := in.Content
 	if len(in.Values) > 0 {
@@ -73,9 +98,15 @@ func setJsonHandlerOutputContent(output *gmap.StrAnyMap, in *HandlerInput) {
 	var contentMap map[string]any
 	if content != "" && json.Unmarshal([]byte(content), &contentMap) == nil {
 		for key, value := range contentMap {
-			if _, found := output.Search(key); !found {
-				output.Set(key, value)
+			// Skip reserved keys to prevent injecting/spoofing core metadata fields.
+			if reservedJsonHandlerKeys.Contains(key) {
+				continue
 			}
+			// Skip keys that already exist in output (e.g., from context values).
+			if output.Get(key) != nil {
+				continue
+			}
+			output.Set(key, value)
 		}
 		return
 	}

--- a/os/glog/glog_z_unit_logger_handler_test.go
+++ b/os/glog/glog_z_unit_logger_handler_test.go
@@ -9,9 +9,11 @@ package glog_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/gogf/gf/v2/container/garray"
+	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/os/glog"
 	"github.com/gogf/gf/v2/test/gtest"
 	"github.com/gogf/gf/v2/text/gstr"
@@ -81,11 +83,58 @@ func TestLogger_SetHandlers_HandlerJson(t *testing.T) {
 		ctx := context.WithValue(context.Background(), "Trace-Id", "1234567890")
 		ctx = context.WithValue(ctx, "Span-Id", "abcdefg")
 
-		l.Debug(ctx, 1, 2, 3)
-		t.Assert(gstr.Count(w.String(), `"CtxStr":"1234567890, abcdefg"`), 1)
-		t.Assert(gstr.Count(w.String(), `"Content":"1 2 3"`), 1)
-		t.Assert(gstr.Count(w.String(), `"Level":"DEBU"`), 1)
+		l.Debug(ctx, g.Map{"Uid": 100, "Name": "john"})
+		output := readJsonHandlerOutput(t, w)
+		t.AssertNE(output["Time"], nil)
+		t.Assert(output["Trace-Id"], "1234567890")
+		t.Assert(output["Span-Id"], "abcdefg")
+		t.Assert(output["Level"], "DEBU")
+		t.Assert(output["Name"], "john")
+		t.Assert(output["Uid"], float64(100))
+		t.Assert(output["CtxStr"], nil)
+		t.Assert(output["Content"], nil)
+		t.Assert(gstr.Contains(w.String(), `"{\"`), false)
 	})
+}
+
+func TestLogger_SetHandlers_HandlerJson_Content(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		w := bytes.NewBuffer(nil)
+		l := glog.NewWithWriter(w)
+		l.SetHandlers(glog.HandlerJson)
+
+		l.Debug(context.Background(), "plain content")
+		output := readJsonHandlerOutput(t, w)
+		t.Assert(output["Content"], "plain content")
+		t.Assert(output["Level"], "DEBU")
+	})
+}
+
+func TestLogger_SetHandlers_HandlerJson_ContentCollision(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		w := bytes.NewBuffer(nil)
+		l := glog.NewWithWriter(w)
+		l.SetHandlers(glog.HandlerJson)
+		l.SetCtxKeys("Trace-Id")
+		ctx := context.WithValue(context.Background(), "Trace-Id", "ctx-trace")
+
+		l.Debug(ctx, g.Map{
+			"Level":    "payload-level",
+			"Trace-Id": "payload-trace",
+			"Name":     "john",
+		})
+		output := readJsonHandlerOutput(t, w)
+		t.Assert(output["Level"], "DEBU")
+		t.Assert(output["Trace-Id"], "ctx-trace")
+		t.Assert(output["Name"], "john")
+	})
+}
+
+func readJsonHandlerOutput(t *gtest.T, w *bytes.Buffer) map[string]any {
+	var output map[string]any
+	err := json.Unmarshal(bytes.TrimSpace(w.Bytes()), &output)
+	t.AssertNil(err)
+	return output
 }
 
 func TestLogger_SetHandlers_HandlerStructure(t *testing.T) {

--- a/os/glog/glog_z_unit_logger_handler_test.go
+++ b/os/glog/glog_z_unit_logger_handler_test.go
@@ -91,7 +91,7 @@ func TestLogger_SetHandlers_HandlerJson(t *testing.T) {
 		t.Assert(output["Level"], "DEBU")
 		t.Assert(output["Name"], "john")
 		t.Assert(output["Uid"], float64(100))
-		t.Assert(output["CtxStr"], nil)
+		t.Assert(output["CtxStr"], "1234567890, abcdefg")
 		t.Assert(output["Content"], nil)
 		t.Assert(gstr.Contains(w.String(), `"{\"`), false)
 	})
@@ -137,6 +137,66 @@ func readJsonHandlerOutput(t *gtest.T, w *bytes.Buffer) map[string]any {
 	return output
 }
 
+func TestLogger_SetHandlers_HandlerJson_Prefix(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		w := bytes.NewBuffer(nil)
+		l := glog.NewWithWriter(w)
+		l.SetHandlers(glog.HandlerJson)
+		l.SetPrefix("my-prefix")
+
+		l.Debug(context.Background(), "test content")
+		output := readJsonHandlerOutput(t, w)
+		t.Assert(output["Prefix"], "my-prefix")
+		t.Assert(output["Content"], "test content")
+		t.Assert(output["Level"], "DEBU")
+	})
+}
+
+func TestLogger_SetHandlers_HandlerJson_ReservedKeyProtection(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		w := bytes.NewBuffer(nil)
+		l := glog.NewWithWriter(w)
+		l.SetHandlers(glog.HandlerJson)
+		// Try to use reserved keys as context keys.
+		l.SetCtxKeys("Time", "Level", "TraceId")
+		ctx := context.WithValue(context.Background(), "Time", "spoofed-time")
+		ctx = context.WithValue(ctx, "Level", "spoofed-level")
+		ctx = context.WithValue(ctx, "TraceId", "spoofed-trace")
+
+		l.Debug(ctx, "test content")
+		output := readJsonHandlerOutput(t, w)
+		// Reserved keys should not be overwritten by context values.
+		t.AssertNE(output["Time"], "spoofed-time")
+		t.Assert(output["Level"], "DEBU")
+		t.AssertNE(output["TraceId"], "spoofed-trace")
+		t.Assert(output["Content"], "test content")
+	})
+}
+
+func TestLogger_SetHandlers_HandlerJson_ContentReservedKeyProtection(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		w := bytes.NewBuffer(nil)
+		l := glog.NewWithWriter(w)
+		l.SetHandlers(glog.HandlerJson)
+
+		// JSON content with reserved keys should not overwrite core metadata.
+		l.Debug(context.Background(), g.Map{
+			"Time":    "spoofed-time",
+			"Level":   "spoofed-level",
+			"Stack":   "spoofed-stack",
+			"Content": "spoofed-content",
+			"Name":    "john",
+		})
+		output := readJsonHandlerOutput(t, w)
+		// Reserved keys in content should be skipped.
+		t.AssertNE(output["Time"], "spoofed-time")
+		t.Assert(output["Level"], "DEBU")
+		t.AssertNE(output["Stack"], "spoofed-stack")
+		// Non-reserved keys should be flattened.
+		t.Assert(output["Name"], "john")
+	})
+}
+
 func TestLogger_SetHandlers_HandlerStructure(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		w := bytes.NewBuffer(nil)
@@ -171,8 +231,8 @@ func Test_SetDefaultHandler(t *testing.T) {
 		ctx = context.WithValue(ctx, "Span-Id", "abcdefg")
 
 		l.Debug(ctx, 1, 2, 3)
-		t.Assert(gstr.Count(w.String(), "1234567890"), 1)
-		t.Assert(gstr.Count(w.String(), "abcdefg"), 1)
+		t.Assert(gstr.Count(w.String(), "1234567890"), 2)
+		t.Assert(gstr.Count(w.String(), "abcdefg"), 2)
 		t.Assert(gstr.Count(w.String(), `"1 2 3"`), 1)
 		t.Assert(gstr.Count(w.String(), `"DEBU"`), 1)
 	})


### PR DESCRIPTION
Fixes #4790 

### 修改要点

1. 在 ctx 中遍历 CtxKeys 中的 key，如果存在则作为 json 的键值对
2. 用户输入仍根据类型区分
    - json 文本，打平到 json 中
    - 非 json 文本，输出到 Content 字段中

核心：输出满足 jsonl 格式，能直接导入到 ES、LTS 等工具中分析

### 范例

```go
func Test_Json(t *testing.T) {
	logger := glog.New()
	logger.SetHandlers(glog.HandlerJson)
	logger.SetCtxKeys("Env", "ClientIP")
	logger.Stack(true)

	ctx := context.WithValue(context.Background(), "Env", "prod")
	ctx = context.WithValue(ctx, "ClientIP", "1.2.3.4")
	logger.Info(ctx, g.Map{"uid": 100, "name": "john"})
	logger.Errorf(ctx, "error occurred, %d", 100200)
}
```

```jsonl
{"ClientIP":"1.2.3.4","Env":"prod","Level":"INFO","Time":"2026-07-02T10:28:08.490+08:00","name":"john","uid":100}
{"ClientIP":"1.2.3.4","Content":"error occurred, 100200","Env":"prod","Level":"ERRO","Time":"2026-07-02T10:28:08.490+08:00"}
```
