### PR TITLE
fix(util/gconv): convert []uuid.UUID without IsNil panic on array

### DIFF
--- a/util/gconv/gconv_z_unit_issue_4786_test.go
+++ b/util/gconv/gconv_z_unit_issue_4786_test.go
@@ -1,0 +1,90 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gconv_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/gconv"
+)
+
+// textArray mimics types like uuid.UUID ([16]byte with UnmarshalText).
+type textArray [4]byte
+
+func (a *textArray) UnmarshalText(text []byte) error {
+	for i := 0; i < len(a) && i < len(text); i++ {
+		a[i] = text[i]
+	}
+	return nil
+}
+
+func Test_Issue4786_SliceOfArrayWithUnmarshalText(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Req struct {
+			IDs []textArray `json:"ids"`
+		}
+		var r Req
+		err := gconv.Struct(map[string]any{
+			"ids": []any{"abcd", "wxyz"},
+		}, &r)
+		t.AssertNil(err)
+		t.Assert(len(r.IDs), 2)
+		t.Assert(string(r.IDs[0][:]), "abcd")
+		t.Assert(string(r.IDs[1][:]), "wxyz")
+	})
+}
+
+func Test_Issue4786_SliceOfUUID(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Req struct {
+			IDs []uuid.UUID `json:"ids"`
+		}
+		id1 := "550e8400-e29b-41d4-a716-446655440000"
+		id2 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+		var r Req
+		err := gconv.Struct(map[string]any{
+			"ids": []any{id1, id2},
+		}, &r)
+		t.AssertNil(err)
+		t.Assert(len(r.IDs), 2)
+		t.Assert(r.IDs[0].String(), id1)
+		t.Assert(r.IDs[1].String(), id2)
+	})
+}
+
+func Test_Issue4786_PointerSliceOfUUID(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Req struct {
+			IDs []*uuid.UUID `json:"ids"`
+		}
+		id1 := "550e8400-e29b-41d4-a716-446655440000"
+		var r Req
+		err := gconv.Struct(map[string]any{
+			"ids": []any{id1},
+		}, &r)
+		t.AssertNil(err)
+		t.Assert(len(r.IDs), 1)
+		t.AssertNE(r.IDs[0], nil)
+		t.Assert(r.IDs[0].String(), id1)
+	})
+}
+
+func Test_Issue4786_SingleUUIDStillWorks(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Req struct {
+			ID uuid.UUID `json:"id"`
+		}
+		id1 := "550e8400-e29b-41d4-a716-446655440000"
+		var r Req
+		err := gconv.Struct(map[string]any{"id": id1}, &r)
+		t.AssertNil(err)
+		t.Assert(r.ID.String(), id1)
+	})
+}

--- a/util/gconv/internal/converter/converter_struct.go
+++ b/util/gconv/internal/converter/converter_struct.go
@@ -500,9 +500,10 @@ func (c *Converter) bindVarToReflectValue(structFieldValue reflect.Value, value 
 
 	kind := structFieldValue.Kind()
 	// Converting using `Set` interface implements, for some types.
+	// Array kinds are never nil; reflect.Value.IsNil panics on them (e.g. uuid.UUID is [16]byte).
 	switch kind {
 	case reflect.Slice, reflect.Array, reflect.Pointer, reflect.Interface:
-		if !structFieldValue.IsNil() {
+		if !utils.CanCallIsNil(structFieldValue) || !structFieldValue.IsNil() {
 			if v, ok := structFieldValue.Interface().(localinterface.ISet); ok {
 				v.Set(value)
 				return nil
@@ -525,9 +526,32 @@ func (c *Converter) bindVarToReflectValue(structFieldValue reflect.Value, value 
 			structFieldValue.Set(reflect.ValueOf(value).Convert(structFieldValue.Type()))
 		}
 
+	// Fixed-size arrays that implement UnmarshalText/JSON (e.g. uuid.UUID as [16]byte)
+	// must not go through MakeSlice — that only works for slice destinations.
+	case reflect.Array:
+		if ok, err = bindVarToReflectValueWithInterfaceCheck(structFieldValue, value); ok || err != nil {
+			return err
+		}
+		// Fallback: element-wise assign when source is a sequence of the same length.
+		reflectValue := reflect.ValueOf(value)
+		if (reflectValue.Kind() == reflect.Slice || reflectValue.Kind() == reflect.Array) &&
+			reflectValue.Len() == structFieldValue.Len() {
+			for i := 0; i < structFieldValue.Len(); i++ {
+				if err = c.bindVarToReflectValue(structFieldValue.Index(i), reflectValue.Index(i).Interface(), option); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		return gerror.NewCodef(
+			gcode.CodeInvalidParameter,
+			`cannot convert value "%v" to type "%s"`,
+			value, structFieldValue.Type().String(),
+		)
+
 	// Note that the slice element might be type of struct,
 	// so it uses Struct function doing the converting internally.
-	case reflect.Slice, reflect.Array:
+	case reflect.Slice:
 		var (
 			reflectArray  reflect.Value
 			reflectValue  = reflect.ValueOf(value)
@@ -557,15 +581,22 @@ func (c *Converter) bindVarToReflectValue(structFieldValue reflect.Value, value 
 					} else {
 						elem = reflect.New(elemType).Elem()
 					}
-					if elem.Kind() == reflect.Struct {
-						if err = c.Struct(reflectValue.Index(i).Interface(), elem, option); err == nil {
+					srcElem := reflectValue.Index(i).Interface()
+					// Array/named types with UnmarshalText (uuid.UUID) and structs first.
+					if ok, ierr := bindVarToReflectValueWithInterfaceCheck(elem, srcElem); ok {
+						if ierr != nil {
+							return ierr
+						}
+						converted = true
+					} else if elem.Kind() == reflect.Struct {
+						if err = c.Struct(srcElem, elem, option); err == nil {
 							converted = true
 						}
 					}
 					if !converted {
 						err = c.doConvertWithReflectValueSet(
 							elem, doConvertInput{
-								FromValue:  reflectValue.Index(i).Interface(),
+								FromValue:  srcElem,
 								ToTypeName: elemTypeName,
 								ReferValue: elem,
 							},
@@ -615,7 +646,12 @@ func (c *Converter) bindVarToReflectValue(structFieldValue reflect.Value, value 
 			} else {
 				elem = reflect.New(elemType).Elem()
 			}
-			if elem.Kind() == reflect.Struct {
+			if ok, ierr := bindVarToReflectValueWithInterfaceCheck(elem, value); ok {
+				if ierr != nil {
+					return ierr
+				}
+				converted = true
+			} else if elem.Kind() == reflect.Struct {
 				if err = c.Struct(value, elem, option); err == nil {
 					converted = true
 				}


### PR DESCRIPTION
Fixes #4786

`uuid.UUID` is `[16]byte`. Converting `[]uuid.UUID` hit two problems:

1. `reflect.Value.IsNil()` panics on array kinds when checking `ISet`.
2. Array destinations were handled with `reflect.MakeSlice`, which only works for slices.

Change:

- Use `utils.CanCallIsNil` before `IsNil`.
- Handle `reflect.Array` via `UnmarshalText`/`UnmarshalJSON` (same path as a single UUID field).
- Prefer interface conversion when filling slice elements.

```
go test ./util/gconv/ -run Issue4786 -count=1
```