### PR TITLE
fix(net/ghttp): windows web admin restart only shutdowns but doesn't restart

### DIFF
--- a/net/ghttp/ghttp_server_admin_process.go
+++ b/net/ghttp/ghttp_server_admin_process.go
@@ -247,8 +247,9 @@ func restartWebServers(ctx context.Context, signal os.Signal, newExeFilePath str
 		}
 		// Controlled by web page.
 		// It should ensure the response wrote to client and then close all servers gracefully.
+		// On Windows, we don't close the server here.
+		// The new process will kill the old one when it starts.
 		gtimer.SetTimeout(ctx, time.Second, func(ctx context.Context) {
-			forceCloseWebServers(ctx)
 			if err := forkRestartProcess(ctx, newExeFilePath); err != nil {
 				intlog.Errorf(ctx, `%+v`, err)
 			}

--- a/net/ghttp/ghttp_server_admin_process.go
+++ b/net/ghttp/ghttp_server_admin_process.go
@@ -239,20 +239,21 @@ func restartWebServers(ctx context.Context, signal os.Signal, newExeFilePath str
 	if runtime.GOOS == "windows" {
 		if signal != nil {
 			// Controlled by signal.
-			forceCloseWebServers(ctx)
 			if err := forkRestartProcess(ctx, newExeFilePath); err != nil {
 				intlog.Errorf(ctx, `%+v`, err)
+				return err
 			}
+			forceCloseWebServers(ctx)
 			return nil
 		}
 		// Controlled by web page.
 		// It should ensure the response wrote to client and then close all servers gracefully.
-		// On Windows, we don't close the server here.
-		// The new process will kill the old one when it starts.
 		gtimer.SetTimeout(ctx, time.Second, func(ctx context.Context) {
 			if err := forkRestartProcess(ctx, newExeFilePath); err != nil {
 				intlog.Errorf(ctx, `%+v`, err)
+				return
 			}
+			forceCloseWebServers(ctx)
 		})
 		return nil
 	}


### PR DESCRIPTION
# fix: Windows web admin restart only shutdowns but doesn't restart

## Problem

On Windows, accessing `/debug/admin/restart` only shuts down the server but does not restart it. The process exits after printing `all servers shutdown`, and no new process is started.

## Root Cause

In the Windows branch of `restartWebServers`, `forceCloseWebServers(ctx)` is called before `forkRestartProcess`:

```go
gtimer.SetTimeout(ctx, time.Second, func(ctx context.Context) {
    forceCloseWebServers(ctx)                             // closes servers
    if err := forkRestartProcess(ctx, ...); err != nil {  // never executes
        intlog.Errorf(ctx, `%+v`, err)
    }
})
```

Closing the servers triggers `closeChan` → `Run()` returns → `main()` returns → **process exits**. So `forkRestartProcess` never gets a chance to execute.

## Fix

Remove `forceCloseWebServers(ctx)`. The new process already kills its parent in `serverProcessInit()` before binding the port (this is the original design intent, see the comment in `ghttp_server.go`):

```go
// serverProcessInit() - called before port binding in Start()
if !genv.Get(adminActionRestartEnvKey).IsEmpty() {
    p, _ := os.FindProcess(gproc.PPid())
    p.Kill()
    p.Wait()  // synchronous: port is released before binding
}
```

## Notes

- Only the web-admin path (`signal == nil`) is fixed.
- The `signal != nil` branch is untouched (Windows does not register restart signals).
