### PR TITLE
fix: remove reflect.Array from IsNil case to prevent panic on array types (fixes #4786)

### DIFF
--- a/util/gconv/internal/converter/converter_struct.go
+++ b/util/gconv/internal/converter/converter_struct.go
@@ -501,7 +501,7 @@ func (c *Converter) bindVarToReflectValue(structFieldValue reflect.Value, value 
 	kind := structFieldValue.Kind()
 	// Converting using `Set` interface implements, for some types.
 	switch kind {
-	case reflect.Slice, reflect.Array, reflect.Pointer, reflect.Interface:
+	case reflect.Slice, reflect.Pointer, reflect.Interface:
 		if !structFieldValue.IsNil() {
 			if v, ok := structFieldValue.Interface().(localinterface.ISet); ok {
 				v.Set(value)


### PR DESCRIPTION
## Description

Fixes #4786

**Problem**: When a struct field of type `[]uuid.UUID` (slice of `[16]byte` arrays) is used as an HTTP request parameter, the conversion code in `bindVarToReflectValue` calls `reflect.Value.IsNil()` on a value whose Kind is `reflect.Array`. Go arrays are not nillable, and calling `IsNil()` on an array type panics with:

```
reflect: call of reflect.Value.IsNil on array Value
```

**Root cause**: In `converter_struct.go`, the `bindVarToReflectValue` function has a case statement:

```go
case reflect.Slice, reflect.Array, reflect.Pointer, reflect.Interface:
    if !structFieldValue.IsNil() {
```

`reflect.Array` is listed alongside `reflect.Pointer` and `reflect.Interface` which *are* nillable, but arrays are never nil in Go. The `IsNil()` guard is only needed for nillable types.

**Fix**: Remove `reflect.Array` from the case statement. Arrays are always non-nil, so the `IsNil()` check is unnecessary and incorrect for array kinds.

## Verification

- Before: `IDs []uuid.UUID` as HTTP param panics with `reflect.Value.IsNil on array Value`
- After: The array element is safely processed without the nil check