### PR TITLE
fix(net/ghttp): use a case-preserving key for the router searching cache

### DIFF
--- a/net/ghttp/ghttp_server_router_serve.go
+++ b/net/ghttp/ghttp_server_router_serve.go
@@ -29,22 +29,39 @@ type handlerCacheItem struct {
 	hasServe    bool
 }
 
-// serveHandlerKey creates and returns a handler key for router.
+// serveHandlerKey creates and returns a handler key for router registration.
+//
+// It is the serveCacheKey with `method` normalized to uppercase, as registration accepts
+// the method in any case, eg BindHandler("get:/api/user", ...) registers a GET route.
 func (s *Server) serveHandlerKey(method, path, domain string) string {
+	return s.serveCacheKey(strings.ToUpper(method), path, domain)
+}
+
+// serveCacheKey creates and returns a cache key for the router searching cache.
+//
+// Different from serveHandlerKey, it does NOT normalize the case of `method`, as the
+// searching result is bound to the exact method token that was searched with. A request
+// carrying a non-canonical method casing(eg "get") must not share the cache item with the
+// canonical one(eg "GET"), or else its serveItem-less result would be cached under the
+// canonical key and make every subsequent well-formed request 404.
+//
+// Note that it also defines the key format of serveHandlerKey, which is the registration
+// side key, so changing the format here changes the registered router keys as well.
+func (s *Server) serveCacheKey(method, path, domain string) string {
 	if len(domain) > 0 {
 		domain = "@" + domain
 	}
 	if method == "" {
 		return path + strings.ToLower(domain)
 	}
-	return strings.ToUpper(method) + ":" + path + strings.ToLower(domain)
+	return method + ":" + path + strings.ToLower(domain)
 }
 
 // getHandlersWithCache searches the router item with cache feature for a given request.
 func (s *Server) getHandlersWithCache(r *Request) (parsedItems []*HandlerItemParsed, serveItem *HandlerItemParsed, hasHook, hasServe bool) {
 	var (
 		ctx    = r.Context()
-		method = strings.ToUpper(r.Method)
+		method = r.Method
 		path   = r.URL.Path
 		host   = r.GetHost()
 	)
@@ -71,7 +88,7 @@ func (s *Server) getHandlersWithCache(r *Request) (parsedItems []*HandlerItemPar
 	if xUrlPath := r.Header.Get(HeaderXUrlPath); xUrlPath != "" {
 		path = xUrlPath
 	}
-	var handlerCacheKey = s.serveHandlerKey(method, path, host)
+	var handlerCacheKey = s.serveCacheKey(method, path, host)
 	value, err := s.serveCache.GetOrSetFunc(ctx, handlerCacheKey, func(ctx context.Context) (any, error) {
 		parsedItems, serveItem, hasHook, hasServe = s.searchHandlers(method, path, host)
 		if parsedItems != nil {

--- a/net/ghttp/ghttp_z_unit_issue_test.go
+++ b/net/ghttp/ghttp_z_unit_issue_test.go
@@ -7,6 +7,7 @@
 package ghttp_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -787,13 +788,23 @@ func Test_Issue4227(t *testing.T) {
 }
 
 // https://github.com/gogf/gf/issues/4765
-// Test_Issue4765 verifies that lowercase HTTP methods (e.g., "get", "post")
-// are normalized to uppercase before building the route cache key, preventing
-// cache pollution that would cause subsequent correctly-cased requests to 404.
+// Test_Issue4765 verifies that a request carrying a non-canonical method casing does not
+// pollute the router searching cache.
+//
+// Such a request does not match a route registered with the canonical method, as the method
+// token is case-sensitive(RFC 9110 section 9.1). But its serveItem-less searching result must
+// not be shared with the canonical method, or else every subsequent well-formed request would
+// be served from that cache item and 404 as well.
+//
+// The method to search with has two sources, and both are covered here: the request line, and
+// the Access-Control-Request-Method header of a preflight request.
 func Test_Issue4765(t *testing.T) {
 	s := g.Server(guid.S())
 	s.Group("/", func(group *ghttp.RouterGroup) {
 		group.GET("/user-case", func(r *ghttp.Request) {
+			r.Response.Write("ok")
+		})
+		group.GET("/preflight-case", func(r *ghttp.Request) {
 			r.Response.Write("ok")
 		})
 	})
@@ -803,42 +814,129 @@ func Test_Issue4765(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
+	var (
+		prefix     = fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort())
+		httpClient = &http.Client{}
+	)
+	// doRequest sends a request using the raw net/http client, as gclient normalizes the
+	// method to uppercase internally and cannot produce a non-canonical method casing.
+	doRequest := func(t *gtest.T, method, path string, header map[string]string) (int, string) {
+		req, err := http.NewRequest(method, prefix+path, nil)
+		t.AssertNil(err)
+		for k, v := range header {
+			req.Header.Set(k, v)
+		}
+		resp, err := httpClient.Do(req)
+		t.AssertNil(err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		t.AssertNil(err)
+		return resp.StatusCode, string(body)
+	}
+
+	// The method to search with comes from the request line.
 	gtest.C(t, func(t *gtest.T) {
-		prefix := fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort())
+		cases := []struct {
+			method string
+			status int
+			body   string
+		}{
+			// Non-canonical casing does not match the route registered as "GET".
+			{"get", http.StatusNotFound, "Not Found"},
+			{"Get", http.StatusNotFound, "Not Found"},
+			// The canonical method still works, which proves the searching result of the
+			// requests above was not cached under the canonical key.
+			{"GET", http.StatusOK, "ok"},
+			{"GET", http.StatusOK, "ok"},
+		}
+		for _, c := range cases {
+			status, body := doRequest(t, c.method, "/user-case", nil)
+			t.Assert(status, c.status)
+			t.Assert(body, c.body)
+		}
+	})
 
-		// Use raw net/http client to send lowercase method, because gclient
-		// normalizes method to uppercase internally.
-		httpClient := &http.Client{}
+	// The method to search with comes from the Access-Control-Request-Method header, which
+	// is client-supplied as well and is not normalized either.
+	gtest.C(t, func(t *gtest.T) {
+		status, body := doRequest(t, http.MethodOptions, "/preflight-case", map[string]string{
+			"Origin":                        "http://example.com",
+			"Access-Control-Request-Method": "get",
+		})
+		t.Assert(status, http.StatusNotFound)
+		t.Assert(body, "Not Found")
 
-		// Step 1: send lowercase "get" — must return 200 "ok".
-		req1, err := http.NewRequest("get", prefix+"/user-case", nil)
-		t.AssertNil(err)
-		resp1, err := httpClient.Do(req1)
-		t.AssertNil(err)
-		body1, err := io.ReadAll(resp1.Body)
-		t.AssertNil(err)
-		resp1.Body.Close()
-		t.Assert(string(body1), "ok")
+		for i := 0; i < 2; i++ {
+			status, body = doRequest(t, http.MethodGet, "/preflight-case", nil)
+			t.Assert(status, http.StatusOK)
+			t.Assert(body, "ok")
+		}
+	})
+}
 
-		// Step 2: send uppercase "GET" — must still return 200 "ok",
-		// proving the cache was not polluted by the lowercase request.
-		req2, err := http.NewRequest("GET", prefix+"/user-case", nil)
-		t.AssertNil(err)
-		resp2, err := httpClient.Do(req2)
-		t.AssertNil(err)
-		body2, err := io.ReadAll(resp2.Body)
-		t.AssertNil(err)
-		resp2.Body.Close()
-		t.Assert(string(body2), "ok")
+// https://github.com/gogf/gf/issues/4830
+// Test_Issue4830 verifies that the router layer and the parameter layer agree on the method
+// of a request.
+//
+// The router searches with the method token as it was received, and `r.Method` keeps that very
+// value, so the framework internal branches on `r.Method`(eg the GET body fallback of GetQuery)
+// and the user code(eg method based middleware) can never diverge from the routing result of
+// the same request.
+func Test_Issue4830(t *testing.T) {
+	s := g.Server(guid.S())
+	s.Group("/", func(group *ghttp.RouterGroup) {
+		group.Middleware(func(r *ghttp.Request) {
+			if r.Method == http.MethodDelete {
+				r.Response.WriteStatusExit(http.StatusForbidden, "blocked")
+			}
+			r.Middleware.Next()
+		})
+		group.GET("/query", func(r *ghttp.Request) {
+			r.Response.Write(r.Method, ",", r.GetQuery("a"))
+		})
+		group.DELETE("/delete", func(r *ghttp.Request) {
+			r.Response.Write("reached")
+		})
+	})
+	s.SetDumpRouterMap(false)
+	s.Start()
+	defer s.Shutdown()
 
-		// Step 3: send mixed-case "Get" — must also work.
-		req3, err := http.NewRequest("Get", prefix+"/user-case", nil)
-		t.AssertNil(err)
-		resp3, err := httpClient.Do(req3)
-		t.AssertNil(err)
-		body3, err := io.ReadAll(resp3.Body)
-		t.AssertNil(err)
-		resp3.Body.Close()
-		t.Assert(string(body3), "ok")
+	time.Sleep(100 * time.Millisecond)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			prefix     = fmt.Sprintf("http://127.0.0.1:%d", s.GetListenedPort())
+			httpClient = &http.Client{}
+			cases      = []struct {
+				method string
+				path   string
+				status int
+				body   string
+			}{
+				// The handler observes the method the request was routed with, so GetQuery
+				// takes its GET branch and falls back to the request body.
+				{"GET", "/query", http.StatusOK, "GET,frombody"},
+				// Non-canonical casing never reaches the handler, so there is no request that
+				// the router treats as GET while the parameter layer does not.
+				{"get", "/query", http.StatusNotFound, "Not Found"},
+				// The middleware observes the same method as the router did.
+				{"DELETE", "/delete", http.StatusForbidden, "blocked"},
+				{"delete", "/delete", http.StatusNotFound, "Not Found"},
+				{"DeLeTe", "/delete", http.StatusNotFound, "Not Found"},
+			}
+		)
+		for _, c := range cases {
+			req, err := http.NewRequest(c.method, prefix+c.path, bytes.NewBufferString(`{"a":"frombody"}`))
+			t.AssertNil(err)
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := httpClient.Do(req)
+			t.AssertNil(err)
+			body, err := io.ReadAll(resp.Body)
+			t.AssertNil(err)
+			resp.Body.Close()
+			t.Assert(resp.StatusCode, c.status)
+			t.Assert(string(body), c.body)
+		}
 	})
 }


### PR DESCRIPTION
## Root cause

#4765 was not really about the case of the HTTP method — it was a mismatch between the cache key and the lookup argument.

`getHandlersWithCache` built its key with `serveHandlerKey`, which uppercases `method`:

```go
return strings.ToUpper(method) + ":" + path + strings.ToLower(domain)
```

but called `searchHandlers` with the method as received. So a `get /api/user` request computed the key `GET:/api/user`, searched with `get`, matched no serving handler, and cached that `serveItem == nil` result under the **canonical** key. Every subsequent well-formed `GET` read it back and 404'd until restart.

The negative result reaches the cache even when nothing matches: every server registers `internalMiddlewareServerTracing` as an `ALL:/*` middleware (`ghttp_server.go:118`), so `parsedItems` is never nil. That is why the issue reproduces with no user middleware at all.

## #4812 fixed one instance of this, and master still has the other

#4812 uppercased the searching method too, but only in the local variable holding the method of the **request line**. The searching method has a second source, assigned to that same variable a few lines later:

```go
if method == http.MethodOptions {
    if v := r.Header.Get("Access-Control-Request-Method"); v != "" {
        method = v            // client-supplied, not normalized
    }
}
```

So the original #4765 pollution is still live on master today, reachable cross-origin from a browser with no user code involved:

```
#1 OPTIONS + Access-Control-Request-Method: get  -> 404 "Not Found"
#2 GET                                           -> 404 "Not Found"   <- poisoned
#3 GET                                           -> 404 "Not Found"
```

## And it left the router and the parameter layer disagreeing

The normalization did not reach `r.Method` either, which feeds four framework-internal branches (`ghttp_request_param_query.go:38,60`, `ghttp_request_param.go:245,351`):

```go
// net/ghttp/ghttp_request_param_query.go:38
if r.Method == http.MethodGet {
	r.parseBody()
}
```

```
sent "GET"   -> 200 r.Method="GET" GetQuery(a)=frombody
sent "get"   -> 200 r.Method="get" GetQuery(a)=
```

Same route, same handler, different result from `r.GetQuery`. Details in #4830.

## This change

Give the searching cache its own key, one that preserves the case of `method`, and search with the method as received. Key and lookup are consistent again for **both** sources of the searching method, without changing what the router matches:

- #4765 is fixed at its root — a non-canonical request never shares a cache item with the canonical one, whichever source the method came from;
- the method token stays case-sensitive, as [RFC 9110 §9.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-9.1) requires (*"The method token is case-sensitive because it might be used as a gateway to object-based systems with case-sensitive method names."*) and as `net/http.ServeMux` behaves;
- `r.Method` keeps the value received on the wire, so every internal check on it — and every method-based middleware — agrees with the routing result.

`serveHandlerKey` now delegates to `serveCacheKey` with the method uppercased, so both keys are built by one piece of code and differ only in that normalization. Route **registration** keeps normalizing, so `s.BindHandler("get:/api/user", ...)` still registers a GET route.

| request sequence | before #4812 | current master | this PR |
|---|---|---|---|
| 1st `get /api/user` | 404 | 200 | 404 |
| 2nd `GET /api/user` | **404 (polluted)** | 200 | 200 |
| 3rd `GET /api/user` | **404 (polluted)** | 200 | 200 |
| 1st `OPTIONS` + `ACRM: get` | 404 | 404 | 404 |
| 2nd `GET` | **404 (polluted)** | **404 (polluted)** | 200 |

#4812 has not been published in any release, so no released version changes behavior here.

## Note on cache cardinality

The searching cache is keyed by the method as received, so `get:/x` and `GET:/x` are now separate items. This does not introduce a new way to grow `serveCache`: the key already contains the client-controlled path, and distinct method tokens (`FOO:/x`, `BAR:/x`) already produced distinct keys before this change. Uppercasing only ever folded casing variants of the same token, so this changes a constant factor, not the bound.

## Tests

`Test_Issue4765` is rewritten. Its assertions were written against the #4812 behavior (`get` → 200), which is precisely what this PR revisits, so they could not be kept. The new ones assert what #4765 actually reported — a non-canonical request 404s, and the canonical request right after it still succeeds, repeatedly — and cover both sources of the searching method, including the preflight case that master still fails.

`Test_Issue4830` is added: `r.Method` is verbatim and `GetQuery` takes its GET branch for a routed GET, and a method-based middleware cannot be bypassed by casing.

Both tests fail without the `ghttp_server_router_serve.go` change and pass with it. `go test ./net/ghttp/` shows no new failures against the master baseline.

closes #4830
