### PR TITLE
fix(gdb/mysql): always URL-encode timezone value in DSN to prevent '+' from being interpreted as space (#4759) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/contrib/drivers/mysql/mysql_open.go
+++ b/contrib/drivers/mysql/mysql_open.go
@@ -10,7 +10,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/errors/gcode"
@@ -48,9 +47,7 @@ func configNodeToSource(config *gdb.ConfigNode) string {
 		config.User, config.Pass, config.Protocol, config.Host, portStr, config.Name, config.Charset,
 	)
 	if config.Timezone != "" {
-		if strings.Contains(config.Timezone, "/") {
-			config.Timezone = url.QueryEscape(config.Timezone)
-		}
+		config.Timezone = url.QueryEscape(config.Timezone)
 		source = fmt.Sprintf("%s&loc=%s", source, config.Timezone)
 	}
 	if config.Extra != "" {


### PR DESCRIPTION
fix #4759

## Problem

When setting a MySQL timezone value containing '+' (e.g., `'+00:00'`), the `configNodeToSource` function only URL-encodes the timezone if it contains '/'. The '+' character is not encoded, causing the Go MySQL driver to interpret it as a space in the query string, resulting in:

```
unknown time zone ' 00:00'
```

## Fix

Always URL-encode the timezone value with `url.QueryEscape` instead of only when it contains '/'. This ensures special characters like '+', ':', and quotes are correctly encoded.

```diff
- if strings.Contains(config.Timezone, "/") {
-     config.Timezone = url.QueryEscape(config.Timezone)
- }
+ config.Timezone = url.QueryEscape(config.Timezone)
```

## Verification

- `url.QueryEscape(UTC)` → `UTC` (no change for safe values)
- `url.QueryEscape(Asia/Shanghai)` → `Asia%2FShanghai` (same as before)
- `url.QueryEscape(+00:00)` → `%27%2B00%3A00%27` (now correctly encoded)
- The `strings` import is no longer needed and has been removed.