### PR TITLE
fix(cmd/gf): sharding pattern ? matches digit suffixes only

### DIFF
--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -17,6 +17,8 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 	"golang.org/x/mod/modfile"
 
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/container/gset"
 	"github.com/gogf/gf/v2/database/gdb"
@@ -27,9 +29,6 @@ import (
 	"github.com/gogf/gf/v2/os/gview"
 	"github.com/gogf/gf/v2/text/gregex"
 	"github.com/gogf/gf/v2/text/gstr"
-
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 )
 
 type (
@@ -267,19 +266,11 @@ func doGenDaoForArray(ctx context.Context, index int, in CGenDaoInput) {
 		}
 		if len(sortedShardingPatterns) > 0 {
 			for _, pattern := range sortedShardingPatterns {
-				var (
-					match      []string
-					regPattern = gstr.Replace(pattern, "?", `(.+)`)
-				)
-				match, err = gregex.MatchString(regPattern, newTableName)
-				if err != nil {
-					mlog.Fatalf(`invalid sharding pattern "%s": %+v`, pattern, err)
-				}
-				if len(match) < 2 {
+				baseName, ok := matchShardingPattern(pattern, newTableName)
+				if !ok {
 					continue
 				}
-				newTableName = gstr.Replace(pattern, "?", "")
-				newTableName = gstr.Trim(newTableName, `_.-`)
+				newTableName = baseName
 				if shardingNewTableSet.Contains(newTableName) {
 					tableNames[i] = ""
 					break
@@ -431,6 +422,25 @@ func getTemplateFromPathOrDefault(filePath string, def string) string {
 		}
 	}
 	return def
+}
+
+// matchShardingPattern returns the base dao table name if tableName matches
+// sharding pattern. Pattern "?" stands for a numeric shard suffix only
+// (e.g. users_001), not arbitrary text — so pattern "a_?" matches a_1 but not
+// non-shard tables like a_b (#4659).
+func matchShardingPattern(pattern, tableName string) (baseName string, ok bool) {
+	if pattern == "" || !gstr.Contains(pattern, "?") {
+		return "", false
+	}
+	// Full-string match; "?" = one or more digits (users_001, a_1, ...).
+	regPattern := `^` + gstr.Replace(pattern, "?", `(\d+)`) + `$`
+	match, err := gregex.MatchString(regPattern, tableName)
+	if err != nil || len(match) < 2 {
+		return "", false
+	}
+	baseName = gstr.Replace(pattern, "?", "")
+	baseName = gstr.Trim(baseName, `_.-`)
+	return baseName, baseName != ""
 }
 
 // containsWildcard checks if the pattern contains wildcard characters (* or ?).

--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -17,8 +17,6 @@ import (
 	"github.com/olekukonko/tablewriter/tw"
 	"golang.org/x/mod/modfile"
 
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
-	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 	"github.com/gogf/gf/v2/container/garray"
 	"github.com/gogf/gf/v2/container/gset"
 	"github.com/gogf/gf/v2/database/gdb"
@@ -29,6 +27,9 @@ import (
 	"github.com/gogf/gf/v2/os/gview"
 	"github.com/gogf/gf/v2/text/gregex"
 	"github.com/gogf/gf/v2/text/gstr"
+
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/mlog"
+	"github.com/gogf/gf/cmd/gf/v2/internal/utility/utils"
 )
 
 type (

--- a/cmd/gf/internal/cmd/gendao/gendao_test.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_test.go
@@ -13,6 +13,38 @@ import (
 	"github.com/gogf/gf/v2/text/gstr"
 )
 
+// Test_Issue4659_ShardingDigitSuffix: non-numeric tables must not be treated as shards.
+func Test_Issue4659_ShardingDigitSuffix(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		// Pattern a_? with digit-only suffix.
+		base, ok := matchShardingPattern("a_?", "a_1")
+		t.Assert(ok, true)
+		t.Assert(base, "a")
+
+		base, ok = matchShardingPattern("a_?", "a_2")
+		t.Assert(ok, true)
+		t.Assert(base, "a")
+
+		// Letter / multi-segment tables are not shards of "a".
+		_, ok = matchShardingPattern("a_?", "a_b")
+		t.Assert(ok, false)
+		_, ok = matchShardingPattern("a_?", "a_c")
+		t.Assert(ok, false)
+		_, ok = matchShardingPattern("a_?", "a_b_1")
+		t.Assert(ok, false)
+
+		// Longer pattern still works for a_b_1.
+		base, ok = matchShardingPattern("a_b_?", "a_b_1")
+		t.Assert(ok, true)
+		t.Assert(base, "a_b")
+
+		// users_001 style multi-digit suffixes.
+		base, ok = matchShardingPattern("users_?", "users_0001")
+		t.Assert(ok, true)
+		t.Assert(base, "users")
+	})
+}
+
 // Test containsWildcard function.
 func Test_containsWildcard(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {


### PR DESCRIPTION
Fixes #4659

With `shardingPattern: ["a_?"]` and tables `a_1`, `a_2`, `a_b`, `a_c`:

- Before: `?` became `(.+)`, so **all four** collapsed to dao `a`; `a_b`/`a_c` never got their own dao.
- After: `?` is `(\d+)` (full match), so only `a_1`/`a_2` are shards of `a`; `a_b`/`a_c` generate normally.

This matches the documented intent (`users_?` → `users_001`, `users_002`).

```
cd cmd/gf && go test ./internal/cmd/gendao/ -run Issue4659 -count=1
```