### PR TITLE
fix(gdb): Model.Partition() now emits PARTITION clause in SELECT queries

### DIFF
--- a/contrib/drivers/gaussdb/gaussdb_dialect.go
+++ b/contrib/drivers/gaussdb/gaussdb_dialect.go
@@ -24,3 +24,10 @@ func (d *Driver) GetBoolLiteral(v bool) string {
 func (d *Driver) GetLockSharedClause() string {
 	return gdb.LockForShare
 }
+
+// GetPartitionClause returns an empty string for GaussDB. GaussDB, being
+// PostgreSQL-compatible, does not support the MySQL-style PARTITION (p)
+// clause on SELECT statements.
+func (d *Driver) GetPartitionClause(partitions string) string {
+	return ""
+}

--- a/contrib/drivers/mariadb/mariadb_unit_init_test.go
+++ b/contrib/drivers/mariadb/mariadb_unit_init_test.go
@@ -189,7 +189,7 @@ func Test_PartitionTable(t *testing.T) {
 		data, err = db3.Ctx(ctx).Model("dbx_order").Partition("p3").All()
 		t.AssertNil(err)
 		dataLen = len(data)
-		t.Assert(dataLen, 5)
+		t.Assert(dataLen, 1)
 	})
 }
 

--- a/contrib/drivers/mysql/mysql_z_unit_init_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_init_test.go
@@ -187,7 +187,7 @@ func Test_PartitionTable(t *testing.T) {
 		data, err = db3.Ctx(ctx).Model("dbx_order").Partition("p3").All()
 		t.AssertNil(err)
 		dataLen = len(data)
-		t.Assert(dataLen, 5)
+		t.Assert(dataLen, 1)
 	})
 }
 func createShopDBTable() {

--- a/contrib/drivers/pgsql/pgsql_dialect.go
+++ b/contrib/drivers/pgsql/pgsql_dialect.go
@@ -25,3 +25,10 @@ func (d *Driver) GetBoolLiteral(v bool) string {
 func (d *Driver) GetLockSharedClause() string {
 	return gdb.LockForShare
 }
+
+// GetPartitionClause returns an empty string for PostgreSQL. PostgreSQL does
+// not support the MySQL-style PARTITION (p) clause on SELECT statements;
+// it uses declarative partitioning with inheritance-based partition pruning.
+func (d *Driver) GetPartitionClause(partitions string) string {
+	return ""
+}

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -356,6 +356,12 @@ type DB interface {
 	// Drivers that don't support MySQL's legacy "LOCK IN SHARE MODE" override
 	// to return their dialect equivalent (e.g. "FOR SHARE" on PostgreSQL).
 	GetLockSharedClause() string
+
+	// GetPartitionClause returns the SQL PARTITION clause appended to the
+	// table name in SELECT queries. Returns an empty string when the driver
+	// does not support the PARTITION clause (e.g. PostgreSQL).
+	// MySQL/MariaDB syntax: " PARTITION (p0,p1)"
+	GetPartitionClause(partitions string) string
 }
 
 // TX defines the interfaces for ORM transaction operations.

--- a/database/gdb/gdb_core_underlying.go
+++ b/database/gdb/gdb_core_underlying.go
@@ -530,6 +530,17 @@ func (c *Core) GetLockSharedClause() string {
 	return LockInShareMode
 }
 
+// GetPartitionClause returns the SQL PARTITION clause for the given partition
+// names. MySQL/MariaDB syntax: " PARTITION (p0,p1)". Drivers that do not
+// support the PARTITION clause (e.g. PostgreSQL, GaussDB) override this to
+// return an empty string.
+func (c *Core) GetPartitionClause(partitions string) string {
+	if partitions == "" {
+		return ""
+	}
+	return " PARTITION (" + partitions + ")"
+}
+
 func (c *Core) columnValueToLocalValue(ctx context.Context, value any, columnType *sql.ColumnType) (any, error) {
 	var scanType = columnType.ScanType()
 	if scanType != nil {

--- a/database/gdb/gdb_model_select.go
+++ b/database/gdb/gdb_model_select.go
@@ -746,6 +746,15 @@ func (m *Model) doGetAllBySql(
 func (m *Model) getFormattedSqlAndArgs(
 	ctx context.Context, selectType SelectType, limit1 bool,
 ) (sqlWithHolder string, holderArgs []any) {
+	// getTableWithPartition returns m.tables with the driver-specific
+	// PARTITION clause appended when m.partition is set.
+	getTableWithPartition := func() string {
+		table := m.tables
+		if m.partition != "" {
+			table += m.db.GetPartitionClause(m.partition)
+		}
+		return table
+	}
 	switch selectType {
 	case SelectTypeCount:
 		queryFields := "COUNT(1)"
@@ -764,7 +773,7 @@ func (m *Model) getFormattedSqlAndArgs(
 			return sqlWithHolder, conditionArgs
 		}
 		conditionWhere, conditionExtra, conditionArgs := m.formatCondition(ctx, false, true)
-		sqlWithHolder = fmt.Sprintf("SELECT %s FROM %s%s", queryFields, m.tables, conditionWhere+conditionExtra)
+		sqlWithHolder = fmt.Sprintf("SELECT %s FROM %s%s", queryFields, getTableWithPartition(), conditionWhere+conditionExtra)
 		if len(m.groupBy) > 0 {
 			sqlWithHolder = fmt.Sprintf("SELECT COUNT(1) FROM (%s) count_alias", sqlWithHolder)
 		}
@@ -785,7 +794,7 @@ func (m *Model) getFormattedSqlAndArgs(
 		// DISTINCT t.user_id uid
 		sqlWithHolder = fmt.Sprintf(
 			"SELECT %s%s FROM %s%s",
-			m.distinct, m.getFieldsFiltered(), m.tables, conditionWhere+conditionExtra,
+			m.distinct, m.getFieldsFiltered(), getTableWithPartition(), conditionWhere+conditionExtra,
 		)
 		return sqlWithHolder, conditionArgs
 	}


### PR DESCRIPTION
## Description

`Model.Partition()` set the `m.partition` field but it was never read during SQL generation. The `PARTITION` clause was absent from every SELECT query, so `Partition()` was effectively a no-op — every call returned the whole table regardless of the partition name.

### Root cause

`database/gdb/gdb_model.go`:
```go
func (m *Model) Partition(partitions ...string) *Model {
    model := m.getModel()
    model.partition = gstr.Join(partitions, ",")
    return model
}
```

The `partition` field had exactly two references in the whole repository — the declaration and the setter. It was never read by `getFormattedSqlAndArgs()` in `gdb_model_select.go`, which generates the SQL string directly from `m.tables`.

### Fix

1. **Add `GetPartitionClause(partitions string) string` to the `DB` interface** — provides a driver-extensible way to emit the `PARTITION` clause.
2. **Default implementation in `Core`** — returns ` PARTITION (partitions)` for MySQL/MariaDB/TiDB.
3. **PostgreSQL and GaussDB drivers override** — return empty string (these databases don't support MySQL-style `PARTITION (p)` clause in SELECT; they use declarative partitioning with inheritance-based pruning).
4. **`getFormattedSqlAndArgs` now uses `getTableWithPartition()`** — appends the partition clause after the table name when `m.partition` is set.
5. **Test expected values updated** — `Partition("p3")` returns 1 row (was 5, which was the whole-table count).

### Before

```sql
SELECT * FROM `t`
SELECT * FROM `t` WHERE ...  -- Partition("p3") had no effect
```

### After (MySQL/MariaDB)

```sql
SELECT * FROM `t` PARTITION (p3)
SELECT * FROM `t` PARTITION (p3) WHERE ...
```

### After (PostgreSQL/GaussDB — unchanged, no-op with warning in docs)

No change — `PARTITION` clause is not supported on these drivers.

Fixes #4826