### PR TITLE
fix(cmd/gf): case-insensitive typeMapping/fieldMapping for gen dao

### DIFF
--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -17,8 +17,6 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 	"golang.org/x/mod/modfile"
 
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/container/gset"
 	"github.com/gogf/gf/v2/database/gdb"
@@ -29,6 +27,9 @@ import (
 	"github.com/gogf/gf/v2/os/gview"
 	"github.com/gogf/gf/v2/text/gregex"
 	"github.com/gogf/gf/v2/text/gstr"
+
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 )
 
 type (

--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -17,6 +17,8 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 	"golang.org/x/mod/modfile"
 
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/container/gset"
 	"github.com/gogf/gf/v2/database/gdb"
@@ -27,9 +29,6 @@ import (
 	"github.com/gogf/gf/v2/os/gview"
 	"github.com/gogf/gf/v2/text/gregex"
 	"github.com/gogf/gf/v2/text/gstr"
-
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 )
 
 type (
@@ -235,6 +234,10 @@ func doGenDaoForArray(ctx context.Context, index int, in CGenDaoInput) {
 		tableNames = array.Slice()
 	}
 
+	// Normalize typeMapping keys to lower-case so config keys like "UUID" match
+	// DB field types like "uuid" (getTypeMappingInfo always looks up ToLower).
+	// See #4734.
+	in.TypeMapping = normalizeTypeMapping(in.TypeMapping)
 	// merge default typeMapping to input typeMapping.
 	if in.TypeMapping == nil {
 		in.TypeMapping = defaultTypeMapping

--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -59,6 +59,41 @@ func generateStructDefinition(ctx context.Context, in generateStructDefinitionIn
 	return buffer.String(), appendImports
 }
 
+// normalizeTypeMapping lower-cases all map keys so config like `UUID` matches
+// DB types reported as `uuid`. Later entries with the same lower key win.
+func normalizeTypeMapping(
+	in map[DBFieldTypeName]CustomAttributeType,
+) map[DBFieldTypeName]CustomAttributeType {
+	if len(in) == 0 {
+		return in
+	}
+	out := make(map[DBFieldTypeName]CustomAttributeType, len(in))
+	for key, typeMapping := range in {
+		out[strings.ToLower(key)] = typeMapping
+	}
+	return out
+}
+
+// lookupFieldMapping finds a field mapping for table.field (case-insensitive).
+func lookupFieldMapping(
+	fieldMapping map[DBTableFieldName]CustomAttributeType, table, field string,
+) (CustomAttributeType, bool) {
+	if len(fieldMapping) == 0 {
+		return CustomAttributeType{}, false
+	}
+	key := fmt.Sprintf("%s.%s", table, field)
+	if typeMapping, ok := fieldMapping[key]; ok {
+		return typeMapping, true
+	}
+	want := strings.ToLower(key)
+	for k, typeMapping := range fieldMapping {
+		if strings.ToLower(k) == want {
+			return typeMapping, true
+		}
+	}
+	return CustomAttributeType{}, false
+}
+
 func getTypeMappingInfo(
 	ctx context.Context, fieldType string, inTypeMapping map[DBFieldTypeName]CustomAttributeType,
 ) (typeNameStr, importStr string) {
@@ -144,11 +179,9 @@ func generateStructFieldDefinition(
 		newFiledName = gstr.TrimLeftStr(newFiledName, v, 1)
 	}
 
-	if in.FieldMapping != nil && len(in.FieldMapping) > 0 {
-		if typeMapping, ok := in.FieldMapping[fmt.Sprintf("%s.%s", in.TableName, newFiledName)]; ok {
-			localTypeNameStr = typeMapping.Type
-			appendImport = typeMapping.Import
-		}
+	if typeMapping, ok := lookupFieldMapping(in.FieldMapping, in.TableName, newFiledName); ok {
+		localTypeNameStr = typeMapping.Type
+		appendImport = typeMapping.Import
 	}
 
 	attrLines = []string{

--- a/cmd/gf/internal/cmd/gendao/gendao_test.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_test.go
@@ -7,11 +7,49 @@
 package gendao
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gogf/gf/v2/test/gtest"
 	"github.com/gogf/gf/v2/text/gstr"
 )
+
+// Test_Issue4734_TypeMappingUUIDCase: config keys like "UUID" must match DB type "uuid".
+func Test_Issue4734_TypeMappingUUIDCase(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		// User config often uses mixed-case keys; lookup always uses ToLower(fieldType).
+		raw := map[DBFieldTypeName]CustomAttributeType{
+			"UUID": {Type: "string"},
+		}
+		normalized := normalizeTypeMapping(raw)
+		// After normalize only "uuid" key remains.
+		t.Assert(normalized["uuid"].Type, "string")
+		_, hasUpper := normalized["UUID"]
+		t.Assert(hasUpper, false)
+
+		// Merge with defaults like doGenDaoForArray does.
+		merged := normalizeTypeMapping(map[DBFieldTypeName]CustomAttributeType{
+			"UUID": {Type: "string"},
+		})
+		for key, typeMapping := range defaultTypeMapping {
+			if _, ok := merged[key]; !ok {
+				merged[key] = typeMapping
+			}
+		}
+		// User override wins over default uuid -> uuid.UUID.
+		name, imp := getTypeMappingInfo(context.Background(), "uuid", merged)
+		t.Assert(name, "string")
+		t.Assert(imp, "")
+
+		// Field mapping is case-insensitive on table.field.
+		fm := map[DBTableFieldName]CustomAttributeType{
+			"Widget.Widget_Id": {Type: "string"},
+		}
+		got, ok := lookupFieldMapping(fm, "widget", "widget_id")
+		t.Assert(ok, true)
+		t.Assert(got.Type, "string")
+	})
+}
 
 // Test containsWildcard function.
 func Test_containsWildcard(t *testing.T) {


### PR DESCRIPTION
Fixes #4734

`gf gen dao` typeMapping lookup always uses `strings.ToLower(fieldType)` (e.g. `uuid` from PostgreSQL), but config keys were kept as written (`UUID` / `Uuid`). A config like:

```yaml
typeMapping:
  UUID:
    type: string
```

never matched, so the default mapping `uuid -> uuid.UUID` stayed in place.

Also make `fieldMapping` (`table.field`) case-insensitive so `Widget.Widget_Id` matches `widget.widget_id`.

```
cd cmd/gf && go test ./internal/cmd/gendao/ -run Issue4734 -count=1
```