### PR TITLE
fix(os/gsession): serialize session file IO under per-id lock

### DIFF
--- a/os/gsession/gsession_storage_file.go
+++ b/os/gsession/gsession_storage_file.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/gogf/gf/v2/container/gmap"
@@ -33,6 +34,9 @@ type StorageFile struct {
 	cryptoKey     []byte        // Used when enable crypto feature.
 	cryptoEnabled bool          // Used when enable crypto feature.
 	updatingIdSet *gset.StrSet  // To be batched updated session id set.
+	// sessionMu holds per-sessionId *sync.RWMutex so concurrent GetSession/SetSession
+	// on the same id never observe a truncated file mid-write (see #4792).
+	sessionMu sync.Map
 }
 
 const (
@@ -126,8 +130,17 @@ func (s *StorageFile) sessionFilePath(sessionId string) string {
 	return gfile.Join(s.path, sessionId) + ".session"
 }
 
+// sessionLock returns the per-session RWMutex used to serialize file IO.
+func (s *StorageFile) sessionLock(sessionId string) *sync.RWMutex {
+	v, _ := s.sessionMu.LoadOrStore(sessionId, &sync.RWMutex{})
+	return v.(*sync.RWMutex)
+}
+
 // RemoveAll deletes all key-value pairs from storage.
 func (s *StorageFile) RemoveAll(ctx context.Context, sessionId string) error {
+	mu := s.sessionLock(sessionId)
+	mu.Lock()
+	defer mu.Unlock()
 	return gfile.RemoveAll(s.sessionFilePath(sessionId))
 }
 
@@ -139,6 +152,10 @@ func (s *StorageFile) RemoveAll(ctx context.Context, sessionId string) error {
 //
 // This function is called ever when session starts.
 func (s *StorageFile) GetSession(ctx context.Context, sessionId string, ttl time.Duration) (sessionData *gmap.StrAnyMap, err error) {
+	mu := s.sessionLock(sessionId)
+	mu.RLock()
+	defer mu.RUnlock()
+
 	var (
 		path    = s.sessionFilePath(sessionId)
 		content = gfile.GetBytes(path)
@@ -172,9 +189,11 @@ func (s *StorageFile) GetSession(ctx context.Context, sessionId string, ttl time
 // SetSession updates the data map for specified session id.
 // This function is called ever after session, which is changed dirty, is closed.
 // This copy all session data map from memory to storage.
+//
+// Per-session lock serializes Get/Set so concurrent GetSession never observes a
+// truncated file between O_TRUNC and the following writes (see #4792).
 func (s *StorageFile) SetSession(ctx context.Context, sessionId string, sessionData *gmap.StrAnyMap, ttl time.Duration) error {
 	intlog.Printf(ctx, "StorageFile.SetSession: %s, %v, %v", sessionId, sessionData, ttl)
-	path := s.sessionFilePath(sessionId)
 	content, err := json.Marshal(sessionData)
 	if err != nil {
 		return err
@@ -186,6 +205,12 @@ func (s *StorageFile) SetSession(ctx context.Context, sessionId string, sessionD
 			return err
 		}
 	}
+
+	mu := s.sessionLock(sessionId)
+	mu.Lock()
+	defer mu.Unlock()
+
+	path := s.sessionFilePath(sessionId)
 	file, err := gfile.OpenWithFlagPerm(
 		path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm,
 	)
@@ -193,13 +218,12 @@ func (s *StorageFile) SetSession(ctx context.Context, sessionId string, sessionD
 		return err
 	}
 	defer file.Close()
+	// Same two writes as before; lock above is what makes them race-free for readers.
 	if _, err = file.Write(gbinary.EncodeInt64(gtime.TimestampMilli())); err != nil {
-		err = gerror.Wrapf(err, `write data failed to file "%s"`, path)
-		return err
+		return gerror.Wrapf(err, `write data failed to file "%s"`, path)
 	}
 	if _, err = file.Write(content); err != nil {
-		err = gerror.Wrapf(err, `write data failed to file "%s"`, path)
-		return err
+		return gerror.Wrapf(err, `write data failed to file "%s"`, path)
 	}
 	return nil
 }

--- a/os/gsession/gsession_z_unit_storage_file_test.go
+++ b/os/gsession/gsession_z_unit_storage_file_test.go
@@ -8,12 +8,17 @@ package gsession_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gogf/gf/v2/container/gmap"
 	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gfile"
 	"github.com/gogf/gf/v2/os/gsession"
 	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/guid"
 )
 
 func Test_StorageFile(t *testing.T) {
@@ -78,5 +83,70 @@ func Test_StorageFile(t *testing.T) {
 		t.Assert(s.MustSize(), 0)
 		t.Assert(s.MustGet("k5"), nil)
 		t.Assert(s.MustGet("k6"), nil)
+	})
+}
+
+// Test_StorageFile_SetSessionAtomic covers #4792: concurrent GetSession must not
+// observe a truncated file while SetSession is rewriting the same session id.
+func Test_StorageFile_SetSessionAtomic(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		dir := gfile.Temp(guid.S())
+		t.AssertNil(gfile.Mkdir(dir))
+		storage := gsession.NewStorageFile(dir, time.Minute)
+		ctx := context.TODO()
+		sessionId := "sid-atomic-" + guid.S()
+		data := gmap.NewStrAnyMapFrom(g.Map{"userId": 1, "name": "u"}, true)
+
+		// seed once
+		t.AssertNil(storage.SetSession(ctx, sessionId, data, time.Minute))
+
+		var wg sync.WaitGroup
+		errCh := make(chan error, 64)
+		// writers
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 50; j++ {
+					d := gmap.NewStrAnyMapFrom(g.Map{"userId": 1, "n": j}, true)
+					if err := storage.SetSession(ctx, sessionId, d, time.Minute); err != nil {
+						errCh <- err
+						return
+					}
+				}
+			}()
+		}
+		// readers — must never see "missing" session while writes are in flight
+		// after the seed (len(content)>8).
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 80; j++ {
+					got, err := storage.GetSession(ctx, sessionId, time.Minute)
+					if err != nil {
+						errCh <- err
+						return
+					}
+					if got == nil {
+						errCh <- fmt.Errorf("GetSession returned nil under concurrent SetSession")
+						return
+					}
+					if got.Get("userId") == nil {
+						errCh <- fmt.Errorf("session missing userId")
+						return
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			t.AssertNil(err)
+		}
+		// final read
+		got, err := storage.GetSession(ctx, sessionId, time.Minute)
+		t.AssertNil(err)
+		t.AssertNE(got, nil)
 	})
 }


### PR DESCRIPTION
Fixes concurrent file-session corruption when `GetSession` races `SetSession` on the same id (#4792).

`StorageFile.SetSession` opens with `O_TRUNC` then writes the 8-byte timestamp and JSON body. Without synchronization a concurrent `GetSession` can read a truncated file (`len <= 8`) and treat the session as missing.

Fix: per-`sessionId` `sync.RWMutex` around Get/Set/Remove file IO. Write path stays the same shape as master (no temp+rename / no large buffer alloc — those tripped CodeQL).

```
go test ./os/gsession/ -run StorageFile -count=1
```