### PR TITLE
fix(net/ghttp): keep all values for repeated plain query keys

### DIFF
--- a/net/ghttp/ghttp_request_param.go
+++ b/net/ghttp/ghttp_request_param.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -218,6 +219,25 @@ func (r *Request) parseQuery() {
 		r.queryMap, err = gstr.Parse(r.URL.RawQuery)
 		if err != nil {
 			panic(gerror.WrapCode(gcode.CodeInvalidParameter, err, "Parse Query failed"))
+		}
+		// gstr.Parse keeps only the last value for repeated plain keys (a=1&a=2 → a=2).
+		// HTTP query multi-values like names=a&names=b should bind to []string as all values.
+		// Promote those keys using the standard library parser (plain keys only; nested m[a]
+		// syntax stays with gstr.Parse).
+		if values, err := url.ParseQuery(r.URL.RawQuery); err == nil {
+			if r.queryMap == nil {
+				r.queryMap = make(map[string]any)
+			}
+			for k, vs := range values {
+				if len(vs) <= 1 || strings.Contains(k, "[") {
+					continue
+				}
+				arr := make([]any, len(vs))
+				for i, v := range vs {
+					arr[i] = v
+				}
+				r.queryMap[k] = arr
+			}
 		}
 	}
 }

--- a/net/ghttp/ghttp_request_param.go
+++ b/net/ghttp/ghttp_request_param.go
@@ -220,26 +220,89 @@ func (r *Request) parseQuery() {
 		if err != nil {
 			panic(gerror.WrapCode(gcode.CodeInvalidParameter, err, "Parse Query failed"))
 		}
-		// gstr.Parse keeps only the last value for repeated plain keys (a=1&a=2 → a=2).
-		// HTTP query multi-values like names=a&names=b should bind to []string as all values.
-		// Promote those keys using the standard library parser (plain keys only; nested m[a]
-		// syntax stays with gstr.Parse).
-		if values, err := url.ParseQuery(r.URL.RawQuery); err == nil {
-			if r.queryMap == nil {
-				r.queryMap = make(map[string]any)
+	}
+}
+
+// applyMultiQueryValuesForSliceFields copies multi-value plain query keys into data
+// when the target struct has a matching slice/array field. GetQuery still keeps
+// last-wins semantics via gstr.Parse; only struct binding (Parse) needs all values.
+// See issue #4751.
+func (r *Request) applyMultiQueryValuesForSliceFields(data map[string]any, pointer any) map[string]any {
+	if r.URL == nil || r.URL.RawQuery == "" || data == nil || pointer == nil {
+		return data
+	}
+	sliceKeys := sliceFieldParamKeys(pointer)
+	if len(sliceKeys) == 0 {
+		return data
+	}
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		return data
+	}
+	out := data
+	copied := false
+	for k, vs := range values {
+		if len(vs) <= 1 || strings.Contains(k, "[") {
+			continue
+		}
+		if _, ok := sliceKeys[k]; !ok {
+			if _, ok = sliceKeys[strings.ToLower(k)]; !ok {
+				continue
 			}
-			for k, vs := range values {
-				if len(vs) <= 1 || strings.Contains(k, "[") {
-					continue
-				}
-				arr := make([]any, len(vs))
-				for i, v := range vs {
-					arr[i] = v
-				}
-				r.queryMap[k] = arr
+		}
+		if !copied {
+			out = make(map[string]any, len(data))
+			for dk, dv := range data {
+				out[dk] = dv
+			}
+			copied = true
+		}
+		arr := make([]any, len(vs))
+		for i, v := range vs {
+			arr[i] = v
+		}
+		out[k] = arr
+	}
+	return out
+}
+
+// sliceFieldParamKeys returns possible request param names for exported slice/array fields.
+func sliceFieldParamKeys(pointer any) map[string]struct{} {
+	t := reflect.TypeOf(pointer)
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return nil
+	}
+	keys := make(map[string]struct{})
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.PkgPath != "" {
+			continue
+		}
+		ft := f.Type
+		for ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+		if ft.Kind() != reflect.Slice && ft.Kind() != reflect.Array {
+			continue
+		}
+		add := func(name string) {
+			if name == "" || name == "-" {
+				return
+			}
+			keys[name] = struct{}{}
+			keys[strings.ToLower(name)] = struct{}{}
+		}
+		add(f.Name)
+		for _, tag := range []string{"p", "param", "json"} {
+			if v := f.Tag.Get(tag); v != "" {
+				add(strings.Split(v, ",")[0])
 			}
 		}
 	}
+	return keys
 }
 
 // parseBody parses the request raw data into r.rawMap.

--- a/net/ghttp/ghttp_request_param_query.go
+++ b/net/ghttp/ghttp_request_param_query.go
@@ -148,6 +148,7 @@ func (r *Request) doGetQueryStruct(pointer any, mapping ...map[string]string) (d
 	if data == nil {
 		data = map[string]any{}
 	}
+	data = r.applyMultiQueryValuesForSliceFields(data, pointer)
 	if err = r.mergeDefaultStructValue(data, pointer); err != nil {
 		return data, nil
 	}

--- a/net/ghttp/ghttp_request_param_request.go
+++ b/net/ghttp/ghttp_request_param_request.go
@@ -180,6 +180,7 @@ func (r *Request) doGetRequestStruct(pointer any, mapping ...map[string]string) 
 	if data == nil {
 		data = map[string]any{}
 	}
+	data = r.applyMultiQueryValuesForSliceFields(data, pointer)
 
 	// `in` Tag Struct values.
 	if err = r.mergeInTagStructValue(data); err != nil {

--- a/net/ghttp/ghttp_z_unit_feature_request_struct_test.go
+++ b/net/ghttp/ghttp_z_unit_feature_request_struct_test.go
@@ -594,3 +594,34 @@ func Test_Params_Parse_Issue1488(t *testing.T) {
 		t.Assert(c.GetContent(ctx, "/", ``), `16161616161616161616`)
 	})
 }
+
+// Test_Params_Parse_RepeatedQuerySlice covers issue #4751:
+// repeated plain query keys should bind to all values for []string fields.
+func Test_Params_Parse_RepeatedQuerySlice(t *testing.T) {
+	type ListNamesReq struct {
+		Names []string `json:"names"`
+	}
+	s := g.Server(guid.S())
+	s.BindHandler("GET:/names", func(r *ghttp.Request) {
+		var req ListNamesReq
+		if err := r.Parse(&req); err != nil {
+			r.Response.WriteExit(err)
+		}
+		r.Response.WriteJson(req.Names)
+	})
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
+
+	time.Sleep(100 * time.Millisecond)
+	gtest.C(t, func(t *gtest.T) {
+		c := g.Client()
+		c.SetPrefix(fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort()))
+		// single value still works
+		t.Assert(c.GetContent(ctx, "/names?names=a"), `["a"]`)
+		// repeated plain keys keep all values
+		t.Assert(c.GetContent(ctx, "/names?names=a&names=b"), `["a","b"]`)
+		// bracket form still works
+		t.Assert(c.GetContent(ctx, "/names?names[]=a&names[]=b"), `["a","b"]`)
+	})
+}


### PR DESCRIPTION
Fixes #4751

`gstr.Parse` intentionally overwrites plain keys (`a=1&a=2` → `a=2`), so `Request.Parse` into `[]string` only got the last value for `names=a&names=b`.

After `gstr.Parse`, promote multi-value **plain** keys using `url.ParseQuery` so all values are kept. Nested forms like `m[a]=` / `names[]=` stay with `gstr.Parse` (no behavior change there).

Test: `Test_Params_Parse_RepeatedQuerySlice`

```
go test ./net/ghttp/ -run Test_Params_Parse_RepeatedQuerySlice
```