### PR TITLE
fix(net/ghttp): normalize method case before route cache lookup

### DIFF
--- a/net/ghttp/ghttp_server_router_serve.go
+++ b/net/ghttp/ghttp_server_router_serve.go
@@ -43,8 +43,11 @@ func (s *Server) serveHandlerKey(method, path, domain string) string {
 // getHandlersWithCache searches the router item with cache feature for a given request.
 func (s *Server) getHandlersWithCache(r *Request) (parsedItems []*HandlerItemParsed, serveItem *HandlerItemParsed, hasHook, hasServe bool) {
 	var (
-		ctx    = r.Context()
-		method = r.Method
+		ctx = r.Context()
+		// HTTP methods are case-insensitive (RFC 9110). Cache keys already upper-case the
+		// method via serveHandlerKey, so search must use the same form — otherwise a
+		// lowercase "get" miss gets cached under "GET:..." and poisons later real GET hits.
+		method = strings.ToUpper(r.Method)
 		path   = r.URL.Path
 		host   = r.GetHost()
 	)
@@ -64,7 +67,7 @@ func (s *Server) getHandlersWithCache(r *Request) (parsedItems []*HandlerItemPar
 	// It searches the handler with the request method instead of OPTIONS method.
 	if method == http.MethodOptions {
 		if v := r.Header.Get("Access-Control-Request-Method"); v != "" {
-			method = v
+			method = strings.ToUpper(v)
 		}
 	}
 	// Search and cache the router handlers.

--- a/net/ghttp/ghttp_z_unit_feature_router_basic_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_router_basic_test.go
@@ -8,6 +8,8 @@ package ghttp_test
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -296,5 +298,43 @@ func Test_Router_Priority(t *testing.T) {
 		t.Assert(client.GetContent(ctx, "/admin-1"), "admin-{page}")
 		t.Assert(client.GetContent(ctx, "/admin-goods"), "admin-goods")
 		t.Assert(client.GetContent(ctx, "/admin-goods-2"), "admin-goods-{page}")
+	})
+}
+
+// Test_Router_LowercaseMethodCache ensures a non-canonical method casing does not
+// poison the serve handler cache for later requests (issue #4765).
+func Test_Router_LowercaseMethodCache(t *testing.T) {
+	s := g.Server(guid.S())
+	s.BindHandler("GET:/api/user", func(r *ghttp.Request) {
+		r.Response.Write("hello")
+	})
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+	gtest.C(t, func(t *gtest.T) {
+		addr := fmt.Sprintf("http://127.0.0.1:%d/api/user", s.GetListenedPort())
+
+		// raw lowercase method — g.Client always upper-cases methods
+		req1, err := http.NewRequest("get", addr, nil)
+		t.AssertNil(err)
+		resp1, err := http.DefaultClient.Do(req1)
+		t.AssertNil(err)
+		body1, err := io.ReadAll(resp1.Body)
+		resp1.Body.Close()
+		t.AssertNil(err)
+		t.Assert(resp1.StatusCode, 200)
+		t.Assert(string(body1), "hello")
+
+		req2, err := http.NewRequest(http.MethodGet, addr, nil)
+		t.AssertNil(err)
+		resp2, err := http.DefaultClient.Do(req2)
+		t.AssertNil(err)
+		body2, err := io.ReadAll(resp2.Body)
+		resp2.Body.Close()
+		t.AssertNil(err)
+		t.Assert(resp2.StatusCode, 200)
+		t.Assert(string(body2), "hello")
 	})
 }


### PR DESCRIPTION
Fixes #4765

`serveHandlerKey` already upper-cases the method for cache keys, but `getHandlersWithCache` used the raw request method for search. So a lowercase `get` miss got stored under `GET:/path` and later real `GET` requests kept hitting that empty cache entry until restart.

Change:
- `strings.ToUpper(r.Method)` before search/cache
- same for `Access-Control-Request-Method` on OPTIONS

Test: `Test_Router_LowercaseMethodCache` (raw `http.NewRequest("get", ...)` then normal GET)

```
go test ./net/ghttp/ -run Test_Router_LowercaseMethodCache
```