### PR TITLE
fix(gdb): append PARTITION clause to generated SQL when Model.Partition() is set

### DIFF
--- a/database/gdb/gdb_model.go
+++ b/database/gdb/gdb_model.go
@@ -187,6 +187,9 @@ func (c *Core) With(objects ...any) *Model {
 func (m *Model) Partition(partitions ...string) *Model {
 	model := m.getModel()
 	model.partition = gstr.Join(partitions, ",")
+	if model.partition != "" {
+		model.tables = fmt.Sprintf(`%s PARTITION (%s)`, model.tables, model.partition)
+	}
 	return model
 }
 


### PR DESCRIPTION
## Description

The `Model.Partition()` method has been a no-op since it was introduced in #2989. The setter stores the partition name in the struct field, but the field is never read during SQL generation, so `PARTITION (name)` never reaches the emitted query.

### Root Cause

`database/gdb/gdb_model.go`:
```go
func (m *Model) Partition(partitions ...string) *Model {
    model := m.getModel()
    model.partition = gstr.Join(partitions, ",")
    return model
}
```

The `partition` field has exactly two references in the whole repository — the declaration and the assignment above. It is never read. SQL generation uses `m.tables`, which `Partition()` does not touch.

### Fix

Append `PARTITION (name)` to `m.tables` when a non-empty partition is set. This is the field used by every SQL builder (SELECT, INSERT, UPDATE, DELETE) as the table reference, so the partition clause automatically flows into all query types.

### Verification

Before:
```sql
-- Partition("p0").All() produces:
SELECT * FROM `t`
```

After:
```sql
-- Partition("p0").All() produces:
SELECT * FROM `t` PARTITION (p0)
```

Fixes #4826
