### PR TITLE
fix(contrib/registry/zookeeper): multi-instance registration leaf per endpoint

### DIFF
--- a/contrib/registry/zookeeper/zookeeper_discovery.go
+++ b/contrib/registry/zookeeper/zookeeper_discovery.go
@@ -19,6 +19,9 @@ import (
 
 // Search searches and returns services with specified condition.
 func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Service, error) {
+	if in.Prefix == "" && in.Name != "" {
+		in.Prefix = gsvc.NewServiceWithName(in.Name).GetPrefix()
+	}
 	prefix := strings.Trim(strings.ReplaceAll(in.Prefix, "/", "-"), "-")
 	instances, err, _ := r.group.Do(prefix, func() (any, error) {
 		serviceNamePath := path.Join(r.opts.namespace, prefix)
@@ -65,8 +68,9 @@ func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Servic
 			"Error with group do",
 		)
 	}
-	// Service filter.
-	filteredServices := make([]gsvc.Service, 0)
+	// Filter and merge multi-instance registrations (same prefix, different endpoints).
+	mergedMap := make(map[string]*gsvc.LocalService)
+	mergedOrder := make([]string, 0)
 	for _, service := range instances.([]gsvc.Service) {
 		if in.Prefix != "" && !gstr.HasPrefix(service.GetKey(), in.Prefix) {
 			continue
@@ -84,8 +88,28 @@ func (r *Registry) Search(_ context.Context, in gsvc.SearchInput) ([]gsvc.Servic
 				continue
 			}
 		}
-		resultItem := service
-		filteredServices = append(filteredServices, resultItem)
+		servicePrefix := service.GetPrefix()
+		if merged, ok := mergedMap[servicePrefix]; ok {
+			merged.Endpoints = append(merged.Endpoints, service.GetEndpoints()...)
+			continue
+		}
+		ls := &gsvc.LocalService{
+			Name:      service.GetName(),
+			Version:   service.GetVersion(),
+			Endpoints: append(gsvc.Endpoints{}, service.GetEndpoints()...),
+			Metadata:  service.GetMetadata(),
+		}
+		if localSvc, ok := service.(*gsvc.LocalService); ok {
+			ls.Head = localSvc.Head
+			ls.Deployment = localSvc.Deployment
+			ls.Namespace = localSvc.Namespace
+		}
+		mergedMap[servicePrefix] = ls
+		mergedOrder = append(mergedOrder, servicePrefix)
+	}
+	filteredServices := make([]gsvc.Service, 0, len(mergedOrder))
+	for _, key := range mergedOrder {
+		filteredServices = append(filteredServices, mergedMap[key])
 	}
 	return filteredServices, nil
 }

--- a/contrib/registry/zookeeper/zookeeper_registrar.go
+++ b/contrib/registry/zookeeper/zookeeper_registrar.go
@@ -18,6 +18,13 @@ import (
 	"github.com/gogf/gf/v2/net/gsvc"
 )
 
+// serviceInstanceLeaf returns a unique ZooKeeper leaf name for one service instance.
+// Derived from endpoints so multiple instances of the same service name can coexist
+// under the same service prefix path (#4149 / #4717).
+func serviceInstanceLeaf(service gsvc.Service) string {
+	return strings.NewReplacer(":", "-", ",", "_").Replace(service.GetEndpoints().String())
+}
+
 // Register registers `service` to Registry.
 // Note that it returns a new Service if it changes the input Service with custom one.
 func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Service, error) {
@@ -51,7 +58,9 @@ func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Servi
 			"Error with marshal Content to Json string",
 		)
 	}
-	servicePath := path.Join(servicePrefixPath, service.GetName())
+	// Unique leaf per instance (endpoint), not per service name, so multi-instance
+	// registration does not delete the previous instance's ephemeral node.
+	servicePath := path.Join(servicePrefixPath, serviceInstanceLeaf(service))
 	if err = r.ensureName(servicePath, data, zk.FlagEphemeral); err != nil {
 		return service, gerror.Wrapf(
 			err,
@@ -67,7 +76,7 @@ func (r *Registry) Register(_ context.Context, service gsvc.Service) (gsvc.Servi
 func (r *Registry) Deregister(ctx context.Context, service gsvc.Service) error {
 	ch := make(chan error, 1)
 	prefix := strings.Trim(strings.ReplaceAll(service.GetPrefix(), "/", "-"), "-")
-	servicePath := path.Join(r.opts.namespace, prefix, service.GetName())
+	servicePath := path.Join(r.opts.namespace, prefix, serviceInstanceLeaf(service))
 	go func() {
 		err := r.conn.Delete(servicePath, -1)
 		ch <- err
@@ -93,9 +102,10 @@ func (r *Registry) ensureName(path string, data []byte, flags int32) error {
 			path,
 		)
 	}
-	// ephemeral nodes handling after restart
-	// fixes a race condition if the server crashes without using CreateProtectedEphemeralSequential()
-	if flags&zk.FlagEphemeral == zk.FlagEphemeral {
+	// Ephemeral nodes: re-create after crash/restart. Only delete when the node
+	// already exists (stat valid) — also avoids wiping a sibling instance once
+	// each instance uses a unique leaf path.
+	if exists && flags&zk.FlagEphemeral == zk.FlagEphemeral {
 		err = r.conn.Delete(path, stat.Version)
 		if err != nil && err != zk.ErrNoNode {
 			return gerror.Wrapf(err,

--- a/contrib/registry/zookeeper/zookeeper_z_unit_leaf_test.go
+++ b/contrib/registry/zookeeper/zookeeper_z_unit_leaf_test.go
@@ -1,0 +1,35 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package zookeeper
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/net/gsvc"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_serviceInstanceLeaf: unique ZK leaf from endpoints (#4717).
+func Test_serviceInstanceLeaf(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		svc := &gsvc.LocalService{
+			Name:      "hello.svc",
+			Version:   "v1.0.0",
+			Endpoints: gsvc.NewEndpoints("127.0.0.1:9000"),
+		}
+		t.Assert(serviceInstanceLeaf(svc), "127.0.0.1-9000")
+
+		svc2 := &gsvc.LocalService{
+			Name:      "hello.svc",
+			Version:   "v1.0.0",
+			Endpoints: gsvc.NewEndpoints("10.0.0.1:8080"),
+		}
+		t.Assert(serviceInstanceLeaf(svc2), "10.0.0.1-8080")
+		// Different instances of the same service get different leaves.
+		t.AssertNE(serviceInstanceLeaf(svc), serviceInstanceLeaf(svc2))
+	})
+}


### PR DESCRIPTION
Fixes #4717 (also #4149)

### Problem
Register used ZK path `.../{serviceName}` as a single ephemeral node and always deleted it before recreate. A second instance of the same service name removed the first instance's registration.

### Fix
1. Leaf path = endpoint-derived name under the service prefix (e.g. `127.0.0.1-9000`)
2. `Search` merges instances with the same service prefix into one entry with combined endpoints
3. `ensureName` only deletes ephemeral nodes when they already exist (avoid nil `stat`)

```
cd contrib/registry/zookeeper && go test -count=1 -run serviceInstanceLeaf .
```

Related prior attempt: #4718 (closed, unmerged).