### PR TITLE
fix(gconv): route map-slice elements through MapToMap in Structs (#4787)

### DIFF
--- a/util/gconv/internal/converter/converter_structs.go
+++ b/util/gconv/internal/converter/converter_structs.go
@@ -115,6 +115,23 @@ func (c *Converter) Structs(params any, pointer any, option ...StructsOption) (e
 			}
 			reflectElemArray.Index(i).Set(tempReflectValue.Addr())
 		}
+	} else if itemTypeKind == reflect.Map {
+		// Map element — use MapToMap instead of Struct.
+		// Struct expects a struct type and silently produces empty maps for non-struct types.
+		for i := 0; i < len(paramsList); i++ {
+			var tempReflectValue reflect.Value
+			if i < pointerRvLength {
+				tempReflectValue = pointerRvElem.Index(i)
+			} else {
+				tempReflectValue = reflect.New(itemType).Elem()
+			}
+			if err = c.MapToMap(paramsList[i], tempReflectValue, nil, MapOption{
+				ContinueOnError: structsOption.StructOption.ContinueOnError,
+			}); err != nil {
+				return err
+			}
+			reflectElemArray.Index(i).Set(tempReflectValue)
+		}
 	} else {
 		// Struct element.
 		for i := 0; i < len(paramsList); i++ {


### PR DESCRIPTION
# Fix: `Result.Structs` / `Model.Scan` into `*[]map[string]interface{}` silently returns empty maps

## Description

When `db.Model().Scan(&rows)` or `Result.Structs(&rows)` is called with `*[]map[string]interface{}`, it returns a slice of the correct length but every element is an empty map, with **no error** returned. Switching to a typed struct slice, or using `Result.List()` / `gconv.Scan()`, works correctly.

## Root Cause

In `converter.Structs` (`converter_structs.go`), the destination element type is checked:

```go
if itemTypeKind == reflect.Pointer {
    // Pointer element — handles correctly
} else {
    // "Struct element" — taken for reflect.Map too
    ...
    c.Struct(paramsList[i], tempReflectValue, ...)  // expects a struct!
}
```

`c.Struct` calls `GetCachedStructInfo()` which returns `nil` for non-struct types (like `reflect.Map`), causing a silent no-op. The pre-allocated slice (correct length) is returned with each map left at its zero value.

By contrast, `gconv.Scan` → `converter.Scan` → `doScanForComplicatedTypes` **does** have the map-slice branch (`sliceElemKind == reflect.Map` → `MapToMaps`), which is why `gconv.Scan` and `Result.List()` work correctly.

## Fix

Added a `reflect.Map` branch in `converter.Structs` that routes map-typed elements through `c.MapToMap` instead of `c.Struct`:

```go
} else if itemTypeKind == reflect.Map {
    // Map element — use MapToMap instead of Struct.
    for i := 0; i < len(paramsList); i++ {
        ...
        c.MapToMap(paramsList[i], tempReflectValue, nil, MapOption{...})
        ...
    }
} else {
    // Struct element (unchanged)
    ...
}
```

This matches the existing behavior of `gconv.Scan`'s `doScanForComplicatedTypes` method, which already handles map-slice conversion via `MapToMaps`.

## Testing

The reproduction case from the issue now produces correct output:

```go
res := gdb.Result{
    gdb.Record{"regionId": gvar.New(1)},
    gdb.Record{"regionId": gvar.New(2)},
    gdb.Record{"regionId": gvar.New(3)},
}
var viaStructs []map[string]interface{}
_ = res.Structs(&viaStructs)
// Before: len=3, first=map[]   (empty maps, no error)
// After:  len=3, first=map[regionId:1]  (correct data)
```

Fixes #4787