### PR TITLE
fix(gdb): include table name in cache key with custom Name so ClearCache can find it (#4581) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/database/gdb/gdb_func.go
+++ b/database/gdb/gdb_func.go
@@ -1002,6 +1002,10 @@ func genSelectCacheKey(table, group, schema, name, sql string, args ...any) stri
 			schema,
 			ghash.BKDR64([]byte(sql+", @PARAMS:"+gconv.String(args))),
 		)
+	} else {
+		// Include table name in the cache key so ClearCache(table) can find cache
+		// entries that use a custom Name.
+		name = fmt.Sprintf(`%s@%s`, table, name)
 	}
 	return fmt.Sprintf(`%s%s`, cachePrefixSelectCache, name)
 }


### PR DESCRIPTION
### Fix: Include table name in cache key with custom Name so ClearCache can find it

**Bug:** When `ClearCache(table)` is called to clear cached SELECT results for a table, it fails to find cache entries that use a custom `CacheOption.Name`. The `ClearCache` function filters by prefix `SelectCache:<table>@`, but the cache key for a custom name was `SelectCache:<name>` — no table name in the key.

**Root cause:** `genSelectCacheKey` uses the custom Name directly as the cache key suffix without including the table name. `ClearCache` then cannot find the entry because it looks for keys starting with `SelectCache:table@`.

**Fix:** When a custom Name is provided in `CacheOption`, include the table name in the cache key: `SelectCache:table@name` instead of `SelectCache:name`. This matches the prefix format used by `ClearCache`.

**Example:**
- Before: `CacheOption{Name: "hello"}` on table `test_table` → key: `SelectCache:hello`
- After: `CacheOption{Name: "hello"}` on table `test_table` → key: `SelectCache:test_table@hello`

The `ClearCache("test_table")` function filters by prefix `SelectCache:test_table@`, which now correctly matches.

Fixes #4581
