### PR TITLE
fix(contrib/registry/nacos): race-free default metadata via atomic + Options

### DIFF
--- a/contrib/registry/nacos/nacos.go
+++ b/contrib/registry/nacos/nacos.go
@@ -9,6 +9,7 @@ package nacos
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/nacos-group/nacos-sdk-go/v2/clients"
 	"github.com/nacos-group/nacos-sdk-go/v2/clients/naming_client"
@@ -38,7 +39,41 @@ type Registry struct {
 	clusterName     string
 	groupName       string
 	defaultEndpoint string
-	defaultMetadata map[string]string
+	// defaultMetadata is stored as a snapshot map via atomic.Value to avoid
+	// data races when SetDefaultMetadata races with Register (see #4649).
+	defaultMetadata atomic.Value // map[string]string
+}
+
+// Option configures a Registry at construction time.
+type Option func(r *Registry)
+
+// WithClusterName sets the cluster name. Default is "DEFAULT".
+func WithClusterName(clusterName string) Option {
+	return func(r *Registry) {
+		r.clusterName = clusterName
+	}
+}
+
+// WithGroupName sets the group name. Default is "DEFAULT_GROUP".
+func WithGroupName(groupName string) Option {
+	return func(r *Registry) {
+		r.groupName = groupName
+	}
+}
+
+// WithDefaultEndpoint sets the default endpoint used on Register when non-empty.
+func WithDefaultEndpoint(endpoint string) Option {
+	return func(r *Registry) {
+		r.defaultEndpoint = endpoint
+	}
+}
+
+// WithDefaultMetadata sets default metadata merged into service metadata on Register.
+// The map is copied; later mutations of the input map do not affect the registry.
+func WithDefaultMetadata(metadata map[string]string) Option {
+	return func(r *Registry) {
+		r.storeDefaultMetadata(metadata)
+	}
 }
 
 // Config is the configuration object for nacos client.
@@ -83,7 +118,7 @@ func New(address string, opts ...constant.ClientOption) (reg *Registry) {
 }
 
 // NewWithConfig creates and returns registry with Config.
-func NewWithConfig(ctx context.Context, config Config) (reg *Registry, err error) {
+func NewWithConfig(ctx context.Context, config Config, opts ...Option) (reg *Registry, err error) {
 	// Data validation.
 	err = g.Validator().Data(config).Run(ctx)
 	if err != nil {
@@ -97,27 +132,35 @@ func NewWithConfig(ctx context.Context, config Config) (reg *Registry, err error
 	if err != nil {
 		return
 	}
-	return NewWithClient(nameingClient), nil
+	return NewWithClient(nameingClient, opts...), nil
 }
 
-// NewWithClient new the instance with INamingClient
-func NewWithClient(client naming_client.INamingClient) *Registry {
+// NewWithClient new the instance with INamingClient.
+// Prefer With* options for init-time configuration instead of Set* methods.
+func NewWithClient(client naming_client.INamingClient, opts ...Option) *Registry {
 	r := &Registry{
-		client:          client,
-		clusterName:     "DEFAULT",
-		groupName:       "DEFAULT_GROUP",
-		defaultMetadata: make(map[string]string),
+		client:      client,
+		clusterName: "DEFAULT",
+		groupName:   "DEFAULT_GROUP",
+	}
+	r.storeDefaultMetadata(nil)
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
 	}
 	return r
 }
 
-// SetClusterName can set the clusterName. The default is 'DEFAULT'
+// SetClusterName can set the clusterName. The default is 'DEFAULT'.
+// Deprecated: use WithClusterName at construction time instead.
 func (reg *Registry) SetClusterName(clusterName string) *Registry {
 	reg.clusterName = clusterName
 	return reg
 }
 
-// SetGroupName can set the groupName. The default is 'DEFAULT_GROUP'
+// SetGroupName can set the groupName. The default is 'DEFAULT_GROUP'.
+// Deprecated: use WithGroupName at construction time instead.
 func (reg *Registry) SetGroupName(groupName string) *Registry {
 	reg.groupName = groupName
 	return reg
@@ -125,6 +168,7 @@ func (reg *Registry) SetGroupName(groupName string) *Registry {
 
 // SetDefaultEndpoint sets the default endpoint for service registration.
 // It overrides the service endpoints when registering if it's not empty.
+// Deprecated: use WithDefaultEndpoint at construction time instead.
 func (reg *Registry) SetDefaultEndpoint(endpoint string) *Registry {
 	reg.defaultEndpoint = endpoint
 	return reg
@@ -132,7 +176,26 @@ func (reg *Registry) SetDefaultEndpoint(endpoint string) *Registry {
 
 // SetDefaultMetadata sets the default metadata for service registration.
 // It will be merged with service's original metadata when registering.
+// The map is copied so concurrent Register is race-free with later Sets.
+// Deprecated: use WithDefaultMetadata at construction time instead.
 func (reg *Registry) SetDefaultMetadata(metadata map[string]string) *Registry {
-	reg.defaultMetadata = metadata
+	reg.storeDefaultMetadata(metadata)
 	return reg
+}
+
+func (reg *Registry) storeDefaultMetadata(metadata map[string]string) {
+	cp := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		cp[k] = v
+	}
+	reg.defaultMetadata.Store(cp)
+}
+
+func (reg *Registry) loadDefaultMetadata() map[string]string {
+	v := reg.defaultMetadata.Load()
+	if v == nil {
+		return nil
+	}
+	m, _ := v.(map[string]string)
+	return m
 }

--- a/contrib/registry/nacos/nacos_register.go
+++ b/contrib/registry/nacos/nacos_register.go
@@ -37,8 +37,8 @@ func (reg *Registry) Register(_ context.Context, service gsvc.Service) (register
 		metadata[k] = gconv.String(v)
 	}
 
-	// Apply default metadata if configured
-	for k, v := range reg.defaultMetadata {
+	// Apply default metadata if configured (snapshot from atomic.Value).
+	for k, v := range reg.loadDefaultMetadata() {
 		metadata[k] = v
 	}
 

--- a/contrib/registry/nacos/nacos_z_unit_metadata_test.go
+++ b/contrib/registry/nacos/nacos_z_unit_metadata_test.go
@@ -1,0 +1,48 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package nacos
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_DefaultMetadata_Race covers #4649: concurrent SetDefaultMetadata and
+// reads (as Register does) must not race under -race.
+func Test_DefaultMetadata_Race(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		reg := NewWithClient(nil, WithDefaultMetadata(map[string]string{"init": "1"}))
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				reg.SetDefaultMetadata(map[string]string{"k": fmt.Sprint(i)})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				m := reg.loadDefaultMetadata()
+				_ = m["k"]
+				_ = m["init"]
+			}
+		}()
+		wg.Wait()
+
+		// Options apply at construction.
+		reg2 := NewWithClient(nil, WithClusterName("C1"), WithGroupName("G1"), WithDefaultEndpoint("1.2.3.4:80"))
+		t.Assert(reg2.clusterName, "C1")
+		t.Assert(reg2.groupName, "G1")
+		t.Assert(reg2.defaultEndpoint, "1.2.3.4:80")
+		md := reg2.loadDefaultMetadata()
+		t.Assert(len(md), 0)
+	})
+}


### PR DESCRIPTION
Fixes #4649

`SetDefaultMetadata` assigned `reg.defaultMetadata` while `Register` ranged over the same map, which fails under `-race`.

Change:

- Store metadata snapshots in `atomic.Value` (copy on write)
- Add construction Options: `WithClusterName`, `WithGroupName`, `WithDefaultEndpoint`, `WithDefaultMetadata` (same style as consul/polaris)
- Keep `Set*` methods for compatibility, marked deprecated; they also snapshot

```
cd contrib/registry/nacos && go test -race -count=1 -run DefaultMetadata .
```