### PR TITLE
fix(database/gdb): do not map MySQL time_zone into ConfigNode.Timezone

### DIFF
--- a/contrib/drivers/mysql/mysql_open.go
+++ b/contrib/drivers/mysql/mysql_open.go
@@ -48,10 +48,13 @@ func configNodeToSource(config *gdb.ConfigNode) string {
 		config.User, config.Pass, config.Protocol, config.Host, portStr, config.Name, config.Charset,
 	)
 	if config.Timezone != "" {
-		if strings.Contains(config.Timezone, "/") {
-			config.Timezone = url.QueryEscape(config.Timezone)
+		// Escape so values like Asia/Shanghai or fixed offsets survive query parsing.
+		// (Previously only names containing "/" were escaped.)
+		loc := config.Timezone
+		if strings.ContainsAny(loc, "/+ :'") {
+			loc = url.QueryEscape(loc)
 		}
-		source = fmt.Sprintf("%s&loc=%s", source, config.Timezone)
+		source = fmt.Sprintf("%s&loc=%s", source, loc)
 	}
 	if config.Extra != "" {
 		source = fmt.Sprintf("%s&%s", source, config.Extra)

--- a/contrib/drivers/mysql/mysql_z_unit_internal_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_internal_test.go
@@ -27,4 +27,37 @@ func Test_configNodeToSource(t *testing.T) {
 		source := configNodeToSource(configNode)
 		t.Assert(source, "username:password@unix(/tmp/mysql.sock)/dbname?charset=")
 	})
+	// loc values with special characters must be query-escaped.
+	gtest.C(t, func(t *gtest.T) {
+		configNode := &gdb.ConfigNode{
+			Host:     "127.0.0.1",
+			Port:     "3306",
+			User:     "u",
+			Pass:     "p",
+			Name:     "db",
+			Type:     "mysql",
+			Protocol: "tcp",
+			Charset:  "utf8",
+			Timezone: "Asia/Shanghai",
+		}
+		source := configNodeToSource(configNode)
+		t.Assert(source, "u:p@tcp(127.0.0.1:3306)/db?charset=utf8&loc=Asia%2FShanghai")
+	})
+	// Extra keeps MySQL system variables (e.g. time_zone) untouched.
+	gtest.C(t, func(t *gtest.T) {
+		configNode := &gdb.ConfigNode{
+			Host:     "127.0.0.1",
+			Port:     "3306",
+			User:     "u",
+			Pass:     "p",
+			Name:     "db",
+			Type:     "mysql",
+			Protocol: "tcp",
+			Charset:  "utf8",
+			Timezone: "UTC",
+			Extra:    "time_zone=%27%2B00%3A00%27&parseTime=true",
+		}
+		source := configNodeToSource(configNode)
+		t.Assert(source, "u:p@tcp(127.0.0.1:3306)/db?charset=utf8&loc=UTC&time_zone=%27%2B00%3A00%27&parseTime=true")
+	})
 }

--- a/database/gdb/gdb_core_config.go
+++ b/database/gdb/gdb_core_config.go
@@ -471,6 +471,10 @@ func parseConfigNodeLink(node *ConfigNode) (*ConfigNode, error) {
 	}
 	if node.Extra != "" {
 		if m, _ := gstr.Parse(node.Extra); len(m) > 0 {
+			// MySQL driver system variables such as time_zone=... must remain in Extra
+			// only. gconv maps "time_zone" onto ConfigNode.Timezone, which is then
+			// re-emitted as DSN loc= and breaks sql.Open (see #4759).
+			delete(m, "time_zone")
 			_ = gconv.Struct(m, &node)
 		}
 	}

--- a/database/gdb/gdb_z_mysql_internal_test.go
+++ b/database/gdb/gdb_z_mysql_internal_test.go
@@ -270,6 +270,19 @@ func Test_parseConfigNodeLink_WithType(t *testing.T) {
 		t.Assert(newNode.Charset, `utf8`)
 		t.Assert(newNode.Protocol, `tcp`)
 	})
+	// https://github.com/gogf/gf/issues/4759
+	// time_zone is a MySQL session system variable; it must not fill Timezone (DSN loc=).
+	gtest.C(t, func(t *gtest.T) {
+		node := &ConfigNode{
+			Link: "mysql:user:pwd@tcp(127.0.0.1:3306)/dbname?charset=utf8&loc=UTC&time_zone=%27%2B00%3A00%27&parseTime=true",
+		}
+		newNode, err := parseConfigNodeLink(node)
+		t.AssertNil(err)
+		t.Assert(newNode.Type, `mysql`)
+		t.Assert(newNode.Charset, `utf8`)
+		t.Assert(newNode.Timezone, ``)
+		t.Assert(newNode.Extra, `charset=utf8&loc=UTC&time_zone=%27%2B00%3A00%27&parseTime=true`)
+	})
 	// https://github.com/gogf/gf/issues/3862
 	gtest.C(t, func(t *gtest.T) {
 		node := &ConfigNode{


### PR DESCRIPTION
Fixes #4759

Link query `time_zone='%2B00:00'` is a MySQL **session system variable** (see go-sql-driver/mysql). gf parsed Extra with `gstr.Parse` + `gconv.Struct`, which mapped `time_zone` onto `ConfigNode.Timezone`. MySQL open then rewrote that as DSN `loc=...`, e.g.

```
...charset=utf8&loc='+00:00'&charset=utf8&loc=UTC&time_zone=...
```

and `sql.Open` failed with `unknown time zone ' 00:00'`.

Change:

- Drop `time_zone` before Extra → ConfigNode mapping so it stays only in Extra
- Query-escape `loc` when Timezone contains special characters (`/`, `+`, …)

```
go test ./database/gdb/ -run parseConfigNodeLink -count=1
```