### PR TITLE
fix(ghttp): sync r.Method after normalization in getHandlersWithCache (#4830)

### DIFF
--- a/net/ghttp/ghttp_server_router_serve.go
+++ b/net/ghttp/ghttp_server_router_serve.go
@@ -48,6 +48,7 @@ func (s *Server) getHandlersWithCache(r *Request) (parsedItems []*HandlerItemPar
 		path   = r.URL.Path
 		host   = r.GetHost()
 	)
+	r.Method = method
 	// In case of, eg:
 	// Case 1:
 	// 		GET /net/http


### PR DESCRIPTION
## Description

In `getHandlersWithCache()`, the HTTP method is normalized to uppercase for routing lookup, but the result is only stored in a local variable. The `r.Method` field on the request object is never updated, causing split-brain between the routing layer and the parameter layer.

### Impact

The parameter layer reads `r.Method` directly (e.g. `r.Method == http.MethodGet`), so it sees the unnormalized value. This causes:

- `r.GetQuery("a")` skipping body parsing when `r.Method` is lowercase `"get"` (not `"GET"`)
- Middleware-based method checks being bypassed by non-canonical casing

### Fix

Added `r.Method = method` after the existing normalization to sync the normalized value back to the request object.

### Related

- Fixes #4830
- PR #4812 introduced the half-fix (normalized local var but not r.Method)