### PR TITLE
feat(os/grpool): let can set limit/cap dynamically

### DIFF
--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -37,6 +37,7 @@ type Pool struct {
 	limitChanger LimitChangerFunc             // Function used to change max goroutine count limit. Let it nil to disable.
 	paused       atomic.Bool                  // Whether the pool is paused from starting new work.
 	timer        *gtimer.Entry
+	limitChanged atomic.Bool
 }
 
 // PoolOption used to pass options

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -36,8 +36,8 @@ type Pool struct {
 	closed       *gtype.Bool                  // Is pool closed or not.
 	limitChanger LimitChangerFunc             // Function used to change max goroutine count limit. Let it nil to disable.
 	paused       atomic.Bool                  // Whether the pool is paused from starting new work.
-	timer        *gtimer.Entry
-	limitChanged atomic.Bool
+	timer        *gtimer.Entry                // Timer entry for running the supervisor job.
+	limitChanged atomic.Bool                  // Marks whether the pool limit changed and supervisor should adjust workers.
 }
 
 // PoolOption is used to pass options for creating a Pool.

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -21,6 +21,8 @@ import (
 // Func is the pool function which contains context parameter.
 type Func func(ctx context.Context)
 
+// LimitChangerFunc updates the pool's goroutine limit dynamically.
+// It should update value and return true if the limit was changed.
 type LimitChangerFunc func(ctx context.Context, value *atomic.Int64) (changed bool)
 
 // RecoverFunc is the pool runtime panic recover function which contains context parameter.
@@ -33,7 +35,7 @@ type Pool struct {
 	list         *glist.TList[*localPoolItem] // List for asynchronous job adding purpose.
 	closed       *gtype.Bool                  // Is pool closed or not.
 	limitChanger LimitChangerFunc             // Function used to change max goroutine count limit. Let it nil to disable.
-	paused       atomic.Bool                  // Whether the pool is parsed (paused) from starting new work.
+	paused       atomic.Bool                  // Whether the pool is paused from starting new work.
 	timer        *gtimer.Entry
 }
 
@@ -133,17 +135,17 @@ func Jobs() int {
 	return defaultPool.Jobs()
 }
 
-// Pause pause pool work.
+// Pause pauses the default pool work.
 func Pause() {
 	defaultPool.Pause()
 }
 
-// IsPaused returns if pool is paused.
+// IsPaused returns whether the default pool is paused.
 func IsPaused() bool {
 	return defaultPool.IsPaused()
 }
 
-// Resume resume pool work.
+// Resume resumes the default pool work.
 func Resume() {
 	defaultPool.Resume()
 }

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -33,7 +33,7 @@ type Pool struct {
 	list         *glist.TList[*localPoolItem] // List for asynchronous job adding purpose.
 	closed       *gtype.Bool                  // Is pool closed or not.
 	limitChanger LimitChangerFunc             // Function used to change max goroutine count limit. Let it nil to disable.
-	parsed       atomic.Bool                  // Pool parsed to work
+	parsed       atomic.Bool                  // Whether the pool is parsed (paused) from starting new work.
 	timer        *gtimer.Entry
 }
 
@@ -74,7 +74,7 @@ func New(limit ...int) *Pool {
 	}
 }
 
-// New creates and returns a new goroutine pool object.
+// NewWithOption creates and returns a new goroutine pool object.
 // The parameter `option` is used to limit the max goroutine count or set limit changer,
 // which is not limited in default.
 func NewWithOption(option ...PoolOption) *Pool {

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -33,7 +33,7 @@ type Pool struct {
 	list         *glist.TList[*localPoolItem] // List for asynchronous job adding purpose.
 	closed       *gtype.Bool                  // Is pool closed or not.
 	limitChanger LimitChangerFunc             // Function used to change max goroutine count limit. Let it nil to disable.
-	parsed       atomic.Bool                  // Whether the pool is parsed (paused) from starting new work.
+	paused       atomic.Bool                  // Whether the pool is parsed (paused) from starting new work.
 	timer        *gtimer.Entry
 }
 
@@ -133,14 +133,14 @@ func Jobs() int {
 	return defaultPool.Jobs()
 }
 
-// Parse parse pool work.
-func Parse() {
-	defaultPool.Parse()
+// Pause pause pool work.
+func Pause() {
+	defaultPool.Pause()
 }
 
-// IsClosed returns if pool is parsed.
-func IsParsed() bool {
-	return defaultPool.IsParsed()
+// IsPaused returns if pool is paused.
+func IsPaused() bool {
+	return defaultPool.IsPaused()
 }
 
 // Resume resume pool work.

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -21,14 +21,14 @@ import (
 // Func is the pool function which contains context parameter.
 type Func func(ctx context.Context)
 
-type LimitChangerFunc func(ctx context.Context, old int) (new int)
+type LimitChangerFunc func(ctx context.Context, value *atomic.Int64) (changed bool)
 
 // RecoverFunc is the pool runtime panic recover function which contains context parameter.
 type RecoverFunc func(ctx context.Context, exception error)
 
 // Pool manages the goroutines using pool.
 type Pool struct {
-	limit        int                          // Max goroutine count limit.
+	limit        atomic.Int64                 // Max goroutine count limit.
 	count        *gtype.Int                   // Current running goroutine count.
 	list         *glist.TList[*localPoolItem] // List for asynchronous job adding purpose.
 	closed       *gtype.Bool                  // Is pool closed or not.
@@ -86,7 +86,6 @@ func NewWithOption(option ...PoolOption) *Pool {
 	}
 	var (
 		pool = &Pool{
-			limit:        -1,
 			limitChanger: nil,
 			count:        gtype.NewInt(),
 			list:         glist.NewT[*localPoolItem](true),
@@ -98,7 +97,9 @@ func NewWithOption(option ...PoolOption) *Pool {
 		)
 	)
 	if o.Limit > 0 {
-		pool.limit = o.Limit
+		pool.limit.Store(int64(o.Limit))
+	} else {
+		pool.limit.Store(-1)
 	}
 	if o.LimitChanger != nil {
 		pool.limitChanger = o.LimitChanger

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -40,7 +40,7 @@ type Pool struct {
 	limitChanged atomic.Bool
 }
 
-// PoolOption used to pass options
+// PoolOption is used to pass options for creating a Pool.
 type PoolOption struct {
 	Limit        int              // Max goroutine count limit.
 	LimitChanger LimitChangerFunc // Function used to change max goroutine count limit. Let it nil to disable.

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -9,6 +9,7 @@ package grpool
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogf/gf/v2/container/glist"
@@ -20,15 +21,26 @@ import (
 // Func is the pool function which contains context parameter.
 type Func func(ctx context.Context)
 
+type LimitChangerFunc func(ctx context.Context, old int) (new int)
+
 // RecoverFunc is the pool runtime panic recover function which contains context parameter.
 type RecoverFunc func(ctx context.Context, exception error)
 
 // Pool manages the goroutines using pool.
 type Pool struct {
-	limit  int                          // Max goroutine count limit.
-	count  *gtype.Int                   // Current running goroutine count.
-	list   *glist.TList[*localPoolItem] // List for asynchronous job adding purpose.
-	closed *gtype.Bool                  // Is pool closed or not.
+	limit        int                          // Max goroutine count limit.
+	count        *gtype.Int                   // Current running goroutine count.
+	list         *glist.TList[*localPoolItem] // List for asynchronous job adding purpose.
+	closed       *gtype.Bool                  // Is pool closed or not.
+	limitChanger LimitChangerFunc             // Function used to change max goroutine count limit. Let it nil to disable.
+	parsed       atomic.Bool                  // Pool parsed to work
+	timer        *gtimer.Entry
+}
+
+// PoolOption used to pass options
+type PoolOption struct {
+	Limit        int              // Max goroutine count limit.
+	LimitChanger LimitChangerFunc // Function used to change max goroutine count limit. Let it nil to disable.
 }
 
 // localPoolItem is the job item storing in job list.
@@ -51,22 +63,47 @@ var (
 // The parameter `limit` is used to limit the max goroutine count,
 // which is not limited in default.
 func New(limit ...int) *Pool {
+	if len(limit) == 0 {
+		return NewWithOption(PoolOption{
+			Limit: -1,
+		})
+	} else {
+		return NewWithOption(PoolOption{
+			Limit: limit[0],
+		})
+	}
+}
+
+// New creates and returns a new goroutine pool object.
+// The parameter `option` is used to limit the max goroutine count or set limit changer,
+// which is not limited in default.
+func NewWithOption(option ...PoolOption) *Pool {
+	var o *PoolOption
+	if len(option) > 0 {
+		o = &option[0]
+	} else {
+		o = &PoolOption{}
+	}
 	var (
 		pool = &Pool{
-			limit:  -1,
-			count:  gtype.NewInt(),
-			list:   glist.NewT[*localPoolItem](true),
-			closed: gtype.NewBool(),
+			limit:        -1,
+			limitChanger: nil,
+			count:        gtype.NewInt(),
+			list:         glist.NewT[*localPoolItem](true),
+			closed:       gtype.NewBool(),
 		}
 		timerDuration = grand.D(
 			minSupervisorTimerDuration,
 			maxSupervisorTimerDuration,
 		)
 	)
-	if len(limit) > 0 && limit[0] > 0 {
-		pool.limit = limit[0]
+	if o.Limit > 0 {
+		pool.limit = o.Limit
 	}
-	gtimer.Add(context.Background(), timerDuration, pool.supervisor)
+	if o.LimitChanger != nil {
+		pool.limitChanger = o.LimitChanger
+	}
+	pool.timer = gtimer.AddSingleton(context.Background(), timerDuration, pool.supervisor)
 	return pool
 }
 
@@ -93,4 +130,19 @@ func Size() int {
 // Jobs returns current job count of default goroutine pool.
 func Jobs() int {
 	return defaultPool.Jobs()
+}
+
+// Parse parse pool work.
+func Parse() {
+	defaultPool.Parse()
+}
+
+// IsClosed returns if pool is parsed.
+func IsParsed() bool {
+	return defaultPool.IsParsed()
+}
+
+// Resume resume pool work.
+func Resume() {
+	defaultPool.Resume()
 }

--- a/os/grpool/grpool.go
+++ b/os/grpool/grpool.go
@@ -137,8 +137,8 @@ func Jobs() int {
 }
 
 // Pause pauses the default pool work.
-func Pause() {
-	defaultPool.Pause()
+func Pause() bool {
+	return defaultPool.Pause()
 }
 
 // IsPaused returns whether the default pool is paused.
@@ -147,6 +147,6 @@ func IsPaused() bool {
 }
 
 // Resume resumes the default pool work.
-func Resume() {
-	defaultPool.Resume()
+func Resume() bool {
+	return defaultPool.Resume()
 }

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -53,19 +53,20 @@ func (p *Pool) AddWithRecover(ctx context.Context, userFunc Func, recoverFunc Re
 	})
 }
 
-// Cap can change the capacity and returns the capacity of the pool before changed.
-// This capacity is defined when pool is created. Pass newCap will change it.
+// Cap returns the capacity of the pool.
+// This capacity is defined when pool is created.
 // It returns -1 if there's no limit.
-func (p *Pool) Cap(newCap ...int) int {
-	if len(newCap) > 0 {
-		cap := int64(newCap[0])
-		if cap <= 0 {
-			cap = -1
-		}
-		return int(p.limit.Swap(cap))
-	} else {
-		return int(p.limit.Load())
+func (p *Pool) Cap() int {
+	return int(p.limit.Load())
+}
+
+// Cap can change the capacity and returns the capacity of the pool before changed.
+// It returns -1 if there's no limit.
+func (p *Pool) SetCap(cap int) int {
+	if cap <= 0 {
+		cap = -1
 	}
+	return int(p.limit.Swap(int64(cap)))
 }
 
 // Size returns current goroutine count of the pool.
@@ -126,7 +127,6 @@ func (p *Pool) Close() {
 	if p.closed.Cas(false, true) {
 		if p.timer != nil {
 			p.timer.Close()
-			p.timer = nil
 		}
 	}
 }

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -71,7 +71,7 @@ func (p *Pool) Jobs() int {
 	return p.list.Size()
 }
 
-// Pause pause pool work. The jobs will be keeped in queue and will be dealed when resumes.
+// Pause pauses pool work. Jobs are kept in the queue and will be processed when the pool resumes.
 func (p *Pool) Pause() bool {
 	if p.IsClosed() {
 		return false
@@ -109,13 +109,21 @@ func (p *Pool) IsClosed() bool {
 
 // Close closes the goroutine pool, which makes all goroutines exit.
 func (p *Pool) Close() {
-	p.closed.Set(true)
+	if p.closed.Cas(false, true) {
+		if p.timer != nil {
+			p.timer.Close()
+			p.timer = nil
+		}
+	}
 }
 
 // checkAndForkNewGoroutineWorker checks and creates a new goroutine worker.
 // Note that the worker dies if the job function panics and the job has no recover handling.
 func (p *Pool) checkAndForkNewGoroutineWorker() {
 	// Check whether fork new goroutine or not.
+	if p.paused.Load() {
+		return
+	}
 	var n int
 	for {
 		n = p.count.Val()
@@ -146,9 +154,9 @@ func (p *Pool) asynchronousWorker() {
 			return
 		}
 		listItem.Func(listItem.Ctx)
-		// ccheck whether need reduce worker.
+		// Check whether need reduce worker.
 		n = p.count.Val()
-		if limit := int(p.limit.Load()); limit != -1 && n > limit && p.count.Cas(n, n-1) {
+		if limit := int(p.limit.Load()); limit > 0 && n > limit && p.count.Cas(n, n-1) {
 			addVal = 0
 			return
 		}

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -84,7 +84,7 @@ func (p *Pool) Parse() bool {
 	return true
 }
 
-// IsClosed returns if pool is parsed.
+// IsParsed returns whether the pool is parsed.
 func (p *Pool) IsParsed() bool {
 	return p.parsed.Load()
 }
@@ -146,7 +146,7 @@ func (p *Pool) asynchronousWorker() {
 			return
 		}
 		listItem.Func(listItem.Ctx)
-		// check whether need reduce woker.
+		// ccheck whether need reduce worker.
 		n = p.count.Val()
 		if limit := int(p.limit.Load()); limit != -1 && n > limit && p.count.Cas(n, n-1) {
 			addVal = 0

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -57,7 +57,7 @@ func (p *Pool) AddWithRecover(ctx context.Context, userFunc Func, recoverFunc Re
 // This capacity is defined when pool is created.
 // It returns -1 if there's no limit.
 func (p *Pool) Cap() int {
-	return p.limit
+	return int(p.limit.Load())
 }
 
 // Size returns current goroutine count of the pool.
@@ -119,7 +119,7 @@ func (p *Pool) checkAndForkNewGoroutineWorker() {
 	var n int
 	for {
 		n = p.count.Val()
-		if p.limit != -1 && n >= p.limit {
+		if limit := int(p.limit.Load()); limit != -1 && n >= limit {
 			// No need fork new goroutine.
 			return
 		}
@@ -148,7 +148,7 @@ func (p *Pool) asynchronousWorker() {
 		listItem.Func(listItem.Ctx)
 		// check whether need reduce woker.
 		n = p.count.Val()
-		if p.limit != -1 && n > p.limit && p.count.Cas(n, n-1) {
+		if limit := int(p.limit.Load()); limit != -1 && n > limit && p.count.Cas(n, n-1) {
 			addVal = 0
 			return
 		}

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -84,7 +84,7 @@ func (p *Pool) Jobs() int {
 	return p.list.Size()
 }
 
-// ClearJobs clear current all jobs and return how many cleared.
+// ClearJobs clears all queued jobs and returns how many were cleared.
 func (p *Pool) ClearJobs() (count int) {
 	items := p.list.PopBackAll()
 	return len(items)

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -71,12 +71,12 @@ func (p *Pool) Jobs() int {
 	return p.list.Size()
 }
 
-// Parse parse pool work.
-func (p *Pool) Parse() bool {
+// Pause pause pool work. The jobs will be keeped in queue and will be dealed when resumes.
+func (p *Pool) Pause() bool {
 	if p.IsClosed() {
 		return false
 	}
-	if !p.parsed.Swap(true) {
+	if !p.paused.Swap(true) {
 		if p.timer != nil {
 			p.timer.Stop()
 		}
@@ -84,9 +84,9 @@ func (p *Pool) Parse() bool {
 	return true
 }
 
-// IsParsed returns whether the pool is parsed.
-func (p *Pool) IsParsed() bool {
-	return p.parsed.Load()
+// IsPaused returns whether the pool is paused.
+func (p *Pool) IsPaused() bool {
+	return p.paused.Load()
 }
 
 // Resume resume pool work.
@@ -94,7 +94,7 @@ func (p *Pool) Resume() bool {
 	if p.IsClosed() {
 		return false
 	}
-	if p.parsed.Swap(false) {
+	if p.paused.Swap(false) {
 		if p.timer != nil {
 			p.timer.Start()
 		}
@@ -140,7 +140,7 @@ func (p *Pool) asynchronousWorker() {
 	)
 	defer func() { p.count.Add(addVal) }()
 	// Harding working, one by one, job never empty, worker never die.
-	for !p.closed.Val() && !p.parsed.Load() {
+	for !p.closed.Val() && !p.paused.Load() {
 		listItem := p.list.PopBack()
 		if listItem == nil {
 			return

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -135,10 +135,10 @@ func (p *Pool) checkAndForkNewGoroutineWorker() {
 
 func (p *Pool) asynchronousWorker() {
 	var (
-		n   int
-		dec int = -1
+		n      int
+		addVal = -1
 	)
-	defer func() { p.count.Add(dec) }()
+	defer func() { p.count.Add(addVal) }()
 	// Harding working, one by one, job never empty, worker never die.
 	for !p.closed.Val() && !p.parsed.Load() {
 		listItem := p.list.PopBack()
@@ -149,7 +149,7 @@ func (p *Pool) asynchronousWorker() {
 		// check whether need reduce woker.
 		n = p.count.Val()
 		if p.limit != -1 && n > p.limit && p.count.Cas(n, n-1) {
-			dec = 0
+			addVal = 0
 			return
 		}
 	}

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -60,13 +60,17 @@ func (p *Pool) Cap() int {
 	return int(p.limit.Load())
 }
 
-// Cap can change the capacity and returns the capacity of the pool before changed.
+// SetCap changes the capacity and returns the pool capacity before the change.
 // It returns -1 if there's no limit.
 func (p *Pool) SetCap(cap int) int {
 	if cap <= 0 {
 		cap = -1
 	}
-	return int(p.limit.Swap(int64(cap)))
+	oldCap := int(p.limit.Swap(int64(cap)))
+	if cap != oldCap {
+		p.limitChanged.Store(true)
+	}
+	return oldCap
 }
 
 // Size returns current goroutine count of the pool.
@@ -162,9 +166,17 @@ func (p *Pool) asynchronousWorker() {
 	)
 	defer func() { p.count.Add(addVal) }()
 	// Harding working, one by one, job never empty, worker never die.
-	for !p.closed.Val() && !p.paused.Load() {
+	for !p.closed.Val() {
+		if p.paused.Load() {
+			return
+		}
 		listItem := p.list.PopBack()
 		if listItem == nil {
+			return
+		}
+		// Avoid starting new work after Pause() is observed.
+		if p.paused.Load() {
+			p.list.PushBack(listItem)
 			return
 		}
 		listItem.Func(listItem.Ctx)

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -71,6 +71,37 @@ func (p *Pool) Jobs() int {
 	return p.list.Size()
 }
 
+// Parse parse pool work.
+func (p *Pool) Parse() bool {
+	if p.IsClosed() {
+		return false
+	}
+	if !p.parsed.Swap(true) {
+		if p.timer != nil {
+			p.timer.Stop()
+		}
+	}
+	return true
+}
+
+// IsClosed returns if pool is parsed.
+func (p *Pool) IsParsed() bool {
+	return p.parsed.Load()
+}
+
+// Resume resume pool work.
+func (p *Pool) Resume() bool {
+	if p.IsClosed() {
+		return false
+	}
+	if p.parsed.Swap(false) {
+		if p.timer != nil {
+			p.timer.Start()
+		}
+	}
+	return true
+}
+
 // IsClosed returns if pool is closed.
 func (p *Pool) IsClosed() bool {
 	return p.closed.Val()
@@ -103,13 +134,23 @@ func (p *Pool) checkAndForkNewGoroutineWorker() {
 }
 
 func (p *Pool) asynchronousWorker() {
-	defer p.count.Add(-1)
+	var (
+		n   int
+		dec int = -1
+	)
+	defer func() { p.count.Add(dec) }()
 	// Harding working, one by one, job never empty, worker never die.
-	for !p.closed.Val() {
+	for !p.closed.Val() && !p.parsed.Load() {
 		listItem := p.list.PopBack()
 		if listItem == nil {
 			return
 		}
 		listItem.Func(listItem.Ctx)
+		// check whether need reduce woker.
+		n = p.count.Val()
+		if p.limit != -1 && n > p.limit && p.count.Cas(n, n-1) {
+			dec = 0
+			return
+		}
 	}
 }

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -53,11 +53,19 @@ func (p *Pool) AddWithRecover(ctx context.Context, userFunc Func, recoverFunc Re
 	})
 }
 
-// Cap returns the capacity of the pool.
-// This capacity is defined when pool is created.
+// Cap can change the capacity and returns the capacity of the pool before changed.
+// This capacity is defined when pool is created. Pass newCap will change it.
 // It returns -1 if there's no limit.
-func (p *Pool) Cap() int {
-	return int(p.limit.Load())
+func (p *Pool) Cap(newCap ...int) int {
+	if len(newCap) > 0 {
+		cap := int64(newCap[0])
+		if cap <= 0 {
+			cap = -1
+		}
+		return int(p.limit.Swap(cap))
+	} else {
+		return int(p.limit.Load())
+	}
 }
 
 // Size returns current goroutine count of the pool.
@@ -69,6 +77,12 @@ func (p *Pool) Size() int {
 // Note that, it does not return worker/goroutine count but the job/task count.
 func (p *Pool) Jobs() int {
 	return p.list.Size()
+}
+
+// ClearJobs clear current all jobs and return how many cleared.
+func (p *Pool) ClearJobs() (count int) {
+	items := p.list.PopBackAll()
+	return len(items)
 }
 
 // Pause pauses pool work. Jobs are kept in the queue and will be processed when the pool resumes.
@@ -89,7 +103,7 @@ func (p *Pool) IsPaused() bool {
 	return p.paused.Load()
 }
 
-// Resume resume pool work.
+// Resume resumes pool work.
 func (p *Pool) Resume() bool {
 	if p.IsClosed() {
 		return false
@@ -127,7 +141,7 @@ func (p *Pool) checkAndForkNewGoroutineWorker() {
 	var n int
 	for {
 		n = p.count.Val()
-		if limit := int(p.limit.Load()); limit != -1 && n >= limit {
+		if limit := p.limit.Load(); limit != -1 && int64(n) >= limit {
 			// No need fork new goroutine.
 			return
 		}
@@ -156,7 +170,7 @@ func (p *Pool) asynchronousWorker() {
 		listItem.Func(listItem.Ctx)
 		// Check whether need reduce worker.
 		n = p.count.Val()
-		if limit := int(p.limit.Load()); limit > 0 && n > limit && p.count.Cas(n, n-1) {
+		if limit := p.limit.Load(); limit > 0 && int64(n) > limit && p.count.Cas(n, n-1) {
 			addVal = 0
 			return
 		}

--- a/os/grpool/grpool_pool.go
+++ b/os/grpool/grpool_pool.go
@@ -16,7 +16,7 @@ import (
 // Add pushes a new job to the pool.
 // The job will be executed asynchronously.
 func (p *Pool) Add(ctx context.Context, f Func) error {
-	for p.closed.Val() {
+	if p.closed.Val() {
 		return gerror.NewCode(
 			gcode.CodeInvalidOperation,
 			"goroutine defaultPool is already closed",
@@ -165,7 +165,7 @@ func (p *Pool) asynchronousWorker() {
 		addVal = -1
 	)
 	defer func() { p.count.Add(addVal) }()
-	// Harding working, one by one, job never empty, worker never die.
+	// Hard working, one by one, job never empty, worker never die.
 	for !p.closed.Val() {
 		if p.paused.Load() {
 			return

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -18,7 +18,7 @@ func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsClosed() {
 		gtimer.Exit()
 	}
-	if p.IsParsed() {
+	if p.IsPaused() {
 		return
 	}
 	var changed = false

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -36,7 +36,8 @@ func (p *Pool) supervisor(ctx context.Context) {
 	if p.list.Size() > 0 && changed {
 		limit := p.limit.Load()
 		if limit == -1 {
-			for i := 0; i < p.list.Size(); i++ {
+			size := p.list.Size()
+			for i := 0; i < size; i++ {
 				p.checkAndForkNewGoroutineWorker()
 			}
 			return

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -24,15 +24,19 @@ func (p *Pool) supervisor(ctx context.Context) {
 	var changed = false
 	if p.limitChanger != nil {
 		changed = p.limitChanger(ctx, &p.limit)
+		if v := p.limit.Load(); v <= 0 && v != -1 {
+			p.limit.Store(-1)
+			changed = true
+		}
 	}
-	if p.count.Val() == 0 {
+	if !changed && p.count.Val() == 0 {
 		changed = true
 	}
 
 	if p.list.Size() > 0 && changed {
 		limit := int(p.limit.Load())
 		n := limit - p.count.Val()
-		if limit <= 0 || n > 0 {
+		if limit == -1 || n > 0 {
 			var number = p.list.Size()
 			if n > 0 && n < number {
 				number = n

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -34,16 +34,23 @@ func (p *Pool) supervisor(ctx context.Context) {
 	}
 
 	if p.list.Size() > 0 && changed {
-		limit := int(p.limit.Load())
-		n := limit - p.count.Val()
-		if limit == -1 || n > 0 {
-			var number = p.list.Size()
-			if n > 0 && n < number {
-				number = n
-			}
-			for i := 0; i < number; i++ {
+		limit := p.limit.Load()
+		if limit == -1 {
+			for i := 0; i < p.list.Size(); i++ {
 				p.checkAndForkNewGoroutineWorker()
 			}
+			return
+		}
+		n := limit - int64(p.count.Val())
+		if n <= 0 {
+			return
+		}
+		number := p.list.Size()
+		if n < int64(number) {
+			number = int(n)
+		}
+		for i := 0; i < number; i++ {
+			p.checkAndForkNewGoroutineWorker()
 		}
 	}
 }

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -14,17 +14,31 @@ import (
 
 // supervisor checks the job list and fork new worker goroutine to handle the job
 // if there are jobs but no workers in pool.
-func (p *Pool) supervisor(_ context.Context) {
+func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsClosed() {
 		gtimer.Exit()
 	}
-	if p.list.Size() > 0 && p.count.Val() == 0 {
-		var number = p.list.Size()
-		if p.limit > 0 {
-			number = p.limit
+	if p.IsParsed() {
+		return
+	}
+	if p.limitChanger != nil {
+		limit := p.limitChanger(ctx, p.limit)
+		if limit <= 0 {
+			limit = -1
 		}
-		for i := 0; i < number; i++ {
-			p.checkAndForkNewGoroutineWorker()
+		p.limit = limit
+	}
+
+	if p.list.Size() > 0 {
+		n := p.limit - p.count.Val()
+		if p.limit <= 0 || n > 0 {
+			var number = p.list.Size()
+			if n > 0 {
+				number = n
+			}
+			for i := 0; i < number; i++ {
+				p.checkAndForkNewGoroutineWorker()
+			}
 		}
 	}
 }

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -21,7 +21,7 @@ func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsPaused() {
 		return
 	}
-	var changed = false
+	changed := p.limitChanged.Load()
 	if p.limitChanger != nil {
 		changed = p.limitChanger(ctx, &p.limit)
 		if v := p.limit.Load(); v <= 0 && v != -1 {
@@ -33,25 +33,28 @@ func (p *Pool) supervisor(ctx context.Context) {
 		changed = true
 	}
 
-	if p.list.Size() > 0 && changed {
-		limit := p.limit.Load()
-		if limit == -1 {
-			size := p.list.Size()
-			for i := 0; i < size; i++ {
+	if changed {
+		if p.list.Size() > 0 {
+			limit := p.limit.Load()
+			if limit == -1 {
+				size := p.list.Size()
+				for i := 0; i < size; i++ {
+					p.checkAndForkNewGoroutineWorker()
+				}
+				return
+			}
+			n := limit - int64(p.count.Val())
+			if n <= 0 {
+				return
+			}
+			number := p.list.Size()
+			if n < int64(number) {
+				number = int(n)
+			}
+			for i := 0; i < number; i++ {
 				p.checkAndForkNewGoroutineWorker()
 			}
-			return
 		}
-		n := limit - int64(p.count.Val())
-		if n <= 0 {
-			return
-		}
-		number := p.list.Size()
-		if n < int64(number) {
-			number = int(n)
-		}
-		for i := 0; i < number; i++ {
-			p.checkAndForkNewGoroutineWorker()
-		}
+		p.limitChanged.Store(false)
 	}
 }

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -34,7 +34,7 @@ func (p *Pool) supervisor(ctx context.Context) {
 		n := limit - p.count.Val()
 		if limit <= 0 || n > 0 {
 			var number = p.list.Size()
-			if n > 0 {
+			if n > 0 && n < number {
 				number = n
 			}
 			for i := 0; i < number; i++ {

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -21,7 +21,7 @@ func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsPaused() {
 		return
 	}
-	changed := p.limitChanged.Load()
+	changed := p.limitChanged.Swap(false)
 	if p.limitChanger != nil {
 		changed = p.limitChanger(ctx, &p.limit)
 		if v := p.limit.Load(); v <= 0 && v != -1 {
@@ -55,6 +55,5 @@ func (p *Pool) supervisor(ctx context.Context) {
 				p.checkAndForkNewGoroutineWorker()
 			}
 		}
-		p.limitChanged.Store(false)
 	}
 }

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -21,17 +21,18 @@ func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsParsed() {
 		return
 	}
+	var changed = false
 	if p.limitChanger != nil {
-		limit := p.limitChanger(ctx, p.limit)
-		if limit <= 0 {
-			limit = -1
-		}
-		p.limit = limit
+		changed = p.limitChanger(ctx, &p.limit)
+	}
+	if p.count.Val() == 0 {
+		changed = true
 	}
 
-	if p.list.Size() > 0 {
-		n := p.limit - p.count.Val()
-		if p.limit <= 0 || n > 0 {
+	if p.list.Size() > 0 && changed {
+		limit := int(p.limit.Load())
+		n := limit - p.count.Val()
+		if limit <= 0 || n > 0 {
 			var number = p.list.Size()
 			if n > 0 {
 				number = n

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -8,6 +8,7 @@ package grpool
 
 import (
 	"context"
+	"math"
 
 	"github.com/gogf/gf/v2/os/gtimer"
 )
@@ -28,6 +29,9 @@ func (p *Pool) supervisor(ctx context.Context) {
 		}
 		if v := p.limit.Load(); v <= 0 && v != -1 {
 			p.limit.Store(-1)
+			changed = true
+		} else if v > int64(math.MaxInt) {
+			p.limit.Store(int64(math.MaxInt))
 			changed = true
 		}
 	}

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -23,7 +23,9 @@ func (p *Pool) supervisor(ctx context.Context) {
 	}
 	changed := p.limitChanged.Swap(false)
 	if p.limitChanger != nil {
-		changed = p.limitChanger(ctx, &p.limit)
+		if p.limitChanger(ctx, &p.limit) {
+			changed = true
+		}
 		if v := p.limit.Load(); v <= 0 && v != -1 {
 			p.limit.Store(-1)
 			changed = true

--- a/os/grpool/grpool_supervisor.go
+++ b/os/grpool/grpool_supervisor.go
@@ -17,6 +17,7 @@ import (
 // if there are jobs but no workers in pool.
 func (p *Pool) supervisor(ctx context.Context) {
 	if p.IsClosed() {
+		// gtimer.Exit() panics internally, so the code below is unreachable.
 		gtimer.Exit()
 	}
 	if p.IsPaused() {

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -113,6 +113,90 @@ func Test_Limit3(t *testing.T) {
 	})
 }
 
+func Test_Limit4(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			array = garray.NewArray(true)
+			size  = 1000
+			limit = 100
+			pool  = grpool.NewWithOption(grpool.PoolOption{
+				Limit: 100,
+				LimitChanger: func(ctx context.Context, old int) (new int) {
+					return limit
+				},
+			})
+		)
+		t.Assert(pool.Cap(), 100)
+		for i := 0; i < size; i++ {
+			pool.Add(ctx, func(ctx context.Context) {
+				array.Append(1)
+				time.Sleep(2 * time.Second)
+			})
+		}
+		time.Sleep(time.Second)
+		t.Assert(pool.Size(), 100)
+		t.Assert(pool.Jobs(), 900)
+		t.Assert(array.Len(), 100)
+		limit = 50
+		time.Sleep(time.Second * 2)
+		t.Assert(pool.Size(), 50)
+		t.Assert(pool.Jobs(), 850)
+		t.Assert(array.Len(), 150)
+		limit = 100
+		time.Sleep(time.Second * 2)
+		t.Assert(pool.Size(), 100)
+		t.Assert(pool.Jobs(), 750)
+		t.Assert(array.Len(), 250)
+		pool.Close()
+		time.Sleep(2 * time.Second)
+		t.Assert(pool.Size(), 0)
+		t.Assert(pool.Jobs(), 750)
+		t.Assert(array.Len(), 250)
+		t.Assert(pool.IsClosed(), true)
+		t.AssertNE(pool.Add(ctx, func(ctx context.Context) {}), nil)
+	})
+}
+
+func Test_ParseAndResume(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			array = garray.NewArray(true)
+			size  = 1000
+			pool  = grpool.New(100)
+		)
+		t.Assert(pool.Cap(), 100)
+		for i := 0; i < size; i++ {
+			pool.Add(ctx, func(ctx context.Context) {
+				array.Append(1)
+				time.Sleep(2 * time.Second)
+			})
+		}
+		time.Sleep(time.Second)
+		t.Assert(pool.Size(), 100)
+		t.Assert(pool.Jobs(), 900)
+		t.Assert(array.Len(), 100)
+		pool.Parse()
+		time.Sleep(time.Second * 2)
+		t.Assert(pool.Size(), 0)
+		t.Assert(pool.Jobs(), 900)
+		t.Assert(array.Len(), 100)
+		t.Assert(pool.IsParsed(), true)
+		pool.Resume()
+		time.Sleep(time.Second * 2)
+		t.Assert(pool.Size(), 100)
+		t.Assert(pool.Jobs(), 800)
+		t.Assert(array.Len(), 200)
+		t.Assert(pool.IsParsed(), false)
+		pool.Close()
+		time.Sleep(2 * time.Second)
+		t.Assert(pool.Size(), 0)
+		t.Assert(pool.Jobs(), 800)
+		t.Assert(array.Len(), 200)
+		t.Assert(pool.IsClosed(), true)
+		t.AssertNE(pool.Add(ctx, func(ctx context.Context) {}), nil)
+	})
+}
+
 func Test_AddWithRecover(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -18,6 +18,17 @@ import (
 	"github.com/gogf/gf/v2/test/gtest"
 )
 
+func waitUntil(timeout time.Duration, condition func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return condition()
+}
+
 func Test_Basic(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (
@@ -136,25 +147,34 @@ func Test_Limit4(t *testing.T) {
 				time.Sleep(2 * time.Second)
 			})
 		}
-		time.Sleep(time.Second)
-		t.Assert(pool.Size(), 100)
-		t.Assert(pool.Jobs(), 900)
-		t.Assert(array.Len(), 100)
+		t.Assert(waitUntil(2*time.Second, func() bool {
+			return pool.Size() == 100 && pool.Jobs() <= 900 && array.Len() > 0
+		}), true)
+		t.Assert(pool.Jobs()+array.Len(), size)
+
 		limit.Store(50)
-		time.Sleep(time.Second * 2)
+		t.Assert(waitUntil(4*time.Second, func() bool {
+			return pool.Size() <= 50 && pool.Size() >= 0
+		}), true)
 		t.Assert(pool.Size(), 50)
-		t.Assert(pool.Jobs(), 850)
-		t.Assert(array.Len(), 150)
+		t.Assert(pool.Jobs()+array.Len(), size)
+
+		jobsBeforeIncrease := pool.Jobs()
+		arrayBeforeIncrease := array.Len()
 		limit.Store(100)
-		time.Sleep(time.Second * 2)
-		t.Assert(pool.Size(), 100)
-		t.Assert(pool.Jobs(), 750)
-		t.Assert(array.Len(), 250)
+		t.Assert(waitUntil(4*time.Second, func() bool {
+			return pool.Size() > 50
+		}), true)
+		t.AssertLE(pool.Size(), 100)
+		t.AssertGT(pool.Jobs(), 0)
+		t.AssertLT(pool.Jobs(), jobsBeforeIncrease)
+		t.AssertGT(array.Len(), arrayBeforeIncrease)
+		t.Assert(pool.Jobs()+array.Len(), size)
+
 		pool.Close()
 		time.Sleep(2 * time.Second)
 		t.Assert(pool.Size(), 0)
-		t.Assert(pool.Jobs(), 750)
-		t.Assert(array.Len(), 250)
+		t.Assert(pool.Jobs()+array.Len(), size)
 		t.Assert(pool.IsClosed(), true)
 		t.AssertNE(pool.Add(ctx, func(ctx context.Context) {}), nil)
 	})

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -116,14 +116,16 @@ func Test_Limit3(t *testing.T) {
 
 func Test_Limit4(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
+		var limit atomic.Int64
+		limit.Store(100)
 		var (
 			array = garray.NewArray(true)
 			size  = 1000
-			limit = 100
 			pool  = grpool.NewWithOption(grpool.PoolOption{
 				Limit: 100,
 				LimitChanger: func(ctx context.Context, val *atomic.Int64) (changed bool) {
-					return val.Swap(int64(limit)) != int64(limit)
+					v := limit.Load()
+					return val.Swap(v) != v
 				},
 			})
 		)
@@ -138,12 +140,12 @@ func Test_Limit4(t *testing.T) {
 		t.Assert(pool.Size(), 100)
 		t.Assert(pool.Jobs(), 900)
 		t.Assert(array.Len(), 100)
-		limit = 50
+		limit.Store(50)
 		time.Sleep(time.Second * 2)
 		t.Assert(pool.Size(), 50)
 		t.Assert(pool.Jobs(), 850)
 		t.Assert(array.Len(), 150)
-		limit = 100
+		limit.Store(100)
 		time.Sleep(time.Second * 2)
 		t.Assert(pool.Size(), 100)
 		t.Assert(pool.Jobs(), 750)

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -160,7 +160,7 @@ func Test_Limit4(t *testing.T) {
 	})
 }
 
-func Test_ParseAndResume(t *testing.T) {
+func Test_PauseAndResume(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (
 			array = garray.NewArray(true)
@@ -178,18 +178,18 @@ func Test_ParseAndResume(t *testing.T) {
 		t.Assert(pool.Size(), 100)
 		t.Assert(pool.Jobs(), 900)
 		t.Assert(array.Len(), 100)
-		pool.Parse()
+		pool.Pause()
 		time.Sleep(time.Second * 2)
 		t.Assert(pool.Size(), 0)
 		t.Assert(pool.Jobs(), 900)
 		t.Assert(array.Len(), 100)
-		t.Assert(pool.IsParsed(), true)
+		t.Assert(pool.IsPaused(), true)
 		pool.Resume()
 		time.Sleep(time.Second * 2)
 		t.Assert(pool.Size(), 100)
 		t.Assert(pool.Jobs(), 800)
 		t.Assert(array.Len(), 200)
-		t.Assert(pool.IsParsed(), false)
+		t.Assert(pool.IsPaused(), false)
 		pool.Close()
 		time.Sleep(2 * time.Second)
 		t.Assert(pool.Size(), 0)

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -9,6 +9,7 @@ package grpool_test
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -121,8 +122,8 @@ func Test_Limit4(t *testing.T) {
 			limit = 100
 			pool  = grpool.NewWithOption(grpool.PoolOption{
 				Limit: 100,
-				LimitChanger: func(ctx context.Context, old int) (new int) {
-					return limit
+				LimitChanger: func(ctx context.Context, val *atomic.Int64) (changed bool) {
+					return val.Swap(int64(limit)) != int64(limit)
 				},
 			})
 		)

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -183,39 +183,61 @@ func Test_Limit4(t *testing.T) {
 func Test_PauseAndResume(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (
-			array = garray.NewArray(true)
-			size  = 1000
-			pool  = grpool.New(100)
+			err                 error
+			started             atomic.Int64
+			completed           atomic.Int64
+			firstBatchReleased  = make(chan struct{})
+			secondBatchReleased = make(chan struct{})
+			size                = 20
+			pool                = grpool.New(10)
 		)
-		t.Assert(pool.Cap(), 100)
-		for i := 0; i < size; i++ {
-			pool.Add(ctx, func(ctx context.Context) {
-				array.Append(1)
-				time.Sleep(2 * time.Second)
-			})
+		waitForCondition := func(condition func() bool) {
+			t.Helper()
+			deadline := time.Now().Add(5 * time.Second)
+			for time.Now().Before(deadline) {
+				if condition() {
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			t.Fatal("timed out waiting for pool state")
 		}
-		time.Sleep(time.Second)
-		t.Assert(pool.Size(), 100)
-		t.Assert(pool.Jobs(), 900)
-		t.Assert(array.Len(), 100)
-		pool.Pause()
-		time.Sleep(time.Second * 2)
-		t.Assert(pool.Size(), 0)
-		t.Assert(pool.Jobs(), 900)
-		t.Assert(array.Len(), 100)
+		t.Assert(pool.Cap(), 10)
+		for i := 0; i < size; i++ {
+			err = pool.Add(ctx, func(ctx context.Context) {
+				current := started.Add(1)
+				if current <= 10 {
+					<-firstBatchReleased
+				} else {
+					<-secondBatchReleased
+				}
+				completed.Add(1)
+			})
+			t.AssertNil(err)
+		}
+		waitForCondition(func() bool {
+			return pool.Size() == 10 && pool.Jobs() == 10 && started.Load() == 10
+		})
+		t.Assert(pool.Pause(), true)
+		close(firstBatchReleased)
+		waitForCondition(func() bool {
+			return pool.Size() == 0 && pool.Jobs() == 10 && started.Load() == 10 && completed.Load() == 10
+		})
 		t.Assert(pool.IsPaused(), true)
-		pool.Resume()
-		time.Sleep(time.Second * 2)
-		t.Assert(pool.Size(), 100)
-		t.Assert(pool.Jobs(), 800)
-		t.Assert(array.Len(), 200)
+		t.Assert(pool.Resume(), true)
+		waitForCondition(func() bool {
+			return pool.Size() == 10 && pool.Jobs() == 0 && started.Load() == 20 && completed.Load() == 10
+		})
 		t.Assert(pool.IsPaused(), false)
+		close(secondBatchReleased)
+		waitForCondition(func() bool {
+			return pool.Size() == 0 && pool.Jobs() == 0 && completed.Load() == 20
+		})
 		pool.Close()
-		time.Sleep(2 * time.Second)
-		t.Assert(pool.Size(), 0)
-		t.Assert(pool.Jobs(), 800)
-		t.Assert(array.Len(), 200)
 		t.Assert(pool.IsClosed(), true)
+		t.Assert(pool.Size(), 0)
+		t.Assert(pool.Jobs(), 0)
+		t.Assert(completed.Load(), int64(20))
 		t.AssertNE(pool.Add(ctx, func(ctx context.Context) {}), nil)
 	})
 }

--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -116,7 +116,9 @@ func Test_Limit3(t *testing.T) {
 		t.Assert(pool.Jobs(), 900)
 		t.Assert(array.Len(), 100)
 		pool.Close()
-		time.Sleep(2 * time.Second)
+		t.Assert(waitUntil(5*time.Second, func() bool {
+			return pool.Size() == 0
+		}), true)
 		t.Assert(pool.Size(), 0)
 		t.Assert(pool.Jobs(), 900)
 		t.Assert(array.Len(), 100)
@@ -163,7 +165,7 @@ func Test_Limit4(t *testing.T) {
 		arrayBeforeIncrease := array.Len()
 		limit.Store(100)
 		t.Assert(waitUntil(4*time.Second, func() bool {
-			return pool.Size() > 50
+			return pool.Size() > 50 && pool.Jobs() < jobsBeforeIncrease
 		}), true)
 		t.AssertLE(pool.Size(), 100)
 		t.AssertGT(pool.Jobs(), 0)
@@ -172,7 +174,9 @@ func Test_Limit4(t *testing.T) {
 		t.Assert(pool.Jobs()+array.Len(), size)
 
 		pool.Close()
-		time.Sleep(2 * time.Second)
+		t.Assert(waitUntil(5*time.Second, func() bool {
+			return pool.Size() == 0
+		}), true)
 		t.Assert(pool.Size(), 0)
 		t.Assert(pool.Jobs()+array.Len(), size)
 		t.Assert(pool.IsClosed(), true)


### PR DESCRIPTION
This pull request introduces significant enhancements to the goroutine pool (`grpool`) by adding support for dynamic resizing of the pool, pause/resume functionality, and improved state management. These changes make the pool more flexible and robust, allowing runtime adjustment of worker limits and better control over job execution. The pull request also includes comprehensive tests for the new features.

**Dynamic Pool Management and Control:**

* Added a `LimitChangerFunc` and `PoolOption` to allow dynamic adjustment of the pool's goroutine limit at runtime, and refactored the pool to use `atomic.Int64` for thread-safe limit handling. (`os/grpool/grpool.go`, [[1]](diffhunk://#diff-84ea74fe58f8ff7de3267939e2d8d7abd11940109a350383606eb7adbfbc0a6eR24-R45) [[2]](diffhunk://#diff-84ea74fe58f8ff7de3267939e2d8d7abd11940109a350383606eb7adbfbc0a6eR68-R91) [[3]](diffhunk://#diff-84ea74fe58f8ff7de3267939e2d8d7abd11940109a350383606eb7adbfbc0a6eL66-R109)
* Implemented new methods to pause and resume the pool (`Pause`, `Resume`, `IsPaused`), preventing new jobs from starting while paused and resuming execution when desired. (`os/grpool/grpool.go`, [[1]](diffhunk://#diff-84ea74fe58f8ff7de3267939e2d8d7abd11940109a350383606eb7adbfbc0a6eR137-R151); `os/grpool/grpool_pool.go`, [[2]](diffhunk://#diff-7421b86248bfc8aa5e4a18c35fc5645c83641bcd414cc638bca5350a5f74df8cR83-R144)
* Updated the supervisor logic to support dynamic limit changes and pausing, ensuring the pool responds immediately to limit changes and pause/resume commands. (`os/grpool/grpool_supervisor.go`, [os/grpool/grpool_supervisor.goL17-R51](diffhunk://#diff-bcb1c90011b873d29dc42ed5b47f62f55369e737a094d67d375e2803ab343d17L17-R51))

**API Additions and Improvements:**

* Added methods to get and set the pool capacity at runtime (`Cap`, `SetCap`), and to clear all pending jobs (`ClearJobs`). (`os/grpool/grpool_pool.go`, [[1]](diffhunk://#diff-7421b86248bfc8aa5e4a18c35fc5645c83641bcd414cc638bca5350a5f74df8cL60-R69) [[2]](diffhunk://#diff-7421b86248bfc8aa5e4a18c35fc5645c83641bcd414cc638bca5350a5f74df8cR83-R144)

**Testing:**

* Added unit tests to verify dynamic limit changes and pause/resume functionality, ensuring correct behavior under various scenarios. (`os/grpool/grpool_z_unit_test.go`, [os/grpool/grpool_z_unit_test.goR117-R202](diffhunk://#diff-9ab6053c7197ca9538c2bd33b594e2a690bd0d3fbb63a3815bbbe4e743c25990R117-R202))

These changes greatly improve the flexibility and usability of the goroutine pool, making it suitable for more advanced and dynamic workloads.