### PR TITLE
fix(os/glog): make logger config concurrent-safe

### DIFF
--- a/os/glog/glog_logger.go
+++ b/os/glog/glog_logger.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fatih/color"
@@ -35,7 +37,8 @@ import (
 // Logger is the struct for logging management.
 type Logger struct {
 	parent *Logger // Parent logger, if it is not empty, it means the logger is used in chaining function.
-	config Config  // Logger configuration.
+	mu     sync.Mutex
+	config atomic.Value // stores Config; never mutate in place after Store.
 }
 
 const (
@@ -61,9 +64,26 @@ const (
 
 // New creates and returns a custom logger.
 func New() *Logger {
-	return &Logger{
-		config: DefaultConfig(),
+	l := &Logger{}
+	l.storeConfig(DefaultConfig())
+	return l
+}
+
+// loadConfig returns the current logger configuration snapshot.
+func (l *Logger) loadConfig() Config {
+	if l == nil {
+		return Config{}
 	}
+	v := l.config.Load()
+	if v == nil {
+		return DefaultConfig()
+	}
+	return v.(Config)
+}
+
+// storeConfig stores configuration. Caller must hold l.mu when doing read-modify-write.
+func (l *Logger) storeConfig(c Config) {
+	l.config.Store(c)
 }
 
 // NewWithWriter creates and returns a custom logger with io.Writer.
@@ -76,20 +96,20 @@ func NewWithWriter(writer io.Writer) *Logger {
 // Clone returns a new logger, which a `shallow copy` of the current logger.
 // Note that the attribute `config` of the cloned one is the shallow copy of current one.
 func (l *Logger) Clone() *Logger {
-	return &Logger{
-		config: l.config,
-		parent: l,
-	}
+	c := &Logger{parent: l}
+	c.storeConfig(l.loadConfig())
+	return c
 }
 
 // getFilePath returns the logging file path.
 // The logging file name must have extension name of "log".
 func (l *Logger) getFilePath(now time.Time) string {
+	cfg := l.loadConfig()
 	// Content containing "{}" in the file name is formatted using gtime.
-	file, _ := gregex.ReplaceStringFunc(`{.+?}`, l.config.File, func(s string) string {
+	file, _ := gregex.ReplaceStringFunc(`{.+?}`, cfg.File, func(s string) string {
 		return gtime.New(now).Format(strings.Trim(s, "{}"))
 	})
-	file = gfile.Join(l.config.Path, file)
+	file = gfile.Join(cfg.Path, file)
 	return file
 }
 
@@ -99,10 +119,10 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 	// It uses atomic reading operation to enhance the performance checking.
 	// It here uses CAP for performance and concurrent safety.
 	// It just initializes once for each logger.
-	if l.config.RotateSize > 0 || l.config.RotateExpire > 0 {
-		if !l.config.rotatedHandlerInitialized.Val() && l.config.rotatedHandlerInitialized.Cas(false, true) {
+	if l.loadConfig().RotateSize > 0 || l.loadConfig().RotateExpire > 0 {
+		if !l.loadConfig().rotatedHandlerInitialized.Val() && l.loadConfig().rotatedHandlerInitialized.Cas(false, true) {
 			l.rotateChecksTimely(ctx)
-			intlog.Printf(ctx, "logger rotation initialized: every %s", l.config.RotateCheckInterval.String())
+			intlog.Printf(ctx, "logger rotation initialized: every %s", l.loadConfig().RotateCheckInterval.String())
 		}
 	}
 
@@ -123,8 +143,8 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 	)
 
 	// Logging handlers.
-	if len(l.config.Handlers) > 0 {
-		input.handlers = append(input.handlers, l.config.Handlers...)
+	if len(l.loadConfig().Handlers) > 0 {
+		input.handlers = append(input.handlers, l.loadConfig().Handlers...)
 	} else if defaultHandler != nil {
 		input.handlers = []Handler{defaultHandler}
 	}
@@ -132,19 +152,19 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 
 	// Time.
 	timeFormat := ""
-	if l.config.TimeFormat != "" {
-		timeFormat = l.config.TimeFormat
+	if l.loadConfig().TimeFormat != "" {
+		timeFormat = l.loadConfig().TimeFormat
 	} else {
-		if l.config.Flags&F_TIME_DATE > 0 {
+		if l.loadConfig().Flags&F_TIME_DATE > 0 {
 			timeFormat += "2006-01-02"
 		}
-		if l.config.Flags&F_TIME_TIME > 0 {
+		if l.loadConfig().Flags&F_TIME_TIME > 0 {
 			if timeFormat != "" {
 				timeFormat += " "
 			}
 			timeFormat += "15:04:05"
 		}
-		if l.config.Flags&F_TIME_MILLI > 0 {
+		if l.loadConfig().Flags&F_TIME_MILLI > 0 {
 			if timeFormat != "" {
 				timeFormat += " "
 			}
@@ -160,28 +180,28 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 	input.LevelFormat = l.GetLevelPrefix(level)
 
 	// Caller path and Fn name.
-	if l.config.Flags&(F_FILE_LONG|F_FILE_SHORT|F_CALLER_FN) > 0 {
+	if l.loadConfig().Flags&(F_FILE_LONG|F_FILE_SHORT|F_CALLER_FN) > 0 {
 		callerFnName, path, line := gdebug.CallerWithFilter(
 			[]string{consts.StackFilterKeyForGoFrame},
-			l.config.StSkip,
+			l.loadConfig().StSkip,
 		)
-		if l.config.Flags&F_CALLER_FN > 0 {
+		if l.loadConfig().Flags&F_CALLER_FN > 0 {
 			if len(callerFnName) > 2 {
 				input.CallerFunc = fmt.Sprintf(`[%s]`, callerFnName)
 			}
 		}
 		if line >= 0 && len(path) > 1 {
-			if l.config.Flags&F_FILE_LONG > 0 {
+			if l.loadConfig().Flags&F_FILE_LONG > 0 {
 				input.CallerPath = fmt.Sprintf(`%s:%d:`, path, line)
 			}
-			if l.config.Flags&F_FILE_SHORT > 0 {
+			if l.loadConfig().Flags&F_FILE_SHORT > 0 {
 				input.CallerPath = fmt.Sprintf(`%s:%d:`, gfile.Basename(path), line)
 			}
 		}
 	}
 	// Prefix.
-	if len(l.config.Prefix) > 0 {
-		input.Prefix = l.config.Prefix
+	if len(l.loadConfig().Prefix) > 0 {
+		input.Prefix = l.loadConfig().Prefix
 	}
 
 	// Convert value to string.
@@ -192,8 +212,8 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 			input.TraceId = traceId.String()
 		}
 		// Context values.
-		if len(l.config.CtxKeys) > 0 {
-			for _, ctxKey := range l.config.CtxKeys {
+		if len(l.loadConfig().CtxKeys) > 0 {
+			for _, ctxKey := range l.loadConfig().CtxKeys {
 				var ctxValue any
 				if ctxValue = ctx.Value(ctxKey); ctxValue == nil {
 					ctxValue = ctx.Value(gctx.StrKey(gconv.String(ctxKey)))
@@ -207,7 +227,7 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 			}
 		}
 	}
-	if l.config.Flags&F_ASYNC > 0 {
+	if l.loadConfig().Flags&F_ASYNC > 0 {
 		input.IsAsync = true
 		err := asyncPool.Add(ctx, func(ctx context.Context) {
 			input.Next(ctx)
@@ -224,21 +244,21 @@ func (l *Logger) print(ctx context.Context, level int, stack string, values ...a
 func (l *Logger) doFinalPrint(ctx context.Context, input *HandlerInput) *bytes.Buffer {
 	var buffer *bytes.Buffer
 	// Allow output to stdout?
-	if l.config.StdoutPrint {
+	if l.loadConfig().StdoutPrint {
 		if buf := l.printToStdout(ctx, input); buf != nil {
 			buffer = buf
 		}
 	}
 
 	// Output content to disk file.
-	if l.config.Path != "" {
+	if l.loadConfig().Path != "" {
 		if buf := l.printToFile(ctx, input.Time, input); buf != nil {
 			buffer = buf
 		}
 	}
 
 	// Used custom writer.
-	if l.config.Writer != nil {
+	if l.loadConfig().Writer != nil {
 		// Output to custom writer.
 		if buf := l.printToWriter(ctx, input); buf != nil {
 			buffer = buf
@@ -249,9 +269,9 @@ func (l *Logger) doFinalPrint(ctx context.Context, input *HandlerInput) *bytes.B
 
 // printToWriter writes buffer to writer.
 func (l *Logger) printToWriter(ctx context.Context, input *HandlerInput) *bytes.Buffer {
-	if l.config.Writer != nil {
-		var buffer = input.getRealBuffer(l.config.WriterColorEnable)
-		if _, err := l.config.Writer.Write(buffer.Bytes()); err != nil {
+	if l.loadConfig().Writer != nil {
+		var buffer = input.getRealBuffer(l.loadConfig().WriterColorEnable)
+		if _, err := l.loadConfig().Writer.Write(buffer.Bytes()); err != nil {
 			intlog.Errorf(ctx, `%+v`, err)
 		}
 		return buffer
@@ -261,10 +281,10 @@ func (l *Logger) printToWriter(ctx context.Context, input *HandlerInput) *bytes.
 
 // printToStdout outputs logging content to stdout.
 func (l *Logger) printToStdout(ctx context.Context, input *HandlerInput) *bytes.Buffer {
-	if l.config.StdoutPrint {
+	if l.loadConfig().StdoutPrint {
 		var (
 			err    error
-			buffer = input.getRealBuffer(!l.config.StdoutColorDisabled)
+			buffer = input.getRealBuffer(!l.loadConfig().StdoutColorDisabled)
 		)
 		// This will lose color in Windows os system. DO NOT USE.
 		// if _, err := os.Stdout.Write(input.getRealBuffer(true).Bytes()); err != nil {
@@ -281,7 +301,7 @@ func (l *Logger) printToStdout(ctx context.Context, input *HandlerInput) *bytes.
 // printToFile outputs logging content to disk file.
 func (l *Logger) printToFile(ctx context.Context, t time.Time, in *HandlerInput) *bytes.Buffer {
 	var (
-		buffer        = in.getRealBuffer(l.config.WriterColorEnable)
+		buffer        = in.getRealBuffer(l.loadConfig().WriterColorEnable)
 		logFilePath   = l.getFilePath(t)
 		memoryLockKey = memoryLockPrefixForPrintingToFile + logFilePath
 	)
@@ -289,7 +309,7 @@ func (l *Logger) printToFile(ctx context.Context, t time.Time, in *HandlerInput)
 	defer gmlock.Unlock(memoryLockKey)
 
 	// Rotation file size checks.
-	if l.config.RotateSize > 0 && gfile.Size(logFilePath) > l.config.RotateSize {
+	if l.loadConfig().RotateSize > 0 && gfile.Size(logFilePath) > l.loadConfig().RotateSize {
 		if runtime.GOOS == "windows" {
 			file := l.createFpInPool(ctx, logFilePath)
 			if file == nil {
@@ -370,7 +390,7 @@ func (l *Logger) printErr(ctx context.Context, level int, values ...any) {
 		return
 	}
 	var stack string
-	if l.config.StStatus == 1 {
+	if l.loadConfig().StStatus == 1 {
 		stack = l.GetStack()
 	}
 	// In matter of sequence, do not use stderr here, but use the same stdout.
@@ -395,13 +415,13 @@ func (l *Logger) PrintStack(ctx context.Context, skip ...int) {
 // GetStack returns the caller stack content,
 // the optional parameter `skip` specify the skipped stack offset from the end point.
 func (l *Logger) GetStack(skip ...int) string {
-	stackSkip := l.config.StSkip
+	stackSkip := l.loadConfig().StSkip
 	if len(skip) > 0 {
 		stackSkip += skip[0]
 	}
 	filters := []string{pathFilterKey}
-	if l.config.StFilter != "" {
-		filters = append(filters, l.config.StFilter)
+	if l.loadConfig().StFilter != "" {
+		filters = append(filters, l.loadConfig().StFilter)
 	}
 	// Whether filter framework error stacks.
 	if errors.IsStackModeBrief() {

--- a/os/glog/glog_logger_api.go
+++ b/os/glog/glog_logger_api.go
@@ -146,5 +146,5 @@ func (l *Logger) checkLevel(level int) bool {
 	if l == nil {
 		return false
 	}
-	return l.config.Level&level > 0
+	return l.loadConfig().Level&level > 0
 }

--- a/os/glog/glog_logger_chaining.go
+++ b/os/glog/glog_logger_chaining.go
@@ -162,17 +162,9 @@ func (l *Logger) Stdout(enabled ...bool) *Logger {
 	}
 	// stdout printing is enabled if `enabled` is not passed.
 	if len(enabled) > 0 && !enabled[0] {
-		logger.mu.Lock()
-	c := logger.loadConfig()
-	c.StdoutPrint = false
-	logger.storeConfig(c)
-	logger.mu.Unlock()
+		logger.SetStdoutPrint(false)
 	} else {
-		logger.mu.Lock()
-	c := logger.loadConfig()
-	c.StdoutPrint = true
-	logger.storeConfig(c)
-	logger.mu.Unlock()
+		logger.SetStdoutPrint(true)
 	}
 	return logger
 }
@@ -209,16 +201,16 @@ func (l *Logger) Line(long ...bool) *Logger {
 	}
 	if len(long) > 0 && long[0] {
 		logger.mu.Lock()
-	c := logger.loadConfig()
-	c.Flags |= F_FILE_LONG
-	logger.storeConfig(c)
-	logger.mu.Unlock()
+		c := logger.loadConfig()
+		c.Flags |= F_FILE_LONG
+		logger.storeConfig(c)
+		logger.mu.Unlock()
 	} else {
 		logger.mu.Lock()
-	c := logger.loadConfig()
-	c.Flags |= F_FILE_SHORT
-	logger.storeConfig(c)
-	logger.mu.Unlock()
+		c := logger.loadConfig()
+		c.Flags |= F_FILE_SHORT
+		logger.storeConfig(c)
+		logger.mu.Unlock()
 	}
 	return logger
 }

--- a/os/glog/glog_logger_chaining.go
+++ b/os/glog/glog_logger_chaining.go
@@ -54,8 +54,8 @@ func (l *Logger) Cat(category string) *Logger {
 	} else {
 		logger = l
 	}
-	if logger.config.Path != "" {
-		if err := logger.SetPath(gfile.Join(logger.config.Path, category)); err != nil {
+	if path := logger.loadConfig().Path; path != "" {
+		if err := logger.SetPath(gfile.Join(path, category)); err != nil {
 			panic(err)
 		}
 	}
@@ -162,9 +162,17 @@ func (l *Logger) Stdout(enabled ...bool) *Logger {
 	}
 	// stdout printing is enabled if `enabled` is not passed.
 	if len(enabled) > 0 && !enabled[0] {
-		logger.config.StdoutPrint = false
+		logger.mu.Lock()
+	c := logger.loadConfig()
+	c.StdoutPrint = false
+	logger.storeConfig(c)
+	logger.mu.Unlock()
 	} else {
-		logger.config.StdoutPrint = true
+		logger.mu.Lock()
+	c := logger.loadConfig()
+	c.StdoutPrint = true
+	logger.storeConfig(c)
+	logger.mu.Unlock()
 	}
 	return logger
 }
@@ -200,9 +208,17 @@ func (l *Logger) Line(long ...bool) *Logger {
 		logger = l
 	}
 	if len(long) > 0 && long[0] {
-		logger.config.Flags |= F_FILE_LONG
+		logger.mu.Lock()
+	c := logger.loadConfig()
+	c.Flags |= F_FILE_LONG
+	logger.storeConfig(c)
+	logger.mu.Unlock()
 	} else {
-		logger.config.Flags |= F_FILE_SHORT
+		logger.mu.Lock()
+	c := logger.loadConfig()
+	c.Flags |= F_FILE_SHORT
+	logger.storeConfig(c)
+	logger.mu.Unlock()
 	}
 	return logger
 }

--- a/os/glog/glog_logger_config.go
+++ b/os/glog/glog_logger_config.go
@@ -83,12 +83,14 @@ func DefaultConfig() Config {
 
 // GetConfig returns the configuration of current Logger.
 func (l *Logger) GetConfig() Config {
-	return l.config
+	return l.loadConfig()
 }
 
 // SetConfig set configurations for the logger.
 func (l *Logger) SetConfig(config Config) error {
-	l.config = config
+	l.mu.Lock()
+	l.storeConfig(config)
+	l.mu.Unlock()
 	// Necessary validation.
 	if config.Path != "" {
 		if err := l.SetPath(config.Path); err != nil {
@@ -96,7 +98,7 @@ func (l *Logger) SetConfig(config Config) error {
 			return err
 		}
 	}
-	intlog.Printf(context.TODO(), "SetConfig: %+v", l.config)
+	intlog.Printf(context.TODO(), "SetConfig: %+v", l.loadConfig())
 	return nil
 }
 
@@ -125,58 +127,83 @@ func (l *Logger) SetConfigWithMap(m map[string]any) error {
 			return gerror.NewCodef(gcode.CodeInvalidConfiguration, `invalid rotate size: %v`, rotateSizeValue)
 		}
 	}
-	if err := gconv.Struct(m, &l.config); err != nil {
+	c := l.loadConfig()
+	if err := gconv.Struct(m, &c); err != nil {
 		return err
 	}
-	return l.SetConfig(l.config)
+	return l.SetConfig(c)
 }
 
 // SetDebug enables/disables the debug level for logger.
 // The debug level is enabled in default.
 func (l *Logger) SetDebug(debug bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
 	if debug {
-		l.config.Level = l.config.Level | LEVEL_DEBU
+		c.Level = c.Level | LEVEL_DEBU
 	} else {
-		l.config.Level = l.config.Level & ^LEVEL_DEBU
+		c.Level = c.Level & ^LEVEL_DEBU
 	}
+	l.storeConfig(c)
 }
 
 // SetAsync enables/disables async logging output feature.
 func (l *Logger) SetAsync(enabled bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
 	if enabled {
-		l.config.Flags = l.config.Flags | F_ASYNC
+		c.Flags = c.Flags | F_ASYNC
 	} else {
-		l.config.Flags = l.config.Flags & ^F_ASYNC
+		c.Flags = c.Flags & ^F_ASYNC
 	}
+	l.storeConfig(c)
 }
 
 // SetFlags sets extra flags for logging output features.
 func (l *Logger) SetFlags(flags int) {
-	l.config.Flags = flags
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.Flags = flags
+	l.storeConfig(c)
 }
 
 // GetFlags returns the flags of logger.
 func (l *Logger) GetFlags() int {
-	return l.config.Flags
+	return l.loadConfig().Flags
 }
 
 // SetStack enables/disables the stack feature in failure logging outputs.
 func (l *Logger) SetStack(enabled bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
 	if enabled {
-		l.config.StStatus = 1
+		c.StStatus = 1
 	} else {
-		l.config.StStatus = 0
+		c.StStatus = 0
 	}
+	l.storeConfig(c)
 }
 
 // SetStackSkip sets the stack offset from the end point.
 func (l *Logger) SetStackSkip(skip int) {
-	l.config.StSkip = skip
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.StSkip = skip
+	l.storeConfig(c)
 }
 
 // SetStackFilter sets the stack filter from the end point.
 func (l *Logger) SetStackFilter(filter string) {
-	l.config.StFilter = filter
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.StFilter = filter
+	l.storeConfig(c)
 }
 
 // SetCtxKeys sets the context keys for logger. The keys is used for retrieving values
@@ -184,30 +211,38 @@ func (l *Logger) SetStackFilter(filter string) {
 //
 // Note that multiple calls of this function will overwrite the previous set context keys.
 func (l *Logger) SetCtxKeys(keys ...any) {
-	l.config.CtxKeys = keys
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.CtxKeys = keys
+	l.storeConfig(c)
 }
 
 // AppendCtxKeys appends extra keys to logger.
 // It ignores the key if it is already appended to the logger previously.
 func (l *Logger) AppendCtxKeys(keys ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
 	var isExist bool
 	for _, key := range keys {
 		isExist = false
-		for _, ctxKey := range l.config.CtxKeys {
+		for _, ctxKey := range c.CtxKeys {
 			if ctxKey == key {
 				isExist = true
 				break
 			}
 		}
 		if !isExist {
-			l.config.CtxKeys = append(l.config.CtxKeys, key)
+			c.CtxKeys = append(c.CtxKeys, key)
 		}
 	}
+	l.storeConfig(c)
 }
 
 // GetCtxKeys retrieves and returns the context keys for logging.
 func (l *Logger) GetCtxKeys() []any {
-	return l.config.CtxKeys
+	return l.loadConfig().CtxKeys
 }
 
 // SetWriter sets the customized logging `writer` for logging.
@@ -215,13 +250,17 @@ func (l *Logger) GetCtxKeys() []any {
 // Developer can use customized logging `writer` to redirect logging output to another service,
 // eg: kafka, mysql, mongodb, etc.
 func (l *Logger) SetWriter(writer io.Writer) {
-	l.config.Writer = writer
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.Writer = writer
+	l.storeConfig(c)
 }
 
 // GetWriter returns the customized writer object, which implements the io.Writer interface.
 // It returns nil if no writer previously set.
 func (l *Logger) GetWriter() io.Writer {
-	return l.config.Writer
+	return l.loadConfig().Writer
 }
 
 // SetPath sets the directory path for file logging.
@@ -234,60 +273,100 @@ func (l *Logger) SetPath(path string) error {
 			return gerror.Wrapf(err, `Mkdir "%s" failed in PWD "%s"`, path, gfile.Pwd())
 		}
 	}
-	l.config.Path = strings.TrimRight(path, gfile.Separator)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.Path = strings.TrimRight(path, gfile.Separator)
+	l.storeConfig(c)
 	return nil
 }
 
 // GetPath returns the logging directory path for file logging.
 // It returns empty string if no directory path set.
 func (l *Logger) GetPath() string {
-	return l.config.Path
+	return l.loadConfig().Path
 }
 
 // SetFile sets the file name `pattern` for file logging.
 // Datetime pattern can be used in `pattern`, eg: access-{Ymd}.log.
 // The default file name pattern is: Y-m-d.log, eg: 2018-01-01.log
 func (l *Logger) SetFile(pattern string) {
-	l.config.File = pattern
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.File = pattern
+	l.storeConfig(c)
 }
 
 // SetTimeFormat sets the time format for the logging time.
 func (l *Logger) SetTimeFormat(timeFormat string) {
-	l.config.TimeFormat = timeFormat
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.TimeFormat = timeFormat
+	l.storeConfig(c)
 }
 
 // SetStdoutPrint sets whether output the logging contents to stdout, which is true in default.
 func (l *Logger) SetStdoutPrint(enabled bool) {
-	l.config.StdoutPrint = enabled
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.StdoutPrint = enabled
+	l.storeConfig(c)
 }
 
 // SetHeaderPrint sets whether output header of the logging contents, which is true in default.
 func (l *Logger) SetHeaderPrint(enabled bool) {
-	l.config.HeaderPrint = enabled
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.HeaderPrint = enabled
+	l.storeConfig(c)
 }
 
 // SetLevelPrint sets whether output level string of the logging contents, which is true in default.
 func (l *Logger) SetLevelPrint(enabled bool) {
-	l.config.LevelPrint = enabled
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.LevelPrint = enabled
+	l.storeConfig(c)
 }
 
 // SetPrefix sets prefix string for every logging content.
 // Prefix is part of header, which means if header output is shut, no prefix will be output.
 func (l *Logger) SetPrefix(prefix string) {
-	l.config.Prefix = prefix
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.Prefix = prefix
+	l.storeConfig(c)
 }
 
 // SetHandlers sets the logging handlers for current logger.
 func (l *Logger) SetHandlers(handlers ...Handler) {
-	l.config.Handlers = handlers
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.Handlers = handlers
+	l.storeConfig(c)
 }
 
 // SetWriterColorEnable enables file/writer logging with color.
 func (l *Logger) SetWriterColorEnable(enabled bool) {
-	l.config.WriterColorEnable = enabled
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.WriterColorEnable = enabled
+	l.storeConfig(c)
 }
 
 // SetStdoutColorDisabled disables stdout logging with color.
 func (l *Logger) SetStdoutColorDisabled(disabled bool) {
-	l.config.StdoutColorDisabled = disabled
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.StdoutColorDisabled = disabled
+	l.storeConfig(c)
 }

--- a/os/glog/glog_logger_handler.go
+++ b/os/glog/glog_logger_handler.go
@@ -157,11 +157,11 @@ func (in *HandlerInput) ValuesContent() string {
 
 func (in *HandlerInput) getDefaultBuffer(withColor bool) *bytes.Buffer {
 	buffer := bytes.NewBuffer(nil)
-	if in.Logger.config.HeaderPrint {
+	if in.Logger.loadConfig().HeaderPrint {
 		if in.TimeFormat != "" {
 			buffer.WriteString(in.TimeFormat)
 		}
-		if in.Logger.config.LevelPrint && in.LevelFormat != "" {
+		if in.Logger.loadConfig().LevelPrint && in.LevelFormat != "" {
 			var levelStr = "[" + in.LevelFormat + "]"
 			if withColor {
 				in.addStringToBuffer(buffer, in.Logger.getColoredStr(
@@ -178,7 +178,7 @@ func (in *HandlerInput) getDefaultBuffer(withColor bool) *bytes.Buffer {
 	if in.CtxStr != "" {
 		in.addStringToBuffer(buffer, "{"+in.CtxStr+"}")
 	}
-	if in.Logger.config.HeaderPrint {
+	if in.Logger.loadConfig().HeaderPrint {
 		if in.Prefix != "" {
 			in.addStringToBuffer(buffer, in.Prefix)
 		}

--- a/os/glog/glog_logger_level.go
+++ b/os/glog/glog_logger_level.go
@@ -66,45 +66,75 @@ var levelStringMap = map[string]int{
 // Note that levels ` LEVEL_CRIT | LEVEL_PANI | LEVEL_FATA ` cannot be removed for logging content,
 // which are automatically added to levels.
 func (l *Logger) SetLevel(level int) {
-	l.config.Level = level | LEVEL_CRIT | LEVEL_PANI | LEVEL_FATA
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	c.Level = level | LEVEL_CRIT | LEVEL_PANI | LEVEL_FATA
+	l.storeConfig(c)
 }
 
 // GetLevel returns the logging level value.
 func (l *Logger) GetLevel() int {
-	return l.config.Level
+	return l.loadConfig().Level
 }
 
 // SetLevelStr sets the logging level by level string.
 func (l *Logger) SetLevelStr(levelStr string) error {
 	if level, ok := levelStringMap[strings.ToUpper(levelStr)]; ok {
-		l.config.Level = level
-	} else {
-		return gerror.NewCodef(gcode.CodeInvalidParameter, `invalid level string: %s`, levelStr)
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		c := l.loadConfig()
+		c.Level = level
+		l.storeConfig(c)
+		return nil
 	}
-	return nil
+	return gerror.NewCodef(gcode.CodeInvalidParameter, `invalid level string: %s`, levelStr)
 }
 
 // SetLevelPrefix sets the prefix string for specified level.
 func (l *Logger) SetLevelPrefix(level int, prefix string) {
-	l.config.LevelPrefixes[level] = prefix
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	if c.LevelPrefixes == nil {
+		c.LevelPrefixes = make(map[int]string)
+	} else {
+		// copy to avoid racing with concurrent readers holding old Config
+		n := make(map[int]string, len(c.LevelPrefixes)+1)
+		for k, v := range c.LevelPrefixes {
+			n[k] = v
+		}
+		c.LevelPrefixes = n
+	}
+	c.LevelPrefixes[level] = prefix
+	l.storeConfig(c)
 }
 
 // SetLevelPrefixes sets the level to prefix string mapping for the logger.
 func (l *Logger) SetLevelPrefixes(prefixes map[int]string) {
-	for k, v := range prefixes {
-		l.config.LevelPrefixes[k] = v
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	c := l.loadConfig()
+	n := make(map[int]string, len(c.LevelPrefixes)+len(prefixes))
+	for k, v := range c.LevelPrefixes {
+		n[k] = v
 	}
+	for k, v := range prefixes {
+		n[k] = v
+	}
+	c.LevelPrefixes = n
+	l.storeConfig(c)
 }
 
 // GetLevelPrefix returns the prefix string for specified level.
 func (l *Logger) GetLevelPrefix(level int) string {
-	return l.config.LevelPrefixes[level]
+	return l.loadConfig().LevelPrefixes[level]
 }
 
 // getLevelPrefixWithBrackets returns the prefix string with brackets for specified level.
 func (l *Logger) getLevelPrefixWithBrackets(level int) string {
 	levelStr := ""
-	if s, ok := l.config.LevelPrefixes[level]; ok {
+	if s, ok := l.loadConfig().LevelPrefixes[level]; ok {
 		levelStr = "[" + s + "]"
 	}
 	return levelStr

--- a/os/glog/glog_logger_rotate.go
+++ b/os/glog/glog_logger_rotate.go
@@ -29,7 +29,7 @@ const (
 // rotateFileBySize rotates the current logging file according to the
 // configured rotation size.
 func (l *Logger) rotateFileBySize(ctx context.Context, now time.Time) {
-	if l.config.RotateSize <= 0 {
+	if l.loadConfig().RotateSize <= 0 {
 		return
 	}
 	if err := l.doRotateFile(ctx, l.getFilePath(now)); err != nil {
@@ -54,14 +54,14 @@ func (l *Logger) doRotateFile(ctx context.Context, filePath string) error {
 	})
 
 	// No backups, it then just removes the current logging file.
-	if l.config.RotateBackupLimit == 0 {
+	if l.loadConfig().RotateBackupLimit == 0 {
 		if err := gfile.RemoveFile(filePath); err != nil {
 			return err
 		}
 		intlog.Printf(
 			ctx,
 			`%d size exceeds, no backups set, remove original logging file: %s`,
-			l.config.RotateSize, filePath,
+			l.loadConfig().RotateSize, filePath,
 		)
 		return nil
 	}
@@ -109,20 +109,20 @@ func (l *Logger) doRotateFile(ctx context.Context, filePath string) error {
 
 // rotateChecksTimely timely checks the backups expiration and the compression.
 func (l *Logger) rotateChecksTimely(ctx context.Context) {
-	defer gtimer.AddOnce(ctx, l.config.RotateCheckInterval, l.rotateChecksTimely)
+	defer gtimer.AddOnce(ctx, l.loadConfig().RotateCheckInterval, l.rotateChecksTimely)
 
 	// Checks whether file rotation not enabled.
-	if l.config.RotateSize <= 0 && l.config.RotateExpire == 0 {
+	if l.loadConfig().RotateSize <= 0 && l.loadConfig().RotateExpire == 0 {
 		intlog.Printf(
 			ctx,
 			"logging rotation ignore checks: RotateSize: %d, RotateExpire: %s",
-			l.config.RotateSize, l.config.RotateExpire.String(),
+			l.loadConfig().RotateSize, l.loadConfig().RotateExpire.String(),
 		)
 		return
 	}
 
 	// It here uses memory lock to guarantee the concurrent safety.
-	memoryLockKey := memoryLockPrefixForRotating + l.config.Path
+	memoryLockKey := memoryLockPrefixForRotating + l.loadConfig().Path
 	if !gmlock.TryLock(memoryLockKey) {
 		return
 	}
@@ -131,7 +131,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 	var (
 		now        = time.Now()
 		pattern    = "*.log, *.gz"
-		files, err = gfile.ScanDirFile(l.config.Path, pattern, true)
+		files, err = gfile.ScanDirFile(l.loadConfig().Path, pattern, true)
 	)
 	if err != nil {
 		intlog.Errorf(ctx, `%+v`, err)
@@ -139,13 +139,13 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 	intlog.Printf(ctx, "logging rotation start checks: %+v", files)
 	// get file name regex pattern
 	// access-{y-m-d}-test.log => access-$-test.log => access-\$-test\.log => access-(.+?)-test\.log
-	fileNameRegexPattern, _ := gregex.ReplaceString(`{.+?}`, "$", l.config.File)
+	fileNameRegexPattern, _ := gregex.ReplaceString(`{.+?}`, "$", l.loadConfig().File)
 	fileNameRegexPattern = gregex.Quote(fileNameRegexPattern)
 	fileNameRegexPattern = strings.ReplaceAll(fileNameRegexPattern, "\\$", "(.+?)")
 	// =============================================================
 	// Rotation of expired file checks.
 	// =============================================================
-	if l.config.RotateExpire > 0 {
+	if l.loadConfig().RotateExpire > 0 {
 		var (
 			mtime         time.Time
 			subDuration   time.Duration
@@ -162,7 +162,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 			}
 			mtime = gfile.MTime(file)
 			subDuration = now.Sub(mtime)
-			if subDuration > l.config.RotateExpire {
+			if subDuration > l.loadConfig().RotateExpire {
 				func() {
 					memoryLockFileKey := memoryLockPrefixForPrintingToFile + file
 					if !gmlock.TryLock(memoryLockFileKey) {
@@ -173,7 +173,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 					intlog.Printf(
 						ctx,
 						`%v - %v = %v > %v, rotation expire logging file: %s`,
-						now, mtime, subDuration, l.config.RotateExpire, file,
+						now, mtime, subDuration, l.loadConfig().RotateExpire, file,
 					)
 					if err = l.doRotateFile(ctx, file); err != nil {
 						intlog.Errorf(ctx, `%+v`, err)
@@ -183,7 +183,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 		}
 		if expireRotated {
 			// Update the files array.
-			files, err = gfile.ScanDirFile(l.config.Path, pattern, true)
+			files, err = gfile.ScanDirFile(l.loadConfig().Path, pattern, true)
 			if err != nil {
 				intlog.Errorf(ctx, `%+v`, err)
 			}
@@ -194,7 +194,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 	// Rotated file compression.
 	// =============================================================
 	needCompressFileArray := garray.NewStrArray()
-	if l.config.RotateBackupCompress > 0 {
+	if l.loadConfig().RotateBackupCompress > 0 {
 		for _, file := range files {
 			// Eg: access.20200326101301899002.log.gz
 			if gfile.ExtName(file) == "gz" {
@@ -225,7 +225,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 				return true
 			})
 			// Update the files array.
-			files, err = gfile.ScanDirFile(l.config.Path, pattern, true)
+			files, err = gfile.ScanDirFile(l.loadConfig().Path, pattern, true)
 			if err != nil {
 				intlog.Errorf(ctx, `%+v`, err)
 			}
@@ -248,7 +248,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 		}
 		return 1
 	})
-	if l.config.RotateBackupLimit > 0 || l.config.RotateBackupExpire > 0 {
+	if l.loadConfig().RotateBackupLimit > 0 || l.loadConfig().RotateBackupExpire > 0 {
 		for _, file := range files {
 			// ignore not matching file
 			originalLoggingFilePath, _ := gregex.ReplaceString(`\.\d{20}`, "", file)
@@ -260,7 +260,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 			}
 		}
 		intlog.Printf(ctx, `calculated backup files array: %+v`, backupFiles)
-		diff := backupFiles.Len() - l.config.RotateBackupLimit
+		diff := backupFiles.Len() - l.loadConfig().RotateBackupLimit
 		for i := 0; i < diff; i++ {
 			path, _ := backupFiles.PopLeft()
 			intlog.Printf(ctx, `remove exceeded backup limit file: %s`, path)
@@ -269,7 +269,7 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 			}
 		}
 		// Backups expiration checking.
-		if l.config.RotateBackupExpire > 0 {
+		if l.loadConfig().RotateBackupExpire > 0 {
 			var (
 				mtime       time.Time
 				subDuration time.Duration
@@ -278,11 +278,11 @@ func (l *Logger) rotateChecksTimely(ctx context.Context) {
 				path := v.(string)
 				mtime = gfile.MTime(path)
 				subDuration = now.Sub(mtime)
-				if subDuration > l.config.RotateBackupExpire {
+				if subDuration > l.loadConfig().RotateBackupExpire {
 					intlog.Printf(
 						ctx,
 						`%v - %v = %v > %v, remove expired backup file: %s`,
-						now, mtime, subDuration, l.config.RotateBackupExpire, path,
+						now, mtime, subDuration, l.loadConfig().RotateBackupExpire, path,
 					)
 					if err = gfile.RemoveFile(path); err != nil {
 						intlog.Errorf(ctx, `%+v`, err)

--- a/os/glog/glog_z_unit_config_test.go
+++ b/os/glog/glog_z_unit_config_test.go
@@ -25,9 +25,9 @@ func Test_SetConfigWithMap(t *testing.T) {
 		}
 		err := l.SetConfigWithMap(m)
 		t.AssertNil(err)
-		t.Assert(l.config.Path, m["path"])
-		t.Assert(l.config.Level, LEVEL_ALL)
-		t.Assert(l.config.StdoutPrint, m["stdout"])
+		t.Assert(l.GetConfig().Path, m["path"])
+		t.Assert(l.GetConfig().Level, LEVEL_ALL)
+		t.Assert(l.GetConfig().StdoutPrint, m["stdout"])
 	})
 }
 

--- a/os/glog/glog_z_unit_test.go
+++ b/os/glog/glog_z_unit_test.go
@@ -487,3 +487,34 @@ func Test_Concurrent(t *testing.T) {
 		t.Assert(gstr.Count(content, s), c)
 	})
 }
+
+// Test_SetConfigConcurrentWithInfo ensures SetConfig does not race with Info (#4795).
+func Test_SetConfigConcurrentWithInfo(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		l := glog.New()
+		ctx := context.Background()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		stop := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					l.Info(ctx, "hello")
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			cfg := l.GetConfig()
+			for i := 0; i < 500; i++ {
+				_ = l.SetConfig(cfg)
+			}
+			close(stop)
+		}()
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
Fixes #4795

`Logger.config` was a plain field; `SetConfig`/`SetLevel`/… wrote it while `Info`/`Print` read it, which `-race` reliably flags.

Changes:
- store `Config` in `atomic.Value` (`loadConfig` / `storeConfig`)
- mutex around read-modify-write setters
- copy `LevelPrefixes` on write so maps are not shared across snapshots
- `Clone` snapshots via `loadConfig`
- regression test `Test_SetConfigConcurrentWithInfo` (run with `-race`)

```
go test ./os/glog/ -race -run Test_SetConfigConcurrentWithInfo
go test ./os/glog/ -race
```