### PR TITLE
fix(net/goai): add style=deepObject and explode=true for query params with object schema (#4784)

### DIFF
--- a/net/goai/goai_parameter_ref.go
+++ b/net/goai/goai_parameter_ref.go
@@ -77,6 +77,16 @@ func (oai *OpenApiV3) newParameterRefWithStructMethod(field gstructs.Field, path
 	}
 	parameter.Schema = schemaRef
 
+	// If the parameter is a query parameter with an object schema,
+	// set style: deepObject and explode: true per OpenAPI 3.0 specification.
+	// This ensures client generators (e.g. openapi-generator) correctly serialize
+	// nested struct query parameters as ?Param[Field]=value.
+	if parameter.In == ParameterInQuery && schemaRef.Value != nil && schemaRef.Value.Type == TypeObject {
+		parameter.Style = "deepObject"
+		var explodeTrue = true
+		parameter.Explode = &explodeTrue
+	}
+
 	// Ignore parameter.
 	if !isValidParameterName(parameter.Name) {
 		return nil, nil

--- a/net/goai/goai_parameter_ref.go
+++ b/net/goai/goai_parameter_ref.go
@@ -81,10 +81,15 @@ func (oai *OpenApiV3) newParameterRefWithStructMethod(field gstructs.Field, path
 	// set style: deepObject and explode: true per OpenAPI 3.0 specification.
 	// This ensures client generators (e.g. openapi-generator) correctly serialize
 	// nested struct query parameters as ?Param[Field]=value.
+	// Only apply defaults when the user has not explicitly set these via struct tags.
 	if parameter.In == ParameterInQuery && schemaRef.Value != nil && schemaRef.Value.Type == TypeObject {
-		parameter.Style = "deepObject"
-		var explodeTrue = true
-		parameter.Explode = &explodeTrue
+		if parameter.Style == "" {
+			parameter.Style = "deepObject"
+		}
+		if parameter.Explode == nil {
+			var explodeTrue = true
+			parameter.Explode = &explodeTrue
+		}
 	}
 
 	// Ignore parameter.

--- a/net/goai/goai_z_unit_issue_test.go
+++ b/net/goai/goai_z_unit_issue_test.go
@@ -377,6 +377,84 @@ func (Issue4247) Issue4247HasBody(ctx context.Context, req *Issue4247HasBodyReq)
 	return
 }
 
+// https://github.com/gogf/gf/issues/4784
+func Test_Issue4784(t *testing.T) {
+	type FilterOptions struct {
+		IncludeDeleted bool `json:"includeDeleted"`
+		Status         int  `json:"status"`
+	}
+	type Issue4784Req struct {
+		g.Meta  `path:"/test" method:"GET" tags:"default"`
+		Name    string        `json:"name" in:"query"`
+		Options FilterOptions `json:"options" in:"query"`
+	}
+	type Issue4784Res struct{}
+
+	f := func(ctx context.Context, req *Issue4784Req) (res *Issue4784Res, err error) {
+		return
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		oai := goai.New()
+		err := oai.Add(goai.AddInput{
+			Object: f,
+		})
+		t.AssertNil(err)
+
+		// Verify path and method exist.
+		t.AssertNE(oai.Paths["/test"].Get, nil)
+		params := oai.Paths["/test"].Get.Parameters
+		t.Assert(len(params), 2)
+
+		// First param: Name (string type) — should NOT have style/explode.
+		t.Assert(params[0].Value.Name, "name")
+		t.Assert(params[0].Value.In, goai.ParameterInQuery)
+		t.Assert(params[0].Value.Style, "")
+		t.AssertNil(params[0].Value.Explode)
+
+		// Second param: Options (object type) — should have style=deepObject and explode=true.
+		t.Assert(params[1].Value.Name, "options")
+		t.Assert(params[1].Value.In, goai.ParameterInQuery)
+		t.Assert(params[1].Value.Style, "deepObject")
+		t.Assert(params[1].Value.Explode != nil, true)
+		t.Assert(*params[1].Value.Explode, true)
+	})
+}
+
+// Test_Issue4784_Override verifies that explicit style/explode set via struct tags
+// are NOT overwritten by the deepObject default logic.
+func Test_Issue4784_Override(t *testing.T) {
+	type FilterOptions struct {
+		IncludeDeleted bool `json:"includeDeleted"`
+	}
+	type Issue4784OverrideReq struct {
+		g.Meta  `path:"/test" method:"GET" tags:"default"`
+		Options FilterOptions `json:"options" in:"query" style:"form" explode:"false"`
+	}
+	type Issue4784OverrideRes struct{}
+
+	f := func(ctx context.Context, req *Issue4784OverrideReq) (res *Issue4784OverrideRes, err error) {
+		return
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		oai := goai.New()
+		err := oai.Add(goai.AddInput{
+			Object: f,
+		})
+		t.AssertNil(err)
+
+		params := oai.Paths["/test"].Get.Parameters
+		t.Assert(len(params), 1)
+
+		// Options has explicit style=form and explode=false from struct tags — should NOT be overridden.
+		t.Assert(params[0].Value.Name, "options")
+		t.Assert(params[0].Value.Style, "form")
+		t.Assert(params[0].Value.Explode != nil, true)
+		t.Assert(*params[0].Value.Explode, false)
+	})
+}
+
 // https://github.com/gogf/gf/issues/4247
 func Test_Issue4247(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {


### PR DESCRIPTION
## Summary

When a GET/DELETE handler defines a query parameter with a nested struct type (e.g. `FilterOptions`), the generated OpenAPI spec currently omits `style` and `explode` on the parameter. This causes client generators (like openapi-generator) to default to form-style serialization (`?IncludeDeleted=true`), which GoFrame's server-side parser does not accept — the nested struct fields are silently ignored.

Per the [OpenAPI 3.0 spec on parameter serialization](https://swagger.io/docs/specification/serialization/), query parameters of object type should use `style: deepObject` and `explode: true` so that clients serialize them as `?Options[IncludeDeleted]=true`, matching GoFrame's own query string parsing.

## Changes

Modified `net/goai/goai_parameter_ref.go` — in `newParameterRefWithStructMethod`, after setting the parameter schema, check if the parameter is a query parameter with an object schema. If so, set `style: deepObject` and `explode: true`.

## Before

```json
{
  "name": "Options",
  "in": "query",
  "schema": {
    "$ref": "#/components/schemas/FilterOptions"
  }
}
```

## After

```json
{
  "name": "Options",
  "in": "query",
  "style": "deepObject",
  "explode": true,
  "schema": {
    "$ref": "#/components/schemas/FilterOptions"
  }
}
```

Fixes #4784