### PR TITLE
fix(gdb): convert nested Result/Record to standard Go types in Struct/Structs

### DIFF
--- a/database/gdb/gdb_type_record.go
+++ b/database/gdb/gdb_type_record.go
@@ -28,12 +28,27 @@ func (r Record) Xml(rootTag ...string) string {
 }
 
 // Map converts `r` to map[string]any.
+// Nested gdb.Result and gdb.Record values are recursively converted
+// to []map[string]any and map[string]any respectively.
 func (r Record) Map() Map {
 	m := make(map[string]any)
 	for k, v := range r {
-		m[k] = v.Val()
+		m[k] = convertNestedValue(v.Val())
 	}
 	return m
+}
+
+// convertNestedValue recursively converts nested gdb.Result and gdb.Record
+// values to standard Go types ([]map[string]any and map[string]any).
+func convertNestedValue(val any) any {
+	switch vt := val.(type) {
+	case Result:
+		return vt.List()
+	case Record:
+		return vt.Map()
+	default:
+		return val
+	}
 }
 
 // GMap converts `r` to a gmap.
@@ -53,7 +68,7 @@ func (r Record) Struct(pointer any) error {
 		}
 		return nil
 	}
-	return converter.Struct(r, pointer, gconv.StructOption{
+	return converter.Struct(r.Map(), pointer, gconv.StructOption{
 		PriorityTag:     OrmTagForStruct,
 		ContinueOnError: true,
 	})

--- a/database/gdb/gdb_type_result.go
+++ b/database/gdb/gdb_type_result.go
@@ -207,7 +207,7 @@ func (r Result) Structs(pointer any) (err error) {
 			ContinueOnError: true,
 		}
 	)
-	return converter.Structs(r, pointer, gconv.StructsOption{
+	return converter.Structs(r.List(), pointer, gconv.StructsOption{
 		SliceOption:  sliceOption,
 		StructOption: structOption,
 	})


### PR DESCRIPTION
Fixes #4747

## Description

When a `gdb.Record` or `gdb.Result` field contains a nested `gdb.Result` or `gdb.Record` value wrapped in `gvar.New()`, the `Struct()` and `Structs()` methods previously passed the raw `map[string]*gvar.Var` to the converter. The converter does not call `Val()` on `gvar.Var` values in the recursive conversion path, so nested `gdb.Result`/`gdb.Record` values were never converted to the target struct type.

## Changes

1. **`Record.Struct()`** — now passes `r.Map()` (with all `gvar.Var` values unwrapped via `Val()`) instead of `r` directly. This ensures the top-level `*gvar.Var` values are properly unwrapped before conversion.

2. **`Result.Structs()`** — now passes `r.List()` (with all `gvar.Var` values unwrapped via `Map()`) instead of `r` directly. Same benefit for slice-level conversion.

3. **`Record.Map()`** — now recursively converts nested `gdb.Result` and `gdb.Record` values to `[]map[string]any` and `map[string]any` respectively. This ensures that nested database result/record objects are properly handled by the generic struct conversion chain.

## Root Cause

The `gdb` converter's `doMapConvertForMapOrStructValue` function iterates over map entries and passes the raw `*gvar.Var` values to the recursive conversion. Unlike the top-level `doMapConvert` function (which checks for `IVal` interface), the recursive function does not call `Val()` on `*gvar.Var` values. This causes `*gvar.Var` to be treated as a struct with internal fields (`value`, `safe`) instead of being unwrapped to the actual underlying data.

## Verification

- All existing tests pass (`go test ./database/gdb/...`, `go test ./util/gconv/...`, `go test ./container/gvar/...`)
- Build compiles successfully
- The fix correctly handles multi-level nesting: `Record` → `Result` → `Record` → primitive values