### PR TITLE
fix(database/gdb): Result.Structs fill []map destinations

### DIFF
--- a/database/gdb/gdb_type_result.go
+++ b/database/gdb/gdb_type_result.go
@@ -9,6 +9,7 @@ package gdb
 import (
 	"database/sql"
 	"math"
+	"reflect"
 
 	"github.com/gogf/gf/v2/container/gvar"
 	"github.com/gogf/gf/v2/encoding/gjson"
@@ -192,6 +193,7 @@ func (r Result) RecordKeyUint(key string) map[uint]Record {
 
 // Structs converts `r` to struct slice.
 // Note that the parameter `pointer` should be type of *[]struct/*[]*struct.
+// It also supports *[]map[string]any / *[]map[string]interface{} (see #4787).
 func (r Result) Structs(pointer any) (err error) {
 	// If the result is empty and the target pointer is not empty, it returns error.
 	if r.IsEmpty() {
@@ -199,6 +201,11 @@ func (r Result) Structs(pointer any) (err error) {
 			return sql.ErrNoRows
 		}
 		return nil
+	}
+	// converter.Structs treats each map row as a struct and leaves []map destinations empty.
+	// Use List()+Scan for map slices so keys/values are preserved.
+	if isMapStringAnySlicePointer(pointer) {
+		return gconv.Scan(r.List(), pointer)
 	}
 	var (
 		sliceOption  = gconv.SliceOption{ContinueOnError: true}
@@ -211,4 +218,21 @@ func (r Result) Structs(pointer any) (err error) {
 		SliceOption:  sliceOption,
 		StructOption: structOption,
 	})
+}
+
+// isMapStringAnySlicePointer reports whether pointer is *[]map[string]T where T is interface{}/any.
+func isMapStringAnySlicePointer(pointer any) bool {
+	rv := reflect.ValueOf(pointer)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return false
+	}
+	sliceType := rv.Type().Elem()
+	if sliceType.Kind() != reflect.Slice {
+		return false
+	}
+	elem := sliceType.Elem()
+	if elem.Kind() != reflect.Map {
+		return false
+	}
+	return elem.Key().Kind() == reflect.String && elem.Elem().Kind() == reflect.Interface
 }

--- a/database/gdb/gdb_z_unit_result_structs_map_test.go
+++ b/database/gdb/gdb_z_unit_result_structs_map_test.go
@@ -1,0 +1,39 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gdb_test
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_Result_Structs_MapSlice covers #4787.
+func Test_Result_Structs_MapSlice(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		res := gdb.Result{
+			gdb.Record{"regionId": gvar.New(1)},
+			gdb.Record{"regionId": gvar.New(2)},
+			gdb.Record{"regionId": gvar.New(3)},
+		}
+		var rows []map[string]interface{}
+		err := res.Structs(&rows)
+		t.AssertNil(err)
+		t.Assert(len(rows), 3)
+		t.Assert(rows[0]["regionId"], 1)
+		t.Assert(rows[1]["regionId"], 2)
+		t.Assert(rows[2]["regionId"], 3)
+
+		var rowsAny []map[string]any
+		err = res.Structs(&rowsAny)
+		t.AssertNil(err)
+		t.Assert(len(rowsAny), 3)
+		t.Assert(rowsAny[0]["regionId"], 1)
+	})
+}


### PR DESCRIPTION
Fixes #4787

`Result.Structs(&[]map[string]interface{})` returned the right length but every map was empty (no error). `gconv.Scan` / `List()` already worked.

When the destination is a `*[]map[string]…` (interface values), convert via `gconv.Scan(r.List(), pointer)` instead of `converter.Structs`.

Test: `Test_Result_Structs_MapSlice`

```
go test ./database/gdb/ -run Test_Result_Structs_MapSlice
```