### PR TITLE
test(contrib/drivers): expand gaussdb coverage to the MySQL/PgSQL baseline + 8 related bug fixes

### DIFF
--- a/contrib/drivers/gaussdb/gaussdb_convert.go
+++ b/contrib/drivers/gaussdb/gaussdb_convert.go
@@ -30,7 +30,11 @@ func (d *Driver) ConvertValueForField(ctx context.Context, fieldType string, fie
 	var fieldValueKind = reflect.TypeOf(fieldValue).Kind()
 
 	if fieldValueKind == reflect.Slice {
-		// For pgsql, json or jsonb require '[]'
+		// For bytea type, pass []byte directly without any conversion.
+		if _, ok := fieldValue.([]byte); ok && gstr.Contains(fieldType, "bytea") {
+			return d.Core.ConvertValueForField(ctx, fieldType, fieldValue)
+		}
+		// For gaussdb, json or jsonb require '[]'
 		if !gstr.Contains(fieldType, "json") {
 			fieldValue = gstr.ReplaceByMap(gconv.String(fieldValue),
 				map[string]string{
@@ -107,6 +111,9 @@ func (d *Driver) CheckLocalTypeForField(ctx context.Context, fieldType string, f
 	case "_numeric", "_decimal", "_money":
 		return gdb.LocalTypeFloat64Slice, nil
 
+	case "bytea":
+		return gdb.LocalTypeBytes, nil
+
 	case "_bytea":
 		return gdb.LocalTypeBytesSlice, nil
 
@@ -151,8 +158,15 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 	typeName, _ := gregex.ReplaceString(`\(.+\)`, "", fieldType)
 	typeName = strings.ToLower(typeName)
 
-	// Basic types are mostly handled by Core layer, only handle array types here
+	// Basic types are mostly handled by Core layer; handle array types and special-case bytea here.
 	switch typeName {
+
+	// []byte
+	case "bytea":
+		if v, ok := fieldValue.([]byte); ok {
+			return v, nil
+		}
+		return fieldValue, nil
 
 	// []int32
 	case "_int2", "_int4":

--- a/contrib/drivers/gaussdb/gaussdb_convert.go
+++ b/contrib/drivers/gaussdb/gaussdb_convert.go
@@ -114,6 +114,15 @@ func (d *Driver) CheckLocalTypeForField(ctx context.Context, fieldType string, f
 	case "bytea":
 		return gdb.LocalTypeBytes, nil
 
+	// Types whose names merely contain "int" must be listed explicitly: Core's
+	// fallback detection matches that substring, so "point", "interval" and
+	// "tinterval" would otherwise be classified as integers and read back as 0.
+	case "point", "interval", "tinterval":
+		return gdb.LocalTypeString, nil
+
+	case "_point", "_interval", "_tinterval":
+		return gdb.LocalTypeStringSlice, nil
+
 	case "_bytea":
 		return gdb.LocalTypeBytesSlice, nil
 
@@ -209,7 +218,10 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 		return []bool(result), nil
 
 	// []string
-	case "_varchar", "_text", "_char", "_bpchar":
+	case "_varchar", "_text", "_char", "_bpchar",
+		// Geometric/interval arrays have no dedicated pq scanner; their elements
+		// are read as their text representation.
+		"_point", "_interval", "_tinterval":
 		var result pq.StringArray
 		if err := result.Scan(fieldValue); err != nil {
 			return nil, err

--- a/contrib/drivers/gaussdb/gaussdb_convert.go
+++ b/contrib/drivers/gaussdb/gaussdb_convert.go
@@ -115,12 +115,12 @@ func (d *Driver) CheckLocalTypeForField(ctx context.Context, fieldType string, f
 		return gdb.LocalTypeBytes, nil
 
 	// Types whose names merely contain "int" must be listed explicitly: Core's
-	// fallback detection matches that substring, so "point", "interval" and
-	// "tinterval" would otherwise be classified as integers and read back as 0.
-	case "point", "interval", "tinterval":
+	// fallback detection matches that substring, so these would otherwise be
+	// classified as integers and read back as 0.
+	case "point", "interval", "tinterval", "int4range", "int8range":
 		return gdb.LocalTypeString, nil
 
-	case "_point", "_interval", "_tinterval":
+	case "_point", "_interval", "_tinterval", "_int4range", "_int8range":
 		return gdb.LocalTypeStringSlice, nil
 
 	case "_bytea":
@@ -219,9 +219,9 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 
 	// []string
 	case "_varchar", "_text", "_char", "_bpchar",
-		// Geometric/interval arrays have no dedicated pq scanner; their elements
-		// are read as their text representation.
-		"_point", "_interval", "_tinterval":
+		// Geometric/interval/range arrays have no dedicated pq scanner; their
+		// elements are read as their text representation.
+		"_point", "_interval", "_tinterval", "_int4range", "_int8range":
 		var result pq.StringArray
 		if err := result.Scan(fieldValue); err != nil {
 			return nil, err

--- a/contrib/drivers/gaussdb/gaussdb_do_insert.go
+++ b/contrib/drivers/gaussdb/gaussdb_do_insert.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"strings"
 
+	pq "gitee.com/opengauss/openGauss-connector-go-pq"
+
 	"github.com/gogf/gf/v2/container/gset"
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/errors/gcode"
@@ -341,7 +343,10 @@ func (d *Driver) doMergeInsert(
 		keyWithChar := charL + key + charR
 		holder := fmt.Sprintf("$%d", index+1)
 		if fieldType := nullFieldTypes[strings.ToLower(key)]; fieldType != "" {
-			holder += "::" + fieldType
+			// The cast target is quoted: pg_type.typname preserves the case a user
+			// defined type was created with, and an unquoted one would be folded to
+			// lower case and then fail to resolve.
+			holder += "::" + pq.QuoteIdentifier(fieldType)
 		}
 		queryHolders[index] = fmt.Sprintf("%s AS %s", holder, keyWithChar)
 		queryValues[index] = value
@@ -548,6 +553,18 @@ func parseSqlForMerge(table string,
 	return
 }
 
+// trimTypeModifier drops a trailing type modifier from a database type name,
+// e.g. "varchar(45)" -> "varchar", leaving the case of the name untouched.
+func trimTypeModifier(fieldType string) string {
+	if !strings.HasSuffix(fieldType, ")") {
+		return strings.TrimSpace(fieldType)
+	}
+	if index := strings.LastIndexByte(fieldType, '('); index > 0 {
+		return strings.TrimSpace(fieldType[:index])
+	}
+	return strings.TrimSpace(fieldType)
+}
+
 // getNullFieldTypes returns the database type of every record field whose value is
 // NULL, keyed by lower-cased field name. It returns nil when the record holds no
 // NULL value, so the table metadata is only fetched when it is actually needed.
@@ -580,8 +597,12 @@ func (d *Driver) getNullFieldTypes(
 			// TableField.Type carries the type modifier, e.g. "int4(32)". Integer and
 			// float types reject one ("type modifier is not allowed for type int4"),
 			// and it is redundant for the rest since the value is NULL.
-			typeName, _ := d.GetCore().GetFormattedDBTypeNameForField(field.Type)
-			if typeName != "" {
+			//
+			// The modifier is stripped here rather than through
+			// Core.GetFormattedDBTypeNameForField, which lower-cases the name for type
+			// classification; pg_type.typname keeps the case a user defined type was
+			// created with, and losing it makes the cast unresolvable.
+			if typeName := trimTypeModifier(field.Type); typeName != "" {
 				types[strings.ToLower(key)] = typeName
 			}
 			break

--- a/contrib/drivers/gaussdb/gaussdb_do_insert.go
+++ b/contrib/drivers/gaussdb/gaussdb_do_insert.go
@@ -574,10 +574,17 @@ func (d *Driver) getNullFieldTypes(
 			continue
 		}
 		for name, field := range tableFields {
-			if strings.EqualFold(name, key) && field.Type != "" {
-				types[strings.ToLower(key)] = field.Type
-				break
+			if !strings.EqualFold(name, key) {
+				continue
 			}
+			// TableField.Type carries the type modifier, e.g. "int4(32)". Integer and
+			// float types reject one ("type modifier is not allowed for type int4"),
+			// and it is redundant for the rest since the value is NULL.
+			typeName, _ := d.GetCore().GetFormattedDBTypeNameForField(field.Type)
+			if typeName != "" {
+				types[strings.ToLower(key)] = typeName
+			}
+			break
 		}
 	}
 	return types, nil

--- a/contrib/drivers/gaussdb/gaussdb_do_insert.go
+++ b/contrib/drivers/gaussdb/gaussdb_do_insert.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/errors/gcode"
 	"github.com/gogf/gf/v2/errors/gerror"
+	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/text/gstr"
 	"github.com/gogf/gf/v2/util/gconv"
 )
@@ -326,10 +327,23 @@ func (d *Driver) doMergeInsert(
 		conflictKeySet.Add(strings.ToUpper(conflictKey))
 	}
 
+	// A NULL placeholder in the USING branch carries no type of its own, and GaussDB
+	// then infers text for it. Assigning that back to a column such as numeric[],
+	// jsonb, boolean, bytea or uuid fails, which breaks read-modify-write cycles that
+	// carry an untouched NULL column. Cast those placeholders to the real column type.
+	nullFieldTypes, err := d.getNullFieldTypes(ctx, table, one)
+	if err != nil {
+		return nil, err
+	}
+
 	index := 0
 	for key, value := range one {
 		keyWithChar := charL + key + charR
-		queryHolders[index] = fmt.Sprintf("$%d AS %s", index+1, keyWithChar)
+		holder := fmt.Sprintf("$%d", index+1)
+		if fieldType := nullFieldTypes[strings.ToLower(key)]; fieldType != "" {
+			holder += "::" + fieldType
+		}
+		queryHolders[index] = fmt.Sprintf("%s AS %s", holder, keyWithChar)
 		queryValues[index] = value
 		insertKeys[index] = keyWithChar
 		insertValues[index] = fmt.Sprintf("T2.%s", keyWithChar)
@@ -532,4 +546,39 @@ func parseSqlForMerge(table string,
 
 	sqlStr = fmt.Sprintf("%s %s %s %s%s", intoStr, usingStr, onStr, insertStr, updateStr)
 	return
+}
+
+// getNullFieldTypes returns the database type of every record field whose value is
+// NULL, keyed by lower-cased field name. It returns nil when the record holds no
+// NULL value, so the table metadata is only fetched when it is actually needed.
+func (d *Driver) getNullFieldTypes(
+	ctx context.Context, table string, one gdb.Map,
+) (map[string]string, error) {
+	var hasNull bool
+	for _, value := range one {
+		if g.IsNil(value) {
+			hasNull = true
+			break
+		}
+	}
+	if !hasNull {
+		return nil, nil
+	}
+	tableFields, err := d.GetCore().GetDB().TableFields(ctx, table)
+	if err != nil {
+		return nil, err
+	}
+	types := make(map[string]string, len(one))
+	for key, value := range one {
+		if !g.IsNil(value) {
+			continue
+		}
+		for name, field := range tableFields {
+			if strings.EqualFold(name, key) && field.Type != "" {
+				types[strings.ToLower(key)] = field.Type
+				break
+			}
+		}
+	}
+	return types, nil
 }

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_convert_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_convert_test.go
@@ -123,6 +123,35 @@ func Test_CheckLocalTypeForField(t *testing.T) {
 	})
 
 	gtest.C(t, func(t *gtest.T) {
+		// Type names that merely contain "int" must not be detected as integers.
+		for _, typeName := range []string{"point", "interval", "tinterval", "int4range", "int8range"} {
+			localType, err := driver.CheckLocalTypeForField(ctx, typeName, nil)
+			t.AssertNil(err)
+			t.Assert(localType, gdb.LocalTypeString)
+		}
+		for _, typeName := range []string{"_point", "_interval", "_tinterval", "_int4range", "_int8range"} {
+			localType, err := driver.CheckLocalTypeForField(ctx, typeName, nil)
+			t.AssertNil(err)
+			t.Assert(localType, gdb.LocalTypeStringSlice)
+		}
+		// Control: genuine integer types keep their mapping.
+		for _, c := range []struct {
+			typeName string
+			want     gdb.LocalType
+		}{
+			{"int2", gdb.LocalTypeInt},
+			{"int4", gdb.LocalTypeInt},
+			{"int8", gdb.LocalTypeInt64},
+			{"_int4", gdb.LocalTypeInt32Slice},
+			{"_int8", gdb.LocalTypeInt64Slice},
+		} {
+			localType, err := driver.CheckLocalTypeForField(ctx, c.typeName, nil)
+			t.AssertNil(err)
+			t.Assert(localType, c.want)
+		}
+	})
+
+	gtest.C(t, func(t *gtest.T) {
 		// Test uuid type
 		localType, err := driver.CheckLocalTypeForField(ctx, "uuid", nil)
 		t.AssertNil(err)

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_convert_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_convert_test.go
@@ -1,0 +1,437 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/test/gtest"
+
+	"github.com/gogf/gf/contrib/drivers/gaussdb/v2"
+)
+
+// Test_CheckLocalTypeForField tests the CheckLocalTypeForField method
+// for various GaussDB types
+func Test_CheckLocalTypeForField(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		driver = gaussdb.Driver{}
+	)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test basic integer types
+		localType, err := driver.CheckLocalTypeForField(ctx, "int2", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "int4", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "int8", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt64)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test integer array types
+		localType, err := driver.CheckLocalTypeForField(ctx, "_int2", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt32Slice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_int4", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt32Slice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_int8", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt64Slice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test float array types
+		localType, err := driver.CheckLocalTypeForField(ctx, "_float4", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeFloat32Slice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_float8", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeFloat64Slice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test boolean array type
+		localType, err := driver.CheckLocalTypeForField(ctx, "_bool", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeBoolSlice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test string array types
+		localType, err := driver.CheckLocalTypeForField(ctx, "_varchar", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeStringSlice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_text", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeStringSlice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_char", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeStringSlice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_bpchar", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeStringSlice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test numeric array types
+		localType, err := driver.CheckLocalTypeForField(ctx, "_numeric", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeFloat64Slice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_decimal", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeFloat64Slice)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_money", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeFloat64Slice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test bytea type
+		localType, err := driver.CheckLocalTypeForField(ctx, "bytea", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeBytes)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test bytea array type
+		localType, err := driver.CheckLocalTypeForField(ctx, "_bytea", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeBytesSlice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test uuid type
+		localType, err := driver.CheckLocalTypeForField(ctx, "uuid", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeUUID)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test uuid array type
+		localType, err := driver.CheckLocalTypeForField(ctx, "_uuid", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeUUIDSlice)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test type with precision, e.g., "numeric(10,2)"
+		localType, err := driver.CheckLocalTypeForField(ctx, "int2(5)", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "int4(10)", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "INT8(20)", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt64)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test uppercase type names
+		localType, err := driver.CheckLocalTypeForField(ctx, "INT2", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt)
+
+		localType, err = driver.CheckLocalTypeForField(ctx, "_INT4", nil)
+		t.AssertNil(err)
+		t.Assert(localType, gdb.LocalTypeInt32Slice)
+	})
+}
+
+// Test_ConvertValueForLocal tests the ConvertValueForLocal method
+func Test_ConvertValueForLocal(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		driver = gaussdb.Driver{}
+	)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _int2 array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_int2", []byte(`{1,2,3}`))
+		t.AssertNil(err)
+		t.Assert(result, []int32{1, 2, 3})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _int4 array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_int4", []byte(`{10,20,30}`))
+		t.AssertNil(err)
+		t.Assert(result, []int32{10, 20, 30})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _int8 array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_int8", []byte(`{100,200,300}`))
+		t.AssertNil(err)
+		t.Assert(result, []int64{100, 200, 300})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _float4 array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_float4", []byte(`{1.1,2.2,3.3}`))
+		t.AssertNil(err)
+		resultArr := result.([]float32)
+		t.Assert(len(resultArr), 3)
+		t.Assert(resultArr[0] > 1.0 && resultArr[0] < 1.2, true)
+		t.Assert(resultArr[1] > 2.1 && resultArr[1] < 2.3, true)
+		t.Assert(resultArr[2] > 3.2 && resultArr[2] < 3.4, true)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _float8 array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_float8", []byte(`{1.11,2.22,3.33}`))
+		t.AssertNil(err)
+		resultArr := result.([]float64)
+		t.Assert(len(resultArr), 3)
+		t.Assert(resultArr[0] > 1.1 && resultArr[0] < 1.12, true)
+		t.Assert(resultArr[1] > 2.21 && resultArr[1] < 2.23, true)
+		t.Assert(resultArr[2] > 3.32 && resultArr[2] < 3.34, true)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _bool array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_bool", []byte(`{t,f,t}`))
+		t.AssertNil(err)
+		t.Assert(result, []bool{true, false, true})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _varchar array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_varchar", []byte(`{a,b,c}`))
+		t.AssertNil(err)
+		t.Assert(result, []string{"a", "b", "c"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _text array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_text", []byte(`{hello,world}`))
+		t.AssertNil(err)
+		t.Assert(result, []string{"hello", "world"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _char array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_char", []byte(`{x,y,z}`))
+		t.AssertNil(err)
+		t.Assert(result, []string{"x", "y", "z"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _bpchar array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_bpchar", []byte(`{a,b}`))
+		t.AssertNil(err)
+		t.Assert(result, []string{"a", "b"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _numeric array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_numeric", []byte(`{1.11,2.22}`))
+		t.AssertNil(err)
+		resultArr := result.([]float64)
+		t.Assert(len(resultArr), 2)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _decimal array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_decimal", []byte(`{3.33,4.44}`))
+		t.AssertNil(err)
+		resultArr := result.([]float64)
+		t.Assert(len(resultArr), 2)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _money array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_money", []byte(`{5.55,6.66}`))
+		t.AssertNil(err)
+		resultArr := result.([]float64)
+		t.Assert(len(resultArr), 2)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _bytea array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_bytea", []byte(`{"\\x68656c6c6f","\\x776f726c64"}`))
+		t.AssertNil(err)
+		resultArr := result.([][]byte)
+		t.Assert(len(resultArr), 2)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test uuid conversion from []byte
+		result, err := driver.ConvertValueForLocal(ctx, "uuid", []byte(`550e8400-e29b-41d4-a716-446655440000`))
+		t.AssertNil(err)
+		t.Assert(result.(uuid.UUID).String(), "550e8400-e29b-41d4-a716-446655440000")
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test uuid conversion from string
+		result, err := driver.ConvertValueForLocal(ctx, "uuid", "550e8400-e29b-41d4-a716-446655440000")
+		t.AssertNil(err)
+		t.Assert(result.(uuid.UUID).String(), "550e8400-e29b-41d4-a716-446655440000")
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test uuid conversion error case with invalid uuid
+		_, err := driver.ConvertValueForLocal(ctx, "uuid", "invalid-uuid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _uuid array conversion
+		result, err := driver.ConvertValueForLocal(ctx, "_uuid", []byte(`{550e8400-e29b-41d4-a716-446655440000,6ba7b810-9dad-11d1-80b4-00c04fd430c8}`))
+		t.AssertNil(err)
+		resultArr := result.([]uuid.UUID)
+		t.Assert(len(resultArr), 2)
+		t.Assert(resultArr[0].String(), "550e8400-e29b-41d4-a716-446655440000")
+		t.Assert(resultArr[1].String(), "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test _uuid array conversion error case
+		_, err := driver.ConvertValueForLocal(ctx, "_uuid", []byte(`{invalid-uuid}`))
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _int2
+		_, err := driver.ConvertValueForLocal(ctx, "_int2", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _int4
+		_, err := driver.ConvertValueForLocal(ctx, "_int4", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _int8
+		_, err := driver.ConvertValueForLocal(ctx, "_int8", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _float4
+		_, err := driver.ConvertValueForLocal(ctx, "_float4", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _float8
+		_, err := driver.ConvertValueForLocal(ctx, "_float8", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _bool
+		_, err := driver.ConvertValueForLocal(ctx, "_bool", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _varchar
+		_, err := driver.ConvertValueForLocal(ctx, "_varchar", 12345)
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _numeric
+		_, err := driver.ConvertValueForLocal(ctx, "_numeric", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test error case with invalid data for _bytea
+		_, err := driver.ConvertValueForLocal(ctx, "_bytea", "invalid")
+		t.AssertNE(err, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test bytea conversion - should preserve []byte as-is
+		input := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x5D, 0x5B}
+		result, err := driver.ConvertValueForLocal(ctx, "bytea", input)
+		t.AssertNil(err)
+		resultBytes, ok := result.([]byte)
+		t.Assert(ok, true)
+		t.Assert(len(resultBytes), len(input))
+		t.Assert(resultBytes, input)
+	})
+}
+
+// Test_ConvertValueForField tests the ConvertValueForField method
+func Test_ConvertValueForField(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		driver = gaussdb.Driver{}
+	)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test nil value
+		result, err := driver.ConvertValueForField(ctx, "varchar", nil)
+		t.AssertNil(err)
+		t.Assert(result, nil)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test slice value for non-json type (should convert [] to {})
+		result, err := driver.ConvertValueForField(ctx, "int4[]", []int{1, 2, 3})
+		t.AssertNil(err)
+		t.Assert(result, "{1,2,3}")
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test slice value for non-json type with strings
+		// Note: gconv.String for []string{"a","b","c"} produces ["a","b","c"] which then gets converted to {"a","b","c"}
+		result, err := driver.ConvertValueForField(ctx, "varchar[]", []string{"a", "b", "c"})
+		t.AssertNil(err)
+		t.Assert(result, `{"a","b","c"}`)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test slice value for json type (should keep [] as is)
+		result, err := driver.ConvertValueForField(ctx, "json", []int{1, 2, 3})
+		t.AssertNil(err)
+		t.Assert(result, "[1,2,3]")
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test slice value for jsonb type (should keep [] as is)
+		result, err := driver.ConvertValueForField(ctx, "jsonb", []string{"a", "b"})
+		t.AssertNil(err)
+		t.Assert(result, `["a","b"]`)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test []byte value for bytea type (should preserve raw bytes, not do []->{} replacement)
+		input := []byte{0xDE, 0xAD, 0x5B, 0x5D, 0xBE, 0xEF}
+		result, err := driver.ConvertValueForField(ctx, "bytea", input)
+		t.AssertNil(err)
+		resultBytes, ok := result.([]byte)
+		t.Assert(ok, true)
+		t.Assert(resultBytes, input)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_core_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_core_test.go
@@ -1,0 +1,184 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/text/gstr"
+)
+
+func Test_DB_Ping(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		err1 := db.PingMaster()
+		err2 := db.PingSlave()
+		t.Assert(err1, nil)
+		t.Assert(err2, nil)
+	})
+}
+
+func Test_DB_Prepare(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		st, err := db.Prepare(ctx, "SELECT 100")
+		t.AssertNil(err)
+
+		rows, err := st.Query()
+		t.AssertNil(err)
+
+		array, err := rows.Columns()
+		t.AssertNil(err)
+		// GaussDB returns the column name as "?column?" for unnamed expressions.
+		t.AssertNE(array[0], "")
+
+		err = rows.Close()
+		t.AssertNil(err)
+	})
+}
+
+func Test_Empty_Slice_Argument(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.GetAll(ctx, fmt.Sprintf(`select * from %s where id in(?)`, table), g.Slice{})
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+	})
+}
+
+// Test_DB_UpdateCounter tests gdb.Counter usage for increment/decrement.
+// GaussDB-adapted: no AUTO_INCREMENT, uses standard INTEGER.
+func Test_DB_UpdateCounter(t *testing.T) {
+	tableName := "gf_update_counter_test_" + gtime.TimestampNanoStr()
+	_, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id integer NOT NULL,
+			views integer DEFAULT 0 NOT NULL,
+			updated_time integer DEFAULT 0 NOT NULL
+		);
+	`, tableName))
+	if err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(tableName)
+
+	gtest.C(t, func(t *gtest.T) {
+		insertData := g.Map{
+			"id":           1,
+			"views":        0,
+			"updated_time": 0,
+		}
+		_, err = db.Insert(ctx, tableName, insertData)
+		t.AssertNil(err)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		gdbCounter := &gdb.Counter{
+			Field: "id",
+			Value: 1,
+		}
+		updateData := g.Map{
+			"views": gdbCounter,
+		}
+		result, err := db.Update(ctx, tableName, updateData, "id", 1)
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+		one, err := db.Model(tableName).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"].Int(), 1)
+		t.Assert(one["views"].Int(), 2)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		gdbCounter := &gdb.Counter{
+			Field: "views",
+			Value: -1,
+		}
+		updateData := g.Map{
+			"views":        gdbCounter,
+			"updated_time": gtime.Now().Unix(),
+		}
+		result, err := db.Update(ctx, tableName, updateData, "id", 1)
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+		one, err := db.Model(tableName).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"].Int(), 1)
+		t.Assert(one["views"].Int(), 1)
+	})
+}
+
+// Test_DB_Ctx verifies context deadline cancels a running query.
+// GaussDB-adapted: uses pg_sleep(seconds) instead of MySQL's SLEEP(seconds).
+func Test_DB_Ctx(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, err := db.Query(ctx, "SELECT pg_sleep(10)")
+		t.AssertNE(err, nil)
+		t.Assert(gstr.Contains(err.Error(), "deadline") ||
+			gstr.Contains(err.Error(), "canceling") ||
+			gstr.Contains(err.Error(), "context"), true)
+	})
+}
+
+func Test_DB_Ctx_Logger(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		defer db.SetDebug(db.GetDebug())
+		db.SetDebug(true)
+		ctx := context.WithValue(context.Background(), "Trace-Id", "123456789")
+		_, err := db.Query(ctx, "SELECT 1")
+		t.AssertNil(err)
+	})
+}
+
+func Test_Core_ClearTableFields(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		fields, err := db.TableFields(ctx, table)
+		t.AssertNil(err)
+		// GaussDB baseline table has 9 columns:
+		// id, passport, password, nickname, create_time,
+		// favorite_movie, favorite_music, numeric_values, decimal_values.
+		t.Assert(len(fields), 9)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		err := db.GetCore().ClearTableFields(ctx, table)
+		t.AssertNil(err)
+	})
+}
+
+func Test_Core_ClearTableFieldsAll(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		err := db.GetCore().ClearTableFieldsAll(ctx)
+		t.AssertNil(err)
+	})
+}
+
+func Test_Core_ClearCache(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		err := db.GetCore().ClearCache(ctx, "")
+		t.AssertNil(err)
+	})
+}
+
+func Test_Core_ClearCacheAll(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		err := db.GetCore().ClearCacheAll(ctx)
+		t.AssertNil(err)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_batch_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_batch_test.go
@@ -1,0 +1,362 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_Model_Batch_Insert tests batch insert with different batch sizes.
+func Test_Model_Batch_Insert(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Prepare data for batch insert
+		data := g.Slice{}
+		for i := 1; i <= 10; i++ {
+			data = append(data, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("batch_user_%d", i),
+				"password":    fmt.Sprintf("batch_pass_%d", i),
+				"nickname":    fmt.Sprintf("batch_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+
+		// Batch insert with batch size 3
+		result, err := db.Model(table).Batch(3).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 10)
+
+		// Verify all records were inserted
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 10)
+
+		// Verify specific records
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "batch_user_1")
+
+		one, err = db.Model(table).Where("id", 10).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "batch_user_10")
+	})
+}
+
+// Test_Model_Batch_Replace tests batch replace operation.
+// The GaussDB driver routes Replace through doSave, which emits a MERGE statement
+// keyed on the primary key.
+func Test_Model_Batch_Replace(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Initial insert with all NOT NULL columns
+		data := g.Slice{}
+		for i := 1; i <= 5; i++ {
+			data = append(data, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("original_%d", i),
+				"password":    fmt.Sprintf("orig_pass_%d", i),
+				"nickname":    fmt.Sprintf("orig_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+		_, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+
+		// Batch replace with overlapping ids
+		replaceData := g.Slice{}
+		for i := 3; i <= 8; i++ {
+			replaceData = append(replaceData, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("replaced_%d", i),
+				"password":    fmt.Sprintf("repl_pass_%d", i),
+				"nickname":    fmt.Sprintf("new_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+		result, err := db.Model(table).Batch(2).Data(replaceData).Replace()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.AssertGT(n, 0)
+
+		// Verify replaced records
+		one, err := db.Model(table).Where("id", 3).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "replaced_3")
+		t.Assert(one["nickname"], "new_name_3")
+
+		// Verify new records
+		one, err = db.Model(table).Where("id", 8).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "replaced_8")
+
+		// Verify total count: ids 1-8
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 8)
+	})
+}
+
+// Test_Model_Batch_Save tests batch save operation.
+// The GaussDB driver implements Save with a MERGE statement keyed on the primary key.
+func Test_Model_Batch_Save(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Initial data
+		data := g.Slice{}
+		for i := 1; i <= 5; i++ {
+			data = append(data, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("save_user_%d", i),
+				"password":    fmt.Sprintf("save_pass_%d", i),
+				"nickname":    fmt.Sprintf("save_nick_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+		_, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+
+		// Batch save with overlapping and new ids
+		saveData := g.Slice{}
+		for i := 3; i <= 8; i++ {
+			saveData = append(saveData, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("saved_%d", i),
+				"password":    fmt.Sprintf("saved_pass_%d", i),
+				"nickname":    fmt.Sprintf("save_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+		result, err := db.Model(table).Batch(3).Data(saveData).Save()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.AssertGT(n, 0)
+
+		// Verify updated records
+		one, err := db.Model(table).Where("id", 3).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "saved_3")
+
+		// Verify inserted records
+		one, err = db.Model(table).Where("id", 8).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "saved_8")
+
+		// Verify total count
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 8)
+	})
+}
+
+// Test_Model_Batch_LargeBatch tests batch operation with large dataset.
+func Test_Model_Batch_LargeBatch(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Prepare 1500 records
+		data := g.Slice{}
+		totalRecords := 1500
+		for i := 1; i <= totalRecords; i++ {
+			data = append(data, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("large_user_%d", i),
+				"password":    fmt.Sprintf("large_pass_%d", i),
+				"nickname":    fmt.Sprintf("large_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+
+		// Batch insert with batch size 100
+		result, err := db.Model(table).Batch(100).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, totalRecords)
+
+		// Verify count
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, totalRecords)
+
+		// Verify first and last records
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "large_user_1")
+
+		one, err = db.Model(table).Where("id", totalRecords).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], fmt.Sprintf("large_user_%d", totalRecords))
+	})
+}
+
+// Test_Model_Batch_EmptyBatch tests batch operation with empty data.
+func Test_Model_Batch_EmptyBatch(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Empty slice
+		data := g.Slice{}
+
+		// Batch insert with empty data should return error
+		_, err := db.Model(table).Batch(10).Data(data).Insert()
+		t.AssertNE(err, nil)
+		t.AssertIN(err.Error(), "data list cannot be empty")
+
+		// Verify no records inserted
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 0)
+	})
+}
+
+// Test_Model_Batch_SingleRecord tests batch operation with single record.
+func Test_Model_Batch_SingleRecord(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Single record batch insert
+		data := g.Slice{
+			g.Map{
+				"id":          1,
+				"passport":    "single_user",
+				"password":    "single_pass",
+				"nickname":    "single_name",
+				"create_time": gtime.Now().String(),
+			},
+		}
+
+		result, err := db.Model(table).Batch(10).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify the record
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "single_user")
+		t.Assert(one["nickname"], "single_name")
+	})
+}
+
+// Test_Model_Batch_VsBatch tests equivalence across different batch sizes.
+func Test_Model_Batch_VsBatch(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Prepare data
+		data := g.Slice{}
+		for i := 1; i <= 100; i++ {
+			data = append(data, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("perf_user_%d", i),
+				"password":    fmt.Sprintf("perf_pass_%d", i),
+				"nickname":    fmt.Sprintf("perf_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+
+		// Test with batch size 1
+		result, err := db.Model(table).Batch(1).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 100)
+
+		// Clean up
+		_, err = db.Model(table).Where("1=1").Delete()
+		t.AssertNil(err)
+
+		// Test with batch size 10
+		result, err = db.Model(table).Batch(10).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ = result.RowsAffected()
+		t.Assert(n, 100)
+
+		// Clean up
+		_, err = db.Model(table).Where("1=1").Delete()
+		t.AssertNil(err)
+
+		// Test with batch size 50
+		result, err = db.Model(table).Batch(50).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ = result.RowsAffected()
+		t.Assert(n, 100)
+
+		// All batch sizes should produce same result
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 100)
+	})
+}
+
+// Test_Model_Batch_WithTransaction tests batch operation within transaction.
+func Test_Model_Batch_WithTransaction(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		data := g.Slice{}
+		for i := 1; i <= 50; i++ {
+			data = append(data, g.Map{
+				"id":          i,
+				"passport":    fmt.Sprintf("tx_batch_%d", i),
+				"password":    fmt.Sprintf("tx_pass_%d", i),
+				"nickname":    fmt.Sprintf("tx_name_%d", i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+
+		// Test commit
+		err := db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			result, err := tx.Model(table).Batch(10).Data(data).Insert()
+			t.AssertNil(err)
+			n, _ := result.RowsAffected()
+			t.Assert(n, 50)
+			return nil
+		})
+		t.AssertNil(err)
+
+		// Verify commit
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 50)
+
+		// Clean up
+		_, err = db.Model(table).Where("1=1").Delete()
+		t.AssertNil(err)
+
+		// Test rollback
+		err = db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			_, err := tx.Model(table).Batch(10).Data(data).Insert()
+			t.AssertNil(err)
+			return fmt.Errorf("rollback test")
+		})
+		t.AssertNE(err, nil)
+
+		// Verify rollback - no records should exist
+		count, err = db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 0)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_cache_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_cache_test.go
@@ -1,0 +1,294 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_Model_Cache_Basic tests basic cache functionality.
+func Test_Model_Cache_Basic(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// First query - cache miss, result from DB
+		one, err := db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Name:     "test_cache_basic",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 1)
+		t.Assert(one["passport"], "user_1")
+
+		// Update the record in DB
+		_, err = db.Model(table).Data(g.Map{"passport": "updated_user"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Second query - cache hit, still returns old cached value
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Name:     "test_cache_basic",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1") // cached value, not "updated_user"
+
+		// Query without cache - returns updated value from DB
+		one, err = db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "updated_user")
+	})
+}
+
+// Test_Model_Cache_TTL tests cache TTL expiration.
+func Test_Model_Cache_TTL(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Cache with short TTL
+		one, err := db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Millisecond * 100, // 100ms TTL
+			Name:     "test_cache_ttl",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1")
+
+		// Update record
+		_, err = db.Model(table).Data(g.Map{"passport": "ttl_test"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Immediate query - cache still valid
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Millisecond * 100,
+			Name:     "test_cache_ttl",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1") // cached value
+
+		// Wait for cache to expire
+		time.Sleep(time.Millisecond * 150)
+
+		// Query after expiration - should get fresh data
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Millisecond * 100,
+			Name:     "test_cache_ttl",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "ttl_test") // fresh value from DB
+	})
+}
+
+// Test_Model_Cache_Clear tests clearing cache with negative duration.
+func Test_Model_Cache_Clear(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Set cache
+		one, err := db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 60,
+			Name:     "test_cache_clear",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1")
+
+		// Update record and clear cache
+		_, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: -1,
+			Name:     "test_cache_clear",
+		}).Data(g.Map{"passport": "cleared"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Query again - should get fresh data since cache was cleared
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 60,
+			Name:     "test_cache_clear",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "cleared")
+	})
+}
+
+// Test_Model_Cache_NoExpire tests cache with no expiration (Duration=0).
+func Test_Model_Cache_NoExpire(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Cache with no expiration
+		one, err := db.Model(table).Cache(gdb.CacheOption{
+			Duration: 0, // never expires
+			Name:     "test_cache_no_expire",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1")
+
+		// Update record
+		_, err = db.Model(table).Data(g.Map{"passport": "no_expire_test"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Wait a bit
+		time.Sleep(time.Millisecond * 100)
+
+		// Query - cache should still be valid
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: 0,
+			Name:     "test_cache_no_expire",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1") // cached value persists
+
+		// Clear the cache with update operation
+		_, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: -1,
+			Name:     "test_cache_no_expire",
+		}).Data(g.Map{"nickname": "cleared"}).Where("id", 1).Update()
+		t.AssertNil(err)
+	})
+}
+
+// Test_Model_Cache_DisabledInTransaction tests cache is disabled in transactions.
+func Test_Model_Cache_DisabledInTransaction(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		err := db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			// First query in transaction
+			one, err := tx.Model(table).Cache(gdb.CacheOption{
+				Duration: time.Second * 10,
+				Name:     "test_tx_cache",
+			}).Where("id", 1).One()
+			t.AssertNil(err)
+			t.Assert(one["passport"], "user_1")
+
+			// Update in transaction
+			_, err = tx.Model(table).Data(g.Map{"passport": "tx_update"}).Where("id", 1).Update()
+			t.AssertNil(err)
+
+			// Second query - should see updated value (cache disabled in tx)
+			one, err = tx.Model(table).Cache(gdb.CacheOption{
+				Duration: time.Second * 10,
+				Name:     "test_tx_cache",
+			}).Where("id", 1).One()
+			t.AssertNil(err)
+			t.Assert(one["passport"], "tx_update") // not cached, fresh from DB
+
+			return nil
+		})
+		t.AssertNil(err)
+	})
+}
+
+// Test_Model_PageCache tests pagination cache.
+func Test_Model_PageCache(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// First page query with cache
+		all, err := db.Model(table).PageCache(
+			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
+			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
+		).Page(1, 3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+
+		// Insert new record.
+		_, err = db.Model(table).Data(g.Map{
+			"id":          11,
+			"passport":    "user_11",
+			"password":    "pass_11",
+			"nickname":    "name_11",
+			"create_time": gtime.Now().String(),
+		}).Insert()
+		t.AssertNil(err)
+
+		// Query again - should return cached results
+		all, err = db.Model(table).PageCache(
+			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
+			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
+		).Page(1, 3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3) // cached results
+
+		// Clear page cache by updating with Duration=-1
+		_, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: -1,
+			Name:     "test_page_count",
+		}).Data(g.Map{"nickname": "page_test"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Query with fresh cache - should return updated count
+		all, err = db.Model(table).PageCache(
+			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
+			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
+		).Page(1, 3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3) // still 3 items per page
+
+		// Verify total count increased
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 11)
+	})
+}
+
+// Test_Model_Cache_DifferentNames tests different cache names for same query.
+func Test_Model_Cache_DifferentNames(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Cache with name1
+		one, err := db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Name:     "cache_name1",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1")
+
+		// Cache same query with name2
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Name:     "cache_name2",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1")
+
+		// Update record and clear only cache_name1
+		_, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: -1,
+			Name:     "cache_name1",
+		}).Data(g.Map{"passport": "diff_name"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Query with cache_name1 - should get fresh data
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Name:     "cache_name1",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "diff_name")
+
+		// Query with cache_name2 - should still have cached old value
+		one, err = db.Model(table).Cache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Name:     "cache_name2",
+		}).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_1") // still cached
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_cache_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_cache_test.go
@@ -69,16 +69,10 @@ func Test_Model_Cache_TTL(t *testing.T) {
 		_, err = db.Model(table).Data(g.Map{"passport": "ttl_test"}).Where("id", 1).Update()
 		t.AssertNil(err)
 
-		// Immediate query - cache still valid
-		one, err = db.Model(table).Cache(gdb.CacheOption{
-			Duration: time.Millisecond * 100,
-			Name:     "test_cache_ttl",
-		}).Where("id", 1).One()
-		t.AssertNil(err)
-		t.Assert(one["passport"], "user_1") // cached value
-
-		// Wait for cache to expire
-		time.Sleep(time.Millisecond * 150)
+		// Wait for cache to expire. Serving the cached value before it expires is
+		// covered by Test_Model_Cache_Basic, whose TTL is wide enough that a slow
+		// database round trip cannot exhaust it.
+		time.Sleep(time.Millisecond * 300)
 
 		// Query after expiration - should get fresh data
 		one, err = db.Model(table).Cache(gdb.CacheOption{

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_cache_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_cache_test.go
@@ -193,12 +193,13 @@ func Test_Model_PageCache(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		// First page query with cache
-		all, err := db.Model(table).PageCache(
+		all, count, err := db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
 		t.Assert(len(all), 3)
+		t.Assert(count, 10)
 
 		// Insert new record.
 		_, err = db.Model(table).Data(g.Map{
@@ -211,12 +212,14 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query again - should return cached results
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // cached results
+		t.Assert(len(all), 3)
+		// Count comes from the cache, so it still reports the pre-insert value.
+		t.Assert(count, 10)
 
 		// Clear page cache by updating with Duration=-1
 		_, err = db.Model(table).Cache(gdb.CacheOption{
@@ -226,17 +229,19 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query with fresh cache - should return updated count
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // still 3 items per page
+		t.Assert(len(all), 3)
+		// Count cache was cleared above, so the new row is visible.
+		t.Assert(count, 11)
 
 		// Verify total count increased
-		count, err := db.Model(table).Count()
+		totalCount, err := db.Model(table).Count()
 		t.AssertNil(err)
-		t.Assert(count, 11)
+		t.Assert(totalCount, 11)
 	})
 }
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_concurrent_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_concurrent_test.go
@@ -1,0 +1,417 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Note: the worker goroutines below only record their outcome; every assertion runs
+// on the test goroutine after Wait(). gtest assertions panic on failure, and a panic
+// raised in a spawned goroutine is not recovered by gtest.C — it would abort the whole
+// test binary and skip every remaining test rather than failing just this one.
+
+// Test_Concurrent_Insert tests concurrent Insert operations.
+func Test_Concurrent_Insert(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 10
+			errs        = make([]error, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, id int) {
+				defer wg.Done()
+				_, errs[idx] = db.Model(table).Insert(g.Map{
+					"passport":    fmt.Sprintf("user_%d", id),
+					"password":    fmt.Sprintf("pass_%d", id),
+					"nickname":    fmt.Sprintf("name_%d", id),
+					"create_time": gtime.Now().String(),
+				})
+			}(i, i+1)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			t.AssertNil(err)
+		}
+
+		// Verify all records inserted
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, concurrency)
+	})
+}
+
+// Test_Concurrent_Update tests concurrent Update operations.
+func Test_Concurrent_Update(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 5
+			errs        = make([]error, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, id int) {
+				defer wg.Done()
+				_, errs[idx] = db.Model(table).Data(g.Map{
+					"nickname": fmt.Sprintf("updated_%d", id),
+				}).Where("id", id+1).Update()
+			}(i, i)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			t.AssertNil(err)
+		}
+
+		// Verify updates
+		for i := 0; i < concurrency; i++ {
+			one, err := db.Model(table).Where("id", i+1).One()
+			t.AssertNil(err)
+			t.Assert(one["nickname"].String(), fmt.Sprintf("updated_%d", i))
+		}
+	})
+}
+
+// Test_Concurrent_Delete tests concurrent Delete operations.
+func Test_Concurrent_Delete(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 5
+			errs        = make([]error, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, id int) {
+				defer wg.Done()
+				_, errs[idx] = db.Model(table).Where("id", id+1).Delete()
+			}(i, i)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			t.AssertNil(err)
+		}
+
+		// Verify deletions
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, TableSize-concurrency)
+	})
+}
+
+// Test_Concurrent_Query tests concurrent Query operations.
+func Test_Concurrent_Query(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 20
+			errs        = make([]error, concurrency)
+			results     = make([]gdb.Record, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, id int) {
+				defer wg.Done()
+				results[idx], errs[idx] = db.Model(table).Where("id", (id%TableSize)+1).One()
+			}(i, i)
+		}
+		wg.Wait()
+
+		for i := 0; i < concurrency; i++ {
+			t.AssertNil(errs[i])
+			t.AssertNE(results[i], nil)
+			t.Assert(results[i]["id"].Int(), (i%TableSize)+1)
+		}
+	})
+}
+
+// Test_Concurrent_Transaction tests concurrent transaction operations.
+func Test_Concurrent_Transaction(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 10
+			errs        = make([]error, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, id int) {
+				defer wg.Done()
+				errs[idx] = db.Transaction(ctx, func(ctx g.Ctx, tx gdb.TX) error {
+					_, err := tx.Model(table).Insert(g.Map{
+						"passport":    fmt.Sprintf("user_%d", id),
+						"password":    fmt.Sprintf("pass_%d", id),
+						"nickname":    fmt.Sprintf("name_%d", id),
+						"create_time": gtime.Now().String(),
+					})
+					return err
+				})
+			}(i, i+1)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			t.AssertNil(err)
+		}
+
+		// Verify all transactions committed
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, concurrency)
+	})
+}
+
+// Test_Concurrent_Mixed_Operations tests mixed concurrent operations.
+// Individual operation errors are tolerated here: the interleaved inserts and
+// updates race by design, so the assertion is that the database stays consistent
+// and reachable afterwards rather than that every operation succeeded.
+func Test_Concurrent_Mixed_Operations(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg         sync.WaitGroup
+			operations = 30
+		)
+		wg.Add(operations)
+		for i := 0; i < operations; i++ {
+			switch i % 3 {
+			case 0: // Insert
+				go func(id int) {
+					defer wg.Done()
+					_, _ = db.Model(table).Insert(g.Map{
+						"passport":    fmt.Sprintf("new_user_%d", id),
+						"password":    fmt.Sprintf("new_pass_%d", id),
+						"nickname":    fmt.Sprintf("new_name_%d", id),
+						"create_time": gtime.Now().String(),
+					})
+				}(i)
+			case 1: // Update
+				go func(id int) {
+					defer wg.Done()
+					_, _ = db.Model(table).Data(g.Map{
+						"nickname": fmt.Sprintf("concurrent_%d", id),
+					}).Where("id", (id%TableSize)+1).Update()
+				}(i)
+			case 2: // Query
+				go func(id int) {
+					defer wg.Done()
+					_, _ = db.Model(table).Where("id", (id%TableSize)+1).One()
+				}(i)
+			}
+		}
+		wg.Wait()
+
+		// Verify database is still consistent.
+		// Use AssertGE: concurrent inserts may conflict with the bigserial sequence,
+		// which createInitTable's explicit id inserts do not advance.
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.AssertGE(count, TableSize)
+
+		// The pre-existing rows are all still readable.
+		all, err := db.Model(table).Where("id<=?", TableSize).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+	})
+}
+
+// Test_Concurrent_Connection_Pool tests connection pool under load.
+func Test_Concurrent_Connection_Pool(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg              sync.WaitGroup
+			concurrency     = 50
+			queriesPerRound = 5
+			errs            = make([]error, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, id int) {
+				defer wg.Done()
+				// Each goroutine performs multiple operations
+				for j := 0; j < queriesPerRound; j++ {
+					if _, err := db.Model(table).Where("id", (id%TableSize)+1).One(); err != nil {
+						errs[idx] = err
+						return
+					}
+				}
+			}(i, i)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			t.AssertNil(err)
+		}
+	})
+}
+
+// Test_Concurrent_Schema_Switch tests concurrent operations across two tables.
+// GaussDB-adapted from MariaDB: the MariaDB version uses db2 (a separate schema).
+// GaussDB init_test.go only configures a single DB/schema, so we use two distinct
+// tables within the same schema to exercise the same concurrency pathway.
+func Test_Concurrent_Schema_Switch(t *testing.T) {
+	table1 := createTableWithDb(db, TablePrefix+"schema_1")
+	table2 := createTableWithDb(db, TablePrefix+"schema_2")
+	defer dropTableWithDb(db, table1)
+	defer dropTableWithDb(db, table2)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 10
+			errs1       = make([]error, concurrency)
+			errs2       = make([]error, concurrency)
+		)
+		wg.Add(concurrency * 2)
+		for i := 0; i < concurrency; i++ {
+			// Insert to table1
+			go func(idx int) {
+				defer wg.Done()
+				_, errs1[idx] = db.Model(table1).Insert(g.Map{
+					"passport":    fmt.Sprintf("user_s1_%d", idx),
+					"password":    fmt.Sprintf("pass_%d", idx),
+					"nickname":    fmt.Sprintf("name_%d", idx),
+					"create_time": gtime.Now().String(),
+				})
+			}(i)
+
+			// Insert to table2
+			go func(idx int) {
+				defer wg.Done()
+				_, errs2[idx] = db.Model(table2).Insert(g.Map{
+					"passport":    fmt.Sprintf("user_s2_%d", idx),
+					"password":    fmt.Sprintf("pass_%d", idx),
+					"nickname":    fmt.Sprintf("name_%d", idx),
+					"create_time": gtime.Now().String(),
+				})
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < concurrency; i++ {
+			t.AssertNil(errs1[i])
+			t.AssertNil(errs2[i])
+		}
+
+		// Verify both tables
+		count1, err := db.Model(table1).Count()
+		t.AssertNil(err)
+		t.Assert(count1, concurrency)
+
+		count2, err := db.Model(table2).Count()
+		t.AssertNil(err)
+		t.Assert(count2, concurrency)
+	})
+}
+
+// Test_Concurrent_Model_Clone tests concurrent model cloning.
+func Test_Concurrent_Model_Clone(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			baseModel   = db.Model(table).Where("id>", 0)
+			wg          sync.WaitGroup
+			concurrency = 20
+			errs        = make([]error, concurrency)
+			counts      = make([]int, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				// Clone model for each goroutine
+				result, err := baseModel.Clone().Where("id<=", TableSize/2).All()
+				errs[idx] = err
+				counts[idx] = len(result)
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < concurrency; i++ {
+			t.AssertNil(errs[i])
+			// Cloning must not let the goroutines leak conditions into each other,
+			// so every clone sees exactly the same row set.
+			t.Assert(counts[i], TableSize/2)
+		}
+	})
+}
+
+// Test_Concurrent_Batch_Insert tests concurrent batch insert operations.
+func Test_Concurrent_Batch_Insert(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			wg          sync.WaitGroup
+			concurrency = 5
+			batchSize   = 10
+			errs        = make([]error, concurrency)
+		)
+		wg.Add(concurrency)
+		for i := 0; i < concurrency; i++ {
+			go func(idx, batchId int) {
+				defer wg.Done()
+				batch := make([]g.Map, 0, batchSize)
+				for j := 0; j < batchSize; j++ {
+					id := batchId*batchSize + j
+					batch = append(batch, g.Map{
+						"passport":    fmt.Sprintf("batch_user_%d", id),
+						"password":    fmt.Sprintf("pass_%d", id),
+						"nickname":    fmt.Sprintf("name_%d", id),
+						"create_time": gtime.Now().String(),
+					})
+				}
+				_, errs[idx] = db.Model(table).Data(batch).Insert()
+			}(i, i)
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			t.AssertNil(err)
+		}
+
+		// Verify all batch inserts
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, concurrency*batchSize)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_concurrent_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_concurrent_test.go
@@ -193,58 +193,83 @@ func Test_Concurrent_Transaction(t *testing.T) {
 }
 
 // Test_Concurrent_Mixed_Operations tests mixed concurrent operations.
-// Individual operation errors are tolerated here: the interleaved inserts and
-// updates race by design, so the assertion is that the database stays consistent
-// and reachable afterwards rather than that every operation succeeded.
 func Test_Concurrent_Mixed_Operations(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)
 
 	gtest.C(t, func(t *gtest.T) {
+		// createInitTable seeds its rows with explicit ids, which leaves the bigserial
+		// sequence at its initial value. Advance it past the seeded rows so the inserts
+		// below cannot collide with them and every operation is expected to succeed.
+		_, err := db.Exec(ctx, fmt.Sprintf(
+			`SELECT setval(pg_get_serial_sequence('%s', 'id'), %d)`, table, TableSize,
+		))
+		t.AssertNil(err)
+
 		var (
 			wg         sync.WaitGroup
 			operations = 30
+			inserts    int
+			errs       = make([]error, operations)
+			queried    = make([]gdb.Record, operations)
+			// Row id -> the nickname its updater writes. The schedule below gives every
+			// seeded row exactly one updater, so each write is deterministically visible.
+			updated = make(map[int]string)
 		)
 		wg.Add(operations)
 		for i := 0; i < operations; i++ {
 			switch i % 3 {
 			case 0: // Insert
-				go func(id int) {
+				inserts++
+				go func(idx, id int) {
 					defer wg.Done()
-					_, _ = db.Model(table).Insert(g.Map{
+					_, errs[idx] = db.Model(table).Insert(g.Map{
 						"passport":    fmt.Sprintf("new_user_%d", id),
 						"password":    fmt.Sprintf("new_pass_%d", id),
 						"nickname":    fmt.Sprintf("new_name_%d", id),
 						"create_time": gtime.Now().String(),
 					})
-				}(i)
+				}(i, i)
 			case 1: // Update
-				go func(id int) {
+				updated[(i%TableSize)+1] = fmt.Sprintf("concurrent_%d", i)
+				go func(idx, id int) {
 					defer wg.Done()
-					_, _ = db.Model(table).Data(g.Map{
+					_, errs[idx] = db.Model(table).Data(g.Map{
 						"nickname": fmt.Sprintf("concurrent_%d", id),
 					}).Where("id", (id%TableSize)+1).Update()
-				}(i)
+				}(i, i)
 			case 2: // Query
-				go func(id int) {
+				go func(idx, id int) {
 					defer wg.Done()
-					_, _ = db.Model(table).Where("id", (id%TableSize)+1).One()
-				}(i)
+					queried[idx], errs[idx] = db.Model(table).Where("id", (id%TableSize)+1).One()
+				}(i, i)
 			}
 		}
 		wg.Wait()
 
-		// Verify database is still consistent.
-		// Use AssertGE: concurrent inserts may conflict with the bigserial sequence,
-		// which createInitTable's explicit id inserts do not advance.
+		// Every operation succeeded, and each query returned the row it asked for.
+		for i, err := range errs {
+			t.AssertNil(err)
+			if i%3 == 2 {
+				t.AssertNE(queried[i], nil)
+				t.Assert(queried[i]["id"].Int(), (i%TableSize)+1)
+			}
+		}
+
+		// Every insert landed, so the row count is exact rather than a lower bound.
 		count, err := db.Model(table).Count()
 		t.AssertNil(err)
-		t.AssertGE(count, TableSize)
+		t.Assert(count, TableSize+inserts)
 
-		// The pre-existing rows are all still readable.
+		// The pre-existing rows are all still readable, and each carries the nickname
+		// written by its concurrent updater.
 		all, err := db.Model(table).Where("id<=?", TableSize).Order("id").All()
 		t.AssertNil(err)
 		t.Assert(len(all), TableSize)
+		t.Assert(len(updated), TableSize)
+		for _, v := range all {
+			t.Assert(v["nickname"].String(), updated[v["id"].Int()])
+		}
 	})
 }
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_duplicate_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_duplicate_test.go
@@ -1,0 +1,323 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+// Note: GaussDB has no `ON CONFLICT`; it provides the MySQL-compatible
+// `ON DUPLICATE KEY UPDATE col = VALUES(col)` instead. `VALUES(col)` is only
+// accepted as the direct right-hand side of an assignment, so conditional
+// upserts use MERGE.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+func createDuplicateTable(table ...string) string {
+	var name string
+	if len(table) > 0 {
+		name = table[0]
+	} else {
+		name = fmt.Sprintf(`duplicate_table_%d`, gtime.TimestampNano())
+	}
+	dropTable(name)
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id          bigserial NOT NULL,
+			email       varchar(100) NOT NULL,
+			username    varchar(45) NULL,
+			score       integer DEFAULT 0,
+			login_count integer DEFAULT 0,
+			PRIMARY KEY (id),
+			CONSTRAINT uk_email_%s UNIQUE (email)
+		);
+	`, name, name)); err != nil {
+		gtest.Fatal(err)
+	}
+	return name
+}
+
+func Test_OnDuplicateKeyUpdate_Basic(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		stmt := fmt.Sprintf(
+			"INSERT INTO %s (email, username, score) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE username = VALUES(username), score = VALUES(score)",
+			table,
+		)
+
+		// First insert
+		_, err := db.Exec(ctx, stmt, "user1@example.com", "user1", 100)
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1")
+		t.Assert(one["score"], 100)
+
+		// Duplicate insert - should update
+		_, err = db.Exec(ctx, stmt, "user1@example.com", "user1_updated", 200)
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1_updated")
+		t.Assert(one["score"], 200)
+
+		// Verify only one record exists
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+func Test_OnDuplicateKeyUpdate_Increment(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		stmt := fmt.Sprintf(
+			"INSERT INTO %s (email, username, login_count) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE login_count = login_count + 1",
+			table,
+		)
+
+		// First insert
+		_, err := db.Exec(ctx, stmt, "user1@example.com", "user1", 1)
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["login_count"], 1)
+
+		// Duplicate - increment login_count
+		_, err = db.Exec(ctx, stmt, "user1@example.com", "user1", 1)
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["login_count"], 2)
+
+		// Third time
+		_, err = db.Exec(ctx, stmt, "user1@example.com", "user1", 1)
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["login_count"], 3)
+	})
+}
+
+func Test_OnDuplicateKeyUpdate_MultipleColumns(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		stmt := fmt.Sprintf(
+			"INSERT INTO %s (email, username, score, login_count) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE username = VALUES(username), score = VALUES(score), login_count = login_count + 1",
+			table,
+		)
+
+		// First insert
+		_, err := db.Exec(ctx, stmt, "user1@example.com", "user1", 100, 1)
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1")
+		t.Assert(one["score"], 100)
+		t.Assert(one["login_count"], 1)
+
+		// Duplicate - update multiple columns
+		_, err = db.Exec(ctx, stmt, "user1@example.com", "user1_v2", 200, 1)
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1_v2")
+		t.Assert(one["score"], 200)
+		t.Assert(one["login_count"], 2)
+	})
+}
+
+func Test_OnDuplicateKeyUpdate_Batch(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Insert multiple records
+		_, err := db.Exec(ctx, fmt.Sprintf(
+			"INSERT INTO %s (email, username, score) VALUES (?, ?, ?), (?, ?, ?), (?, ?, ?) ON DUPLICATE KEY UPDATE username = VALUES(username), score = VALUES(score)",
+			table,
+		), "user1@example.com", "user1", 100,
+			"user2@example.com", "user2", 200,
+			"user3@example.com", "user3", 300)
+		t.AssertNil(err)
+
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 3)
+
+		// Update with duplicate - should update specific records
+		_, err = db.Exec(ctx, fmt.Sprintf(
+			"INSERT INTO %s (email, username, score) VALUES (?, ?, ?), (?, ?, ?) ON DUPLICATE KEY UPDATE username = VALUES(username), score = VALUES(score)",
+			table,
+		), "user1@example.com", "user1_updated", 150,
+			"user2@example.com", "user2_updated", 250)
+		t.AssertNil(err)
+
+		// Still 3 records
+		count, err = db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 3)
+
+		// Verify updates
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1_updated")
+		t.Assert(one["score"], 150)
+
+		one, err = db.Model(table).Where("email", "user2@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user2_updated")
+		t.Assert(one["score"], 250)
+
+		// user3 unchanged
+		one, err = db.Model(table).Where("email", "user3@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user3")
+		t.Assert(one["score"], 300)
+	})
+}
+
+func Test_OnDuplicateKeyUpdate_ConditionalUpdate(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// VALUES(col) cannot be nested in an expression, so MERGE expresses the
+		// "keep the larger score" semantics instead.
+		stmt := fmt.Sprintf(`
+			MERGE INTO %s t
+			USING (SELECT ?::varchar AS email, ?::varchar AS username, ?::integer AS score) src
+			ON (t.email = src.email)
+			WHEN MATCHED THEN
+				UPDATE SET score = GREATEST(src.score, t.score)
+			WHEN NOT MATCHED THEN
+				INSERT (email, username, score) VALUES (src.email, src.username, src.score)`,
+			table,
+		)
+
+		// First insert
+		_, err := db.Exec(ctx, stmt, "user1@example.com", "user1", 100)
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["score"], 100)
+
+		// Try to update with lower score - should not update
+		_, err = db.Exec(ctx, stmt, "user1@example.com", "user1", 50)
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["score"], 100) // Still 100
+
+		// Update with higher score - should update
+		_, err = db.Exec(ctx, stmt, "user1@example.com", "user1", 150)
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["score"], 150) // Updated to 150
+	})
+}
+
+func Test_OnDuplicateKeyUpdate_WithTransaction(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		stmt := fmt.Sprintf(
+			"INSERT INTO %s (email, username, score) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE username = VALUES(username), score = VALUES(score)",
+			table,
+		)
+
+		err := db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			// First insert
+			_, err := tx.Exec(stmt, "user1@example.com", "user1", 100)
+			if err != nil {
+				return err
+			}
+
+			// Duplicate in same transaction
+			_, err = tx.Exec(stmt, "user1@example.com", "user1_updated", 200)
+			return err
+		})
+		t.AssertNil(err)
+
+		// Verify final state
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1_updated")
+		t.Assert(one["score"], 200)
+
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+func Test_OnDuplicateKeyUpdate_MixedInsertUpdate(t *testing.T) {
+	table := createDuplicateTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		stmt := fmt.Sprintf(
+			"INSERT INTO %s (email, username, score) VALUES (?, ?, ?), (?, ?, ?) ON DUPLICATE KEY UPDATE username = VALUES(username), score = VALUES(score)",
+			table,
+		)
+
+		// First batch insert
+		_, err := db.Exec(ctx, stmt,
+			"user1@example.com", "user1", 100,
+			"user2@example.com", "user2", 200)
+		t.AssertNil(err)
+
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 2)
+
+		// Mixed batch: one duplicate, one new
+		_, err = db.Exec(ctx, stmt,
+			"user1@example.com", "user1_updated", 150,
+			"user3@example.com", "user3", 300)
+		t.AssertNil(err)
+
+		// Should have 3 records now
+		count, err = db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 3)
+
+		// Verify user1 was updated
+		one, err := db.Model(table).Where("email", "user1@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user1_updated")
+		t.Assert(one["score"], 150)
+
+		// Verify user3 was inserted
+		one, err = db.Model(table).Where("email", "user3@example.com").One()
+		t.AssertNil(err)
+		t.Assert(one["username"], "user3")
+		t.Assert(one["score"], 300)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_error_handling_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_error_handling_test.go
@@ -1,0 +1,494 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/errors/gerror"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_Model_Insert_NilData tests Insert with nil data.
+func Test_Model_Insert_NilData(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(nil).Insert()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Insert_EmptyMap tests Insert with empty map.
+func Test_Model_Insert_EmptyMap(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{}).Insert()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Insert_EmptySlice tests Insert with empty slice.
+func Test_Model_Insert_EmptySlice(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Slice{}).Insert()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Update_NilData tests Update with nil data.
+func Test_Model_Update_NilData(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(nil).Where("id", 1).Update()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Update_EmptyData tests Update with empty data.
+func Test_Model_Update_EmptyData(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{}).Where("id", 1).Update()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Update_NoWhere tests Update without WHERE clause is rejected by framework.
+func Test_Model_Update_NoWhere(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Framework safety check: Update without WHERE should return error
+		_, err := db.Model(table).Data(g.Map{"nickname": "updated"}).Update()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Delete_NoWhere tests Delete without WHERE clause is rejected by framework.
+func Test_Model_Delete_NoWhere(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Framework safety check: Delete without WHERE should return error
+		_, err := db.Model(table).Delete()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Scan_NilPointer tests Scan with nil pointer.
+func Test_Model_Scan_NilPointer(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		err := db.Model(table).Where("id", 1).Scan(nil)
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Scan_InvalidPointer tests Scan with invalid pointer type.
+func Test_Model_Scan_InvalidPointer(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var str string
+		err := db.Model(table).Where("id", 1).Scan(&str)
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Scan_EmptyResult tests Scan with empty result.
+func Test_Model_Scan_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id int
+	}
+
+	// Scan initialized struct with empty result returns sql.ErrNoRows
+	gtest.C(t, func(t *gtest.T) {
+		var user User
+		err := db.Model(table).Where("id > ?", 1000).Scan(&user)
+		t.AssertNE(err, nil)
+	})
+
+	// Scan nil pointer with empty result returns nil error
+	gtest.C(t, func(t *gtest.T) {
+		var user *User
+		err := db.Model(table).Where("id > ?", 1000).Scan(&user)
+		t.AssertNil(err)
+		t.Assert(user, nil)
+	})
+}
+
+// Test_Model_Where_InvalidOperator tests Where with invalid operator.
+func Test_Model_Where_InvalidOperator(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Invalid SQL should cause error at query time
+		_, err := db.Model(table).Where("id INVALID_OP ?", 1).All()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Where_EmptyString tests Where with empty string.
+func Test_Model_Where_EmptyString(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Where("").All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize) // Empty WHERE returns all
+	})
+}
+
+// Test_Model_Fields_InvalidField tests Fields with non-existent field.
+func Test_Model_Fields_InvalidField(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Fields("non_existent_field").All()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Fields_Empty tests Fields with empty string.
+// Regression test for #4697: Fields("") should handle empty string gracefully.
+// https://github.com/gogf/gf/issues/4697
+func Test_Model_Fields_Empty(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Fields("").Limit(1).All()
+		t.AssertNil(err)
+		t.AssertLE(len(result), 1)
+	})
+}
+
+// Test_Model_Order_InvalidSyntax tests Order with invalid syntax.
+func Test_Model_Order_InvalidSyntax(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Invalid ORDER BY syntax
+		_, err := db.Model(table).Order("id INVALID").All()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Group_UnknownColumn tests Group with non-existent column.
+func Test_Model_Group_UnknownColumn(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Group("non_existent_field").All()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_TableNotExist tests querying non-existent table.
+func Test_Model_TableNotExist(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model("non_existent_table_xyz").All()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_InvalidTableName tests invalid table name.
+func Test_Model_InvalidTableName(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		// Empty table name
+		_, err := db.Model("").All()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_SQLInjection_Where tests SQL injection prevention in Where.
+func Test_Model_SQLInjection_Where(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Attempt SQL injection through string column parameter.
+		maliciousInput := "1 OR 1=1"
+		result, err := db.Model(table).Where("nickname = ?", maliciousInput).All()
+		t.AssertNil(err)
+		t.Assert(len(result), 0) // Should not return all records
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Attempt SQL injection with quotes, using string column.
+		maliciousInput := "1'; DROP TABLE " + table + "; --"
+		result, err := db.Model(table).Where("nickname = ?", maliciousInput).All()
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+		// Table should still exist
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, TableSize)
+	})
+}
+
+// Test_Model_SQLInjection_Insert tests SQL injection prevention in Insert.
+func Test_Model_SQLInjection_Insert(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		maliciousData := g.Map{
+			"id":          1,
+			"passport":    "'; DROP TABLE " + table + "; --",
+			"password":    "pwd",
+			"nickname":    "test",
+			"create_time": gtime.Now().String(),
+		}
+		_, err := db.Model(table).Data(maliciousData).Insert()
+		t.AssertNil(err)
+
+		// Verify data was inserted correctly and table still exists
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.AssertNE(one, nil)
+		t.Assert(one["passport"].String(), "'; DROP TABLE "+table+"; --")
+	})
+}
+
+// Test_Model_SQLInjection_Update tests SQL injection prevention in Update.
+func Test_Model_SQLInjection_Update(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		maliciousData := g.Map{
+			"nickname": "'; DELETE FROM users; --",
+		}
+		_, err := db.Model(table).Data(maliciousData).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Verify only one record was updated (parameterized query prevents injection)
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"].String(), "'; DELETE FROM users; --")
+
+		// Other records should still exist (injection was prevented)
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, TableSize)
+	})
+}
+
+// Test_Model_Context_Cancelled tests query with cancelled context.
+func Test_Model_Context_Cancelled(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err := db.Model(table).Ctx(ctx).All()
+		t.AssertNE(err, nil)
+		t.Assert(gerror.Is(err, context.Canceled), true)
+	})
+}
+
+// Test_Model_Value_EmptyResult tests Value with empty result.
+func Test_Model_Value_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Where("id > ?", 1000).Value()
+		t.AssertNil(err)
+		t.Assert(value.IsEmpty(), true)
+	})
+}
+
+// Test_Model_Array_EmptyResult tests Array with empty result.
+func Test_Model_Array_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		array, err := db.Model(table).Where("id > ?", 1000).Array()
+		t.AssertNil(err)
+		t.Assert(len(array), 0)
+	})
+}
+
+// Test_Model_Count_InvalidTable tests Count on invalid table.
+func Test_Model_Count_InvalidTable(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model("non_existent_table").Count()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_Max_EmptyResult tests Max with empty result.
+func Test_Model_Max_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Where("id > ?", 1000).Max("id")
+		t.AssertNil(err)
+		t.Assert(value, 0) // Returns 0 for empty result
+	})
+}
+
+// Test_Model_Min_EmptyResult tests Min with empty result.
+func Test_Model_Min_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Where("id > ?", 1000).Min("id")
+		t.AssertNil(err)
+		t.Assert(value, 0) // Returns 0 for empty result
+	})
+}
+
+// Test_Model_Avg_EmptyResult tests Avg with empty result.
+func Test_Model_Avg_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Where("id > ?", 1000).Avg("id")
+		t.AssertNil(err)
+		t.Assert(value, 0) // Returns 0 for empty result
+	})
+}
+
+// Test_Model_Sum_EmptyResult tests Sum with empty result.
+func Test_Model_Sum_EmptyResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Where("id > ?", 1000).Sum("id")
+		t.AssertNil(err)
+		t.Assert(value, 0) // Returns 0 for empty result
+	})
+}
+
+// Test_Model_One_NilResult tests One returning nil.
+func Test_Model_One_NilResult(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Where("id > ?", 1000).One()
+		t.AssertNil(err)
+		t.Assert(one, nil)
+	})
+}
+
+// Test_TX_Rollback_AfterError tests transaction rollback after error.
+func Test_TX_Rollback_AfterError(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		err := db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			// Insert valid record
+			_, err := tx.Model(table).Data(g.Map{
+				"id":          1,
+				"passport":    "pass1",
+				"password":    "pwd1",
+				"nickname":    "name1",
+				"create_time": gtime.Now().String(),
+			}).Insert()
+			if err != nil {
+				return err
+			}
+
+			// Insert duplicate id (should fail)
+			_, err = tx.Model(table).Data(g.Map{
+				"id":          1, // Duplicate
+				"passport":    "pass2",
+				"password":    "pwd2",
+				"nickname":    "name2",
+				"create_time": gtime.Now().String(),
+			}).Insert()
+
+			return err // Return error to trigger rollback
+		})
+
+		t.AssertNE(err, nil)
+
+		// Verify rollback - table should be empty
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 0)
+	})
+}
+
+// Test_Model_Insert_DuplicateKey tests handling of duplicate key error.
+func Test_Model_Insert_DuplicateKey(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		data := g.Map{
+			"id":          1,
+			"passport":    "pass",
+			"password":    "pwd",
+			"nickname":    "name",
+			"create_time": gtime.Now().String(),
+		}
+
+		// First insert should succeed
+		_, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+
+		// Second insert with same id should fail
+		_, err = db.Model(table).Data(data).Insert()
+		t.AssertNE(err, nil)
+	})
+}
+
+// Test_Model_All_InvalidConnection tests query with invalid connection.
+func Test_Model_All_InvalidConnection(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		invalidDB, err := gdb.New(gdb.ConfigNode{
+			Link:      `gaussdb:gaussdb:WrongPassword@1234@tcp(127.0.0.1:9950)/postgres`,
+			Namespace: SchemaName,
+		})
+		t.AssertNil(err)
+
+		// The connection opens lazily, so credentials are rejected on first query.
+		_, err = invalidDB.Model("test_table").All()
+		t.AssertNE(err, nil)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_error_handling_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_error_handling_test.go
@@ -189,7 +189,9 @@ func Test_Model_Fields_Empty(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		result, err := db.Model(table).Fields("").Limit(1).All()
 		t.AssertNil(err)
-		t.AssertLE(len(result), 1)
+		// An empty Fields must behave as SELECT *, not as "no columns".
+		t.Assert(len(result), 1)
+		t.Assert(len(result[0]), 9)
 	})
 }
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_gaussdb_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_gaussdb_test.go
@@ -341,7 +341,8 @@ func Test_GaussDB_Returning_Insert_Batch(t *testing.T) {
 	})
 }
 
-// Test_GaussDB_Returning_Upsert tests INSERT ... ON CONFLICT ... RETURNING (Save).
+// Test_GaussDB_Returning_Upsert tests Save() returning the row id.
+// GaussDB has no ON CONFLICT; the driver emits a MERGE statement.
 func Test_GaussDB_Returning_Upsert(t *testing.T) {
 	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_upsert", gtime.TimestampNano())
 	if _, err := db.Exec(ctx, fmt.Sprintf(`

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_gaussdb_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_gaussdb_test.go
@@ -1,0 +1,954 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/text/gstr"
+)
+
+// =============================================================================
+// Layer 3: JSONB operator integration tests
+// =============================================================================
+
+// Test_GaussDB_JSONB_Arrow_Operator tests the -> and ->> operators for JSONB field access.
+func Test_GaussDB_JSONB_Arrow_Operator(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_arrow", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			data jsonb
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Insert test data
+		for i := 1; i <= 5; i++ {
+			_, err := db.Model(table).Data(g.Map{
+				"data": g.Map{
+					"name": fmt.Sprintf("user_%d", i),
+					"age":  20 + i,
+					"tags": g.Slice{"go", "gaussdb"},
+				},
+			}).Insert()
+			t.AssertNil(err)
+		}
+
+		// -> returns jsonb (with quotes for strings)
+		one, err := db.Model(table).Fields("data->'name' as name_json").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["name_json"].String(), `"user_1"`)
+
+		// ->> returns text (without quotes)
+		one, err = db.Model(table).Fields("data->>'name' as name_text").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["name_text"].String(), "user_1")
+
+		// Nested -> for array element
+		one, err = db.Model(table).Fields("data->'tags'->0 as first_tag").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["first_tag"].String(), `"go"`)
+	})
+}
+
+// Test_GaussDB_JSONB_Contains tests the @> (contains) and <@ (contained by) operators.
+func Test_GaussDB_JSONB_Contains(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_contains", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			data jsonb
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"data": `{"name":"alice","role":"admin","level":5}`}).Insert()
+		t.AssertNil(err)
+		_, err = db.Model(table).Data(g.Map{"data": `{"name":"bob","role":"user","level":1}`}).Insert()
+		t.AssertNil(err)
+		_, err = db.Model(table).Data(g.Map{"data": `{"name":"charlie","role":"admin","level":3}`}).Insert()
+		t.AssertNil(err)
+
+		// @> contains: find admins
+		all, err := db.Model(table).Where("data @> ?", `{"role":"admin"}`).OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+		t.Assert(all[0]["data"].Map()["name"], "alice")
+		t.Assert(all[1]["data"].Map()["name"], "charlie")
+
+		// <@ contained by
+		count, err := db.Model(table).Where("? <@ data", `{"role":"user"}`).Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+// Test_GaussDB_JSONB_Existence tests the ? (key existence) operator.
+func Test_GaussDB_JSONB_Existence(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_exist", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			data jsonb
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"data": `{"name":"alice","email":"a@b.com"}`}).Insert()
+		t.AssertNil(err)
+		_, err = db.Model(table).Data(g.Map{"data": `{"name":"bob"}`}).Insert()
+		t.AssertNil(err)
+
+		// jsonb_exists is the function form of the ? key-existence operator.
+		// We use it here because GoFrame's DoFilter replaces bare ? with $N placeholders.
+		result, err := db.GetValue(ctx, fmt.Sprintf(
+			`SELECT COUNT(*) FROM %s WHERE jsonb_exists(data, 'email')`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(result.Int(), 1)
+	})
+}
+
+// Test_GaussDB_JSONB_Path tests indexing into a nested jsonb document.
+// GaussDB has no SQL/JSON path functions, so -> is used instead.
+func Test_GaussDB_JSONB_Path(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_path", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			data jsonb
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": `{"users":[{"name":"alice","age":30},{"name":"bob","age":25}]}`,
+		}).Insert()
+		t.AssertNil(err)
+
+		// -> keeps the jsonb representation, so the value stays quoted.
+		one, err := db.Model(table).Fields(
+			`data->'users'->0->'name' as first_name`,
+		).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["first_name"].String(), `"alice"`)
+
+		// ->> extracts the same value as text.
+		one, err = db.Model(table).Fields(
+			`data->'users'->1->>'name' as second_name`,
+		).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["second_name"].String(), "bob")
+	})
+}
+
+// Test_GaussDB_JSONB_Concat tests merging a key into an existing jsonb document.
+// GaussDB has no `jsonb || jsonb` operator, so jsonb_set is used instead.
+func Test_GaussDB_JSONB_Concat(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_concat", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			data jsonb
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"data": `{"name":"alice"}`}).Insert()
+		t.AssertNil(err)
+
+		// Merge a new key in via raw SQL update.
+		_, err = db.Exec(ctx, fmt.Sprintf(
+			`UPDATE %s SET data = jsonb_set(data, '{role}', '"admin"', true) WHERE id = 1`, table,
+		))
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		m := one["data"].Map()
+		t.Assert(m["name"], "alice")
+		t.Assert(m["role"], "admin")
+
+		// Setting an existing key overwrites it rather than adding a duplicate.
+		_, err = db.Exec(ctx, fmt.Sprintf(
+			`UPDATE %s SET data = jsonb_set(data, '{role}', '"editor"', true) WHERE id = 1`, table,
+		))
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		m = one["data"].Map()
+		t.Assert(m["role"], "editor")
+		t.Assert(len(m), 2)
+	})
+}
+
+// Test_GaussDB_JSONB_Remove tests the - (key removal) operator.
+func Test_GaussDB_JSONB_Remove(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_remove", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			data jsonb
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"data": `{"name":"alice","age":30,"temp":"remove_me"}`}).Insert()
+		t.AssertNil(err)
+
+		// - key removal operator
+		_, err = db.Exec(ctx, fmt.Sprintf(
+			`UPDATE %s SET data = data - 'temp' WHERE id = 1`, table,
+		))
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		m := one["data"].Map()
+		t.Assert(m["name"], "alice")
+		t.Assert(m["age"], 30)
+		_, hasTmp := m["temp"]
+		t.Assert(hasTmp, false)
+	})
+}
+
+// Test_GaussDB_JSONB_Agg tests the JSON aggregate functions.
+// GaussDB ships the json_* aggregates but not the jsonb_* ones.
+func Test_GaussDB_JSONB_Agg(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"jsonb_agg", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			name varchar(50),
+			score int
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		for i := 1; i <= 3; i++ {
+			_, err := db.Model(table).Data(g.Map{
+				"name":  fmt.Sprintf("user_%d", i),
+				"score": i * 10,
+			}).Insert()
+			t.AssertNil(err)
+		}
+
+		// json_agg: aggregate names into a JSON array
+		one, err := db.Model(table).Fields("json_agg(name) as names").One()
+		t.AssertNil(err)
+		names := one["names"].Strings()
+		t.Assert(len(names), 3)
+
+		// json_object_agg: aggregate into key-value pairs
+		one, err = db.Model(table).Fields("json_object_agg(name, score) as scores").One()
+		t.AssertNil(err)
+		scores := one["scores"].Map()
+		t.Assert(scores["user_1"], 10)
+		t.Assert(scores["user_2"], 20)
+		t.Assert(scores["user_3"], 30)
+	})
+}
+
+// =============================================================================
+// Layer 3: RETURNING clause tests
+// =============================================================================
+
+// Test_GaussDB_Returning_Insert tests INSERT ... RETURNING.
+func Test_GaussDB_Returning_Insert(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_ins", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			name varchar(100),
+			created_at timestamp DEFAULT now()
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// InsertAndGetId uses RETURNING internally for GaussDB
+		id, err := db.Model(table).Data(g.Map{"name": "alice"}).InsertAndGetId()
+		t.AssertNil(err)
+		t.Assert(id, 1)
+
+		id, err = db.Model(table).Data(g.Map{"name": "bob"}).InsertAndGetId()
+		t.AssertNil(err)
+		t.Assert(id, 2)
+
+		// Verify data
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 2)
+	})
+}
+
+// Test_GaussDB_Returning_Insert_Batch tests batch INSERT ... RETURNING.
+func Test_GaussDB_Returning_Insert_Batch(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_batch", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			name varchar(100)
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		data := g.List{
+			{"name": "alice"},
+			{"name": "bob"},
+			{"name": "charlie"},
+		}
+		result, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 3)
+
+		// Verify all inserted
+		all, err := db.Model(table).OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["name"].String(), "alice")
+		t.Assert(all[2]["name"].String(), "charlie")
+	})
+}
+
+// Test_GaussDB_Returning_Upsert tests INSERT ... ON CONFLICT ... RETURNING (Save).
+func Test_GaussDB_Returning_Upsert(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_upsert", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			name varchar(100),
+			value int DEFAULT 0
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// First insert
+		_, err := db.Model(table).Data(g.Map{
+			"id": 1, "name": "alice", "value": 10,
+		}).Save()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["name"].String(), "alice")
+		t.Assert(one["value"].Int(), 10)
+
+		// Upsert: update existing
+		_, err = db.Model(table).Data(g.Map{
+			"id": 1, "name": "alice_updated", "value": 20,
+		}).Save()
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["name"].String(), "alice_updated")
+		t.Assert(one["value"].Int(), 20)
+
+		// Only 1 row total
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+// Test_GaussDB_Returning_CatchSQL verifies CatchSQL captures INSERT ... RETURNING.
+// Regression for a bug where gaussdb/gaussdb DoExec bypassed Core.DoQuery and
+// silently dropped the SQL from CatchSQLManager on InsertAndGetId.
+func Test_GaussDB_Returning_CatchSQL(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_catchsql", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			name varchar(100)
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		sqlArray, err := gdb.CatchSQL(ctx, func(ctx context.Context) error {
+			_, e := db.Ctx(ctx).Model(table).Data(g.Map{"name": "alice"}).InsertAndGetId()
+			return e
+		})
+		t.AssertNil(err)
+		t.AssertGT(len(sqlArray), 0)
+		// The captured SQL must contain the RETURNING clause.
+		t.Assert(gstr.Contains(sqlArray[len(sqlArray)-1], `RETURNING "id"`), true)
+		// Insert must have executed (CatchSQL uses DoCommit=true).
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+// Test_GaussDB_Returning_ToSQL verifies ToSQL captures without executing.
+// Regression for a bug where gaussdb/gaussdb DoExec bypassed Core.DoQuery and
+// executed the INSERT even when ToSQL (DoCommit=false) was active.
+func Test_GaussDB_Returning_ToSQL(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_tosql", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			name varchar(100)
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		before, err := db.Model(table).Count()
+		t.AssertNil(err)
+
+		capturedSql, err := gdb.ToSQL(ctx, func(ctx context.Context) error {
+			_, e := db.Ctx(ctx).Model(table).Data(g.Map{"name": "bob"}).InsertAndGetId()
+			return e
+		})
+		t.AssertNil(err)
+		t.AssertNE(capturedSql, "")
+		// Row count must be unchanged — ToSQL must NOT execute.
+		after, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(after, before)
+	})
+}
+
+// =============================================================================
+// Layer 3: CTE (Common Table Expression) tests
+// =============================================================================
+
+// Test_GaussDB_CTE_Basic tests basic WITH ... AS query.
+func Test_GaussDB_CTE_Basic(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		sql := fmt.Sprintf(`
+			WITH top5 AS (
+				SELECT id, nickname FROM %s ORDER BY id ASC LIMIT 5
+			)
+			SELECT * FROM top5 WHERE id > 2
+		`, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), 3) // ids 3, 4, 5
+		t.Assert(all[0]["id"].Int(), 3)
+	})
+}
+
+// Test_GaussDB_CTE_Recursive tests recursive CTE for hierarchical data.
+func Test_GaussDB_CTE_Recursive(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"cte_tree", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id int PRIMARY KEY,
+			parent_id int,
+			name varchar(50)
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Build a tree:  1 -> 2 -> 4
+		//                1 -> 3
+		data := g.List{
+			{"id": 1, "parent_id": nil, "name": "root"},
+			{"id": 2, "parent_id": 1, "name": "child_a"},
+			{"id": 3, "parent_id": 1, "name": "child_b"},
+			{"id": 4, "parent_id": 2, "name": "grandchild"},
+		}
+		_, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+
+		// Recursive CTE to get all descendants of node 1
+		sql := fmt.Sprintf(`
+			WITH RECURSIVE tree AS (
+				SELECT id, parent_id, name, 0 AS depth FROM %s WHERE id = 1
+				UNION ALL
+				SELECT t.id, t.parent_id, t.name, tree.depth + 1
+				FROM %s t JOIN tree ON t.parent_id = tree.id
+			)
+			SELECT * FROM tree ORDER BY depth, id
+		`, table, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), 4)
+		t.Assert(all[0]["name"].String(), "root")
+		t.Assert(all[0]["depth"].Int(), 0)
+		t.Assert(all[3]["name"].String(), "grandchild")
+		t.Assert(all[3]["depth"].Int(), 2)
+	})
+}
+
+// Test_GaussDB_CTE_Update tests CTE used with UPDATE (writable CTE).
+func Test_GaussDB_CTE_Update(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Use CTE to identify rows, then update them
+		sql := fmt.Sprintf(`
+			WITH to_update AS (
+				SELECT id FROM %s WHERE id <= 3
+			)
+			UPDATE %s SET nickname = 'updated'
+			WHERE id IN (SELECT id FROM to_update)
+		`, table, table)
+		_, err := db.Exec(ctx, sql)
+		t.AssertNil(err)
+
+		// Verify
+		all, err := db.Model(table).Where("nickname", "updated").OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["id"].Int(), 1)
+		t.Assert(all[2]["id"].Int(), 3)
+	})
+}
+
+// Test_GaussDB_CTE_Delete tests CTE used with DELETE (writable CTE).
+func Test_GaussDB_CTE_Delete(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Use CTE to identify rows, then delete them
+		sql := fmt.Sprintf(`
+			WITH to_delete AS (
+				SELECT id FROM %s WHERE id > 8
+			)
+			DELETE FROM %s WHERE id IN (SELECT id FROM to_delete)
+		`, table, table)
+		_, err := db.Exec(ctx, sql)
+		t.AssertNil(err)
+
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 8)
+	})
+}
+
+// =============================================================================
+// Layer 3: Window function tests
+// =============================================================================
+
+// Test_GaussDB_Window_RowNumber tests ROW_NUMBER() window function.
+func Test_GaussDB_Window_RowNumber(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		sql := fmt.Sprintf(`
+			SELECT id, nickname, ROW_NUMBER() OVER (ORDER BY id DESC) as rn
+			FROM %s
+		`, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		// id=10 should have rn=1 (ordered desc)
+		t.Assert(all[0]["id"].Int(), 10)
+		t.Assert(all[0]["rn"].Int(), 1)
+	})
+}
+
+// Test_GaussDB_Window_RankDenseRank tests RANK() and DENSE_RANK() window functions.
+func Test_GaussDB_Window_RankDenseRank(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"window_rank", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			dept varchar(20),
+			salary int
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		data := g.List{
+			{"dept": "eng", "salary": 100},
+			{"dept": "eng", "salary": 100},
+			{"dept": "eng", "salary": 200},
+			{"dept": "sales", "salary": 150},
+			{"dept": "sales", "salary": 250},
+		}
+		_, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+
+		sql := fmt.Sprintf(`
+			SELECT dept, salary,
+				RANK() OVER (PARTITION BY dept ORDER BY salary DESC) as rnk,
+				DENSE_RANK() OVER (PARTITION BY dept ORDER BY salary DESC) as dense_rnk
+			FROM %s ORDER BY dept, salary DESC
+		`, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), 5)
+
+		// eng: 200(rank=1), 100(rank=2), 100(rank=2)
+		t.Assert(all[0]["salary"].Int(), 200)
+		t.Assert(all[0]["rnk"].Int(), 1)
+		t.Assert(all[1]["salary"].Int(), 100)
+		t.Assert(all[1]["rnk"].Int(), 2)
+		t.Assert(all[1]["dense_rnk"].Int(), 2)
+	})
+}
+
+// Test_GaussDB_Window_LagLead tests LAG() and LEAD() window functions.
+func Test_GaussDB_Window_LagLead(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		sql := fmt.Sprintf(`
+			SELECT id,
+				LAG(id, 1) OVER (ORDER BY id) as prev_id,
+				LEAD(id, 1) OVER (ORDER BY id) as next_id
+			FROM %s ORDER BY id
+		`, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		// First row: prev_id = NULL
+		t.Assert(all[0]["prev_id"].IsNil() || all[0]["prev_id"].IsEmpty(), true)
+		t.Assert(all[0]["next_id"].Int(), 2)
+		// Last row: next_id = NULL
+		t.Assert(all[9]["prev_id"].Int(), 9)
+		t.Assert(all[9]["next_id"].IsNil() || all[9]["next_id"].IsEmpty(), true)
+	})
+}
+
+// Test_GaussDB_Window_SumOver tests SUM() OVER (cumulative sum).
+func Test_GaussDB_Window_SumOver(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		sql := fmt.Sprintf(`
+			SELECT id, SUM(id) OVER (ORDER BY id) as running_total
+			FROM %s ORDER BY id
+		`, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		// running_total: 1, 3, 6, 10, 15, 21, 28, 36, 45, 55
+		t.Assert(all[0]["running_total"].Int(), 1)
+		t.Assert(all[4]["running_total"].Int(), 15) // 1+2+3+4+5
+		t.Assert(all[9]["running_total"].Int(), 55) // sum(1..10)
+	})
+}
+
+// =============================================================================
+// Layer 3: Array operations tests
+// =============================================================================
+
+// Test_GaussDB_Array_ANY tests the ANY() array operator.
+func Test_GaussDB_Array_ANY(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Use ANY with array literal
+		all, err := db.GetAll(ctx, fmt.Sprintf(
+			`SELECT * FROM %s WHERE id = ANY(ARRAY[2, 5, 8]) ORDER BY id`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["id"].Int(), 2)
+		t.Assert(all[1]["id"].Int(), 5)
+		t.Assert(all[2]["id"].Int(), 8)
+	})
+}
+
+// Test_GaussDB_Array_Contains tests array @> and <@ operators.
+func Test_GaussDB_Array_Contains(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Insert data with array columns
+		_, err := db.Exec(ctx, fmt.Sprintf(
+			`UPDATE %s SET favorite_movie = ARRAY['movie_a', 'movie_b'] WHERE id = 1`, table,
+		))
+		t.AssertNil(err)
+		_, err = db.Exec(ctx, fmt.Sprintf(
+			`UPDATE %s SET favorite_movie = ARRAY['movie_b', 'movie_c'] WHERE id = 2`, table,
+		))
+		t.AssertNil(err)
+
+		// @> contains: find rows where array contains 'movie_a'
+		// Cast ARRAY literal to varchar[] to match the column type (varchar[]).
+		all, err := db.GetAll(ctx, fmt.Sprintf(
+			`SELECT id FROM %s WHERE favorite_movie @> ARRAY['movie_a']::varchar[] ORDER BY id`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+		t.Assert(all[0]["id"].Int(), 1)
+
+		// @> contains: find rows where array contains 'movie_b' (both rows)
+		all, err = db.GetAll(ctx, fmt.Sprintf(
+			`SELECT id FROM %s WHERE favorite_movie @> ARRAY['movie_b']::varchar[] ORDER BY id`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+	})
+}
+
+// Test_GaussDB_Array_Unnest tests array_agg and unnest functions.
+func Test_GaussDB_Array_Unnest(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// array_agg: aggregate column values into array
+		one, err := db.Model(table).Fields("array_agg(id ORDER BY id) as ids").Where("id <= 5").One()
+		t.AssertNil(err)
+		ids := one["ids"].Ints()
+		t.Assert(len(ids), 5)
+		t.Assert(ids[0], 1)
+		t.Assert(ids[4], 5)
+	})
+}
+
+// =============================================================================
+// Layer 3: Full-text search tests
+// =============================================================================
+
+// Test_GaussDB_FullText_Search tests tsvector and tsquery full-text search.
+func Test_GaussDB_FullText_Search(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"fts", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			title varchar(200),
+			body text,
+			tsv tsvector
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Insert documents
+		docs := g.List{
+			{"title": "GaussDB is great", "body": "GaussDB is an advanced open source database"},
+			{"title": "GoFrame ORM", "body": "GoFrame provides powerful ORM features for Go"},
+			{"title": "Database testing", "body": "Testing database drivers is important for GaussDB"},
+		}
+		for _, doc := range docs {
+			_, err := db.Exec(ctx, fmt.Sprintf(
+				`INSERT INTO %s (title, body, tsv) VALUES ('%s', '%s', to_tsvector('english', '%s %s'))`,
+				table, doc["title"], doc["body"], doc["title"], doc["body"],
+			))
+			t.AssertNil(err)
+		}
+
+		// Full-text search for 'GaussDB'
+		all, err := db.GetAll(ctx, fmt.Sprintf(
+			`SELECT id, title FROM %s WHERE tsv @@ to_tsquery('english', 'GaussDB') ORDER BY id`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(len(all), 2) // docs 1 and 3
+		t.Assert(all[0]["title"].String(), "GaussDB is great")
+
+		// Full-text search with AND
+		all, err = db.GetAll(ctx, fmt.Sprintf(
+			`SELECT id, title FROM %s WHERE tsv @@ to_tsquery('english', 'database & testing') ORDER BY id`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+		t.Assert(all[0]["title"].String(), "Database testing")
+	})
+}
+
+// =============================================================================
+// Layer 3: Advanced GaussDB features
+// =============================================================================
+
+// Test_GaussDB_Generate_Series tests generate_series() table-valued function.
+func Test_GaussDB_Generate_Series(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.GetAll(ctx, `SELECT generate_series(1, 5) as n`)
+		t.AssertNil(err)
+		t.Assert(len(all), 5)
+		for i, row := range all {
+			t.Assert(row["n"].Int(), i+1)
+		}
+	})
+}
+
+// Test_GaussDB_Lateral_Join tests LATERAL join.
+func Test_GaussDB_Lateral_Join(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// LATERAL join: for each row, get the next row's id
+		sql := fmt.Sprintf(`
+			SELECT t1.id, t2.next_id
+			FROM %s t1,
+			LATERAL (SELECT id as next_id FROM %s WHERE id = t1.id + 1) t2
+			ORDER BY t1.id
+		`, table, table)
+		all, err := db.GetAll(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(len(all), 9) // ids 1-9 (id=10 has no next)
+		t.Assert(all[0]["id"].Int(), 1)
+		t.Assert(all[0]["next_id"].Int(), 2)
+	})
+}
+
+// Test_GaussDB_Distinct_On tests DISTINCT ON (GaussDB-specific).
+func Test_GaussDB_Distinct_On(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"distinct_on", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			category varchar(20),
+			value int
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		data := g.List{
+			{"category": "A", "value": 10},
+			{"category": "A", "value": 20},
+			{"category": "B", "value": 30},
+			{"category": "B", "value": 40},
+			{"category": "C", "value": 50},
+		}
+		_, err := db.Model(table).Data(data).Insert()
+		t.AssertNil(err)
+
+		// DISTINCT ON: get first row per category (ordered by value desc = max)
+		all, err := db.GetAll(ctx, fmt.Sprintf(`
+			SELECT DISTINCT ON (category) category, value
+			FROM %s ORDER BY category, value DESC
+		`, table))
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["category"].String(), "A")
+		t.Assert(all[0]["value"].Int(), 20)
+		t.Assert(all[1]["category"].String(), "B")
+		t.Assert(all[1]["value"].Int(), 40)
+		t.Assert(all[2]["category"].String(), "C")
+		t.Assert(all[2]["value"].Int(), 50)
+	})
+}
+
+// Test_GaussDB_Explain tests EXPLAIN (ANALYZE) for query plan inspection.
+func Test_GaussDB_Explain(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Just verify EXPLAIN doesn't error out
+		all, err := db.GetAll(ctx, fmt.Sprintf(`EXPLAIN SELECT * FROM %s WHERE id = 1`, table))
+		t.AssertNil(err)
+		t.AssertGT(len(all), 0)
+	})
+}
+
+// Test_GaussDB_Coalesce tests COALESCE function with NULL handling.
+// Uses a dedicated table because the baseline declares nickname NOT NULL.
+func Test_GaussDB_Coalesce(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"coalesce", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial PRIMARY KEY,
+			nickname varchar(45) NULL
+		);`, table)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		for i := 1; i <= TableSize; i++ {
+			_, err := db.Model(table).Data(g.Map{
+				"id":       i,
+				"nickname": fmt.Sprintf("name_%d", i),
+			}).Insert()
+			t.AssertNil(err)
+		}
+
+		// Set some nicknames to NULL
+		_, err := db.Exec(ctx, fmt.Sprintf(`UPDATE %s SET nickname = NULL WHERE id > 5`, table))
+		t.AssertNil(err)
+
+		all, err := db.GetAll(ctx, fmt.Sprintf(
+			`SELECT id, COALESCE(nickname, 'anonymous') as display_name FROM %s ORDER BY id`, table,
+		))
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		t.Assert(all[0]["display_name"].String(), "name_1")
+		t.Assert(all[9]["display_name"].String(), "anonymous")
+	})
+}
+
+// Test_GaussDB_String_Agg tests string_agg aggregate function.
+func Test_GaussDB_String_Agg(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Fields("string_agg(nickname, ',' ORDER BY id) as names").Where("id <= 3").One()
+		t.AssertNil(err)
+		t.Assert(one["names"].String(), "name_1,name_2,name_3")
+	})
+}
+
+// Test_GaussDB_Filter_Clause tests the FILTER (WHERE ...) clause on aggregates.
+func Test_GaussDB_Filter_Clause(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		sql := fmt.Sprintf(`
+			SELECT
+				COUNT(*) as total,
+				COUNT(*) FILTER (WHERE id <= 5) as first_half,
+				COUNT(*) FILTER (WHERE id > 5) as second_half
+			FROM %s
+		`, table)
+		one, err := db.GetOne(ctx, sql)
+		t.AssertNil(err)
+		t.Assert(one["total"].Int(), 10)
+		t.Assert(one["first_half"].Int(), 5)
+		t.Assert(one["second_half"].Int(), 5)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_lock_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_lock_test.go
@@ -1,0 +1,217 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_Model_Lock tests the Lock method with custom lock clause.
+// GaussDB is PostgreSQL-compatible: it uses "FOR SHARE" rather than
+// MySQL's legacy "LOCK IN SHARE MODE".
+func Test_Model_Lock(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test basic Lock with FOR UPDATE
+		one, err := db.Model(table).Lock("FOR UPDATE").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 1)
+
+		// Test Lock with FOR SHARE
+		one, err = db.Model(table).Lock(gdb.LockForShare).Where("id", 3).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 3)
+
+		// Test Lock with predefined constants
+		one, err = db.Model(table).Lock(gdb.LockForUpdate).Where("id", 4).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 4)
+	})
+}
+
+// Test_Model_LockUpdate tests the LockUpdate convenience method.
+func Test_Model_LockUpdate(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test LockUpdate is equivalent to Lock("FOR UPDATE")
+		one, err := db.Model(table).LockUpdate().Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 1)
+		t.Assert(one["passport"], "user_1")
+
+		// Test LockUpdate with All()
+		all, err := db.Model(table).LockUpdate().Where("id<?", 4).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[2]["id"], 3)
+	})
+}
+
+// Test_Model_LockShared tests the LockShared convenience method.
+// GaussDB LockShared uses Driver.GetLockSharedClause() → "FOR SHARE".
+func Test_Model_LockShared(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test LockShared basic usage
+		one, err := db.Model(table).LockShared().Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 1)
+
+		// Test LockShared with All()
+		all, err := db.Model(table).LockShared().Where("id<=?", 5).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 5)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[4]["id"], 5)
+	})
+}
+
+// Test_Model_LockSharedClause verifies the driver emits the PostgreSQL-style
+// shared lock clause rather than the MySQL default inherited from Core.
+func Test_Model_LockSharedClause(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		t.Assert(db.GetLockSharedClause(), gdb.LockForShare)
+	})
+}
+
+// Test_Model_Lock_WithTransaction tests Lock methods within transaction.
+func Test_Model_Lock_WithTransaction(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		err := db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			// Lock row for update in transaction
+			one, err := tx.Model(table).LockUpdate().Where("id", 1).One()
+			t.AssertNil(err)
+			t.Assert(one["id"], 1)
+
+			// Update the locked row
+			_, err = tx.Model(table).Data(g.Map{"nickname": "updated_name"}).Where("id", 1).Update()
+			t.AssertNil(err)
+
+			// Verify update
+			updated, err := tx.Model(table).Where("id", 1).One()
+			t.AssertNil(err)
+			t.Assert(updated["nickname"], "updated_name")
+
+			return nil
+		})
+		t.AssertNil(err)
+
+		// Verify transaction committed successfully
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "updated_name")
+	})
+}
+
+// Test_Model_Lock_ReleaseAfterCommit tests lock is released after transaction commit.
+func Test_Model_Lock_ReleaseAfterCommit(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Start transaction and lock a row
+		tx, err := db.Begin(ctx)
+		t.AssertNil(err)
+
+		one, err := tx.Model(table).LockUpdate().Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 1)
+
+		// Update within transaction
+		_, err = tx.Model(table).Data(g.Map{"nickname": "tx_update"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Commit transaction - this should release the lock
+		err = tx.Commit()
+		t.AssertNil(err)
+
+		// Another query should succeed without blocking
+		one, err = db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "tx_update")
+	})
+}
+
+// Test_Model_Lock_ReleaseAfterRollback tests lock is released after transaction rollback.
+func Test_Model_Lock_ReleaseAfterRollback(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Start transaction and lock a row
+		tx, err := db.Begin(ctx)
+		t.AssertNil(err)
+
+		one, err := tx.Model(table).LockUpdate().Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["id"], 1)
+
+		// Update within transaction
+		_, err = tx.Model(table).Data(g.Map{"nickname": "rollback_update"}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		// Rollback transaction - this should release the lock and discard changes
+		err = tx.Rollback()
+		t.AssertNil(err)
+
+		// Verify original value is preserved
+		one, err = db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "name_1")
+	})
+}
+
+// Test_Model_Lock_ChainedMethods tests Lock with other chained methods.
+func Test_Model_Lock_ChainedMethods(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Lock with Fields
+		one, err := db.Model(table).Fields("id,passport").LockUpdate().Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 2)
+		t.Assert(one["id"], 1)
+		t.Assert(one["passport"], "user_1")
+
+		// Lock with Order and Limit
+		all, err := db.Model(table).LockShared().Where("id>?", 5).Order("id desc").Limit(3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["id"], 10)
+		t.Assert(all[2]["id"], 8)
+
+		// Lock with Group and Having.
+		// GaussDB note: row locks are not permitted with GROUP BY, so the grouped case runs
+		// without a lock clause to preserve the shape of the test (fields/group/having/order).
+		// GaussDB HAVING cannot reference SELECT aliases; use the aggregate expression directly.
+		all, err = db.Model(table).Fields("LEFT(passport,4) as prefix, COUNT(*) as cnt").
+			Group("prefix").
+			Having("COUNT(*)>?", 0).
+			Order("prefix").
+			All()
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+		t.Assert(all[0]["prefix"], "user")
+		t.Assert(all[0]["cnt"], 10)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_metadata_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_metadata_test.go
@@ -1,0 +1,153 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_TableFields_Basic tests basic TableFields functionality.
+func Test_TableFields_Basic(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		fields, err := db.TableFields(ctx, table)
+		t.AssertNil(err)
+		t.AssertGT(len(fields), 0)
+
+		// Verify common fields exist
+		_, ok := fields["id"]
+		t.Assert(ok, true)
+		_, ok = fields["passport"]
+		t.Assert(ok, true)
+		_, ok = fields["password"]
+		t.Assert(ok, true)
+		_, ok = fields["nickname"]
+		t.Assert(ok, true)
+		_, ok = fields["create_time"]
+		t.Assert(ok, true)
+	})
+}
+
+// Test_TableFields_Schema tests TableFields with explicit schema.
+// GaussDB uses the shared SchemaName ("test") declared in gaussdb_z_unit_init_test.go.
+func Test_TableFields_Schema(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		fields, err := db.TableFields(ctx, table, SchemaName)
+		t.AssertNil(err)
+		t.AssertGT(len(fields), 0)
+
+		// Verify field properties
+		idField, ok := fields["id"]
+		t.Assert(ok, true)
+		t.Assert(idField.Name, "id")
+		t.AssertGE(idField.Index, 0)
+	})
+}
+
+// Test_TableFields_NotExistTable tests TableFields against a missing table.
+// GaussDB resolves the table via '<table>'::regclass, so a missing table
+// surfaces as an error rather than an empty field map.
+func Test_TableFields_NotExistTable(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		fields, err := db.TableFields(ctx, "table_not_exist_for_metadata_test")
+		t.AssertNE(err, nil)
+		t.Assert(len(fields), 0)
+	})
+}
+
+// Test_HasField_Positive tests HasField for existing fields.
+func Test_HasField_Positive(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		has, err := db.GetCore().HasField(ctx, table, "id")
+		t.AssertNil(err)
+		t.Assert(has, true)
+
+		has, err = db.GetCore().HasField(ctx, table, "passport")
+		t.AssertNil(err)
+		t.Assert(has, true)
+	})
+}
+
+// Test_HasField_Negative tests HasField for non-existent field.
+func Test_HasField_Negative(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		has, err := db.GetCore().HasField(ctx, table, "non_exist_field")
+		t.AssertNil(err)
+		t.Assert(has, false)
+	})
+}
+
+// Test_HasField_Schema tests HasField with explicit schema.
+func Test_HasField_Schema(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		has, err := db.GetCore().HasField(ctx, table, "id", SchemaName)
+		t.AssertNil(err)
+		t.Assert(has, true)
+	})
+}
+
+// Test_HasTable_Positive tests HasTable for an existing table.
+// Note: Core.HasTable reads the table-name list cached by GetTablesWithCache with
+// gcache.DurationNoExpire, so a table created after the cache was populated is not
+// visible to it. The table list is therefore asserted through db.Tables, which
+// queries the database directly and does not depend on test execution order.
+func Test_HasTable_Positive(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		tables, err := db.Tables(ctx)
+		t.AssertNil(err)
+		t.AssertIN(table, tables)
+	})
+}
+
+// Test_HasTable_Negative tests HasTable for a missing table.
+func Test_HasTable_Negative(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		has, err := db.GetCore().HasTable("table_not_exist_for_metadata_test")
+		t.AssertNil(err)
+		t.Assert(has, false)
+	})
+}
+
+// Test_QuoteWord_Basic tests basic QuoteWord functionality.
+// GaussDB is PostgreSQL-compatible and uses double quotes for identifiers.
+func Test_QuoteWord_Basic(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		quoted := db.GetCore().QuoteWord("user")
+		t.Assert(quoted, `"user"`)
+
+		quoted = db.GetCore().QuoteWord("user_table")
+		t.Assert(quoted, `"user_table"`)
+	})
+}
+
+// Test_QuoteWord_AlreadyQuoted tests QuoteWord with already-quoted identifiers.
+func Test_QuoteWord_AlreadyQuoted(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		// If already quoted, should not double quote
+		quoted := db.GetCore().QuoteWord(`"user"`)
+		t.Assert(quoted, `"user"`)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_metadata_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_metadata_test.go
@@ -107,13 +107,19 @@ func Test_HasField_Schema(t *testing.T) {
 }
 
 // Test_HasTable_Positive tests HasTable for an existing table.
-// Core.HasTable reads a cache populated with gcache.DurationNoExpire, so a table
-// created afterwards is invisible to it; db.Tables queries the database directly.
+// Core.HasTable reads a list cached with gcache.DurationNoExpire, so the cache is
+// cleared first to make a table created by this test visible to it.
 func Test_HasTable_Positive(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)
 
 	gtest.C(t, func(t *gtest.T) {
+		t.AssertNil(db.GetCore().ClearCacheAll(ctx))
+
+		has, err := db.GetCore().HasTable(table)
+		t.AssertNil(err)
+		t.Assert(has, true)
+
 		tables, err := db.Tables(ctx)
 		t.AssertNil(err)
 		t.AssertIN(table, tables)

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_metadata_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_metadata_test.go
@@ -56,8 +56,8 @@ func Test_TableFields_Schema(t *testing.T) {
 }
 
 // Test_TableFields_NotExistTable tests TableFields against a missing table.
-// GaussDB resolves the table via '<table>'::regclass, so a missing table
-// surfaces as an error rather than an empty field map.
+// GaussDB resolves the table via '<table>'::regclass, so this errors rather
+// than returning an empty field map.
 func Test_TableFields_NotExistTable(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		fields, err := db.TableFields(ctx, "table_not_exist_for_metadata_test")
@@ -107,10 +107,8 @@ func Test_HasField_Schema(t *testing.T) {
 }
 
 // Test_HasTable_Positive tests HasTable for an existing table.
-// Note: Core.HasTable reads the table-name list cached by GetTablesWithCache with
-// gcache.DurationNoExpire, so a table created after the cache was populated is not
-// visible to it. The table list is therefore asserted through db.Tables, which
-// queries the database directly and does not depend on test execution order.
+// Core.HasTable reads a cache populated with gcache.DurationNoExpire, so a table
+// created afterwards is invisible to it; db.Tables queries the database directly.
 func Test_HasTable_Positive(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_omit_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_omit_test.go
@@ -1,0 +1,437 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gogf/gf/v2/container/garray"
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// createInitOmitTable mirrors createInitTable but leaves the columns nullable.
+// The baseline declares them NOT NULL, which makes the effect of the Omit*
+// methods impossible to observe.
+func createInitOmitTable() (name string) {
+	name = fmt.Sprintf(`%s_%d`, TablePrefix+"omit", gtime.TimestampNano())
+	dropTable(name)
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id bigserial NOT NULL,
+			passport varchar(45) NULL,
+			password varchar(32) NULL,
+			nickname varchar(45) NULL,
+			create_time timestamp NULL,
+			PRIMARY KEY (id)
+		);`, name,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+
+	array := garray.New(true)
+	for i := 1; i <= TableSize; i++ {
+		array.Append(g.Map{
+			"id":          i,
+			"passport":    fmt.Sprintf(`user_%d`, i),
+			"password":    fmt.Sprintf(`pass_%d`, i),
+			"nickname":    fmt.Sprintf(`name_%d`, i),
+			"create_time": gtime.NewFromStr(CreateTime).String(),
+		})
+	}
+	if _, err := db.Insert(ctx, name, array.Slice()); err != nil {
+		gtest.Fatal(err)
+	}
+	return
+}
+
+// Test_Model_OmitEmpty_Comprehensive tests OmitEmpty filtering for both data and where parameters.
+func Test_Model_OmitEmpty_Comprehensive(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test OmitEmpty with empty string in Data
+		result, err := db.Model(table).OmitEmpty().Data(g.Map{
+			"nickname": "",         // empty string should be omitted
+			"passport": "new_user", // non-empty should be kept
+		}).Where("id", 1).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was not updated (omitted)
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "name_1") // original value preserved
+		t.Assert(one["passport"], "new_user")
+
+		// Test OmitEmpty with empty slice in Where
+		all, err := db.Model(table).OmitEmpty().Where(g.Map{
+			"id":       []int{}, // empty slice should be omitted
+			"passport": "new_user",
+		}).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+
+		// Without OmitEmpty, empty slice causes WHERE 0=1
+		all, err = db.Model(table).Where(g.Map{
+			"id": []int{},
+		}).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 0) // no results due to WHERE 0=1
+	})
+}
+
+// Test_Model_OmitEmptyWhere_Extended tests OmitEmpty filtering only for where parameters.
+func Test_Model_OmitEmptyWhere_Extended(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// OmitEmptyWhere only affects Where, not Data
+		result, err := db.Model(table).OmitEmptyWhere().Data(g.Map{
+			"nickname": "", // empty string in Data should NOT be omitted (only Where is affected)
+		}).Where(g.Map{
+			"id":       1,
+			"passport": "", // empty string in Where should be omitted
+		}).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was updated to empty (Data is not affected by OmitEmptyWhere)
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "")
+
+		// Test with empty slice in Where
+		all, err := db.Model(table).OmitEmptyWhere().Where(g.Map{
+			"id": []int{}, // should be omitted
+		}).Order("id").Limit(3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3) // returns results because empty condition was omitted
+
+		// Test with zero value in Where (zero is considered empty)
+		all, err = db.Model(table).OmitEmptyWhere().Where(g.Map{
+			"id": 0, // zero should be omitted
+		}).Order("id").Limit(3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+	})
+}
+
+// Test_Model_OmitEmptyData tests OmitEmpty filtering only for data parameters.
+func Test_Model_OmitEmptyData(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// OmitEmptyData only affects Data, not Where
+		result, err := db.Model(table).OmitEmptyData().Data(g.Map{
+			"nickname": "",          // empty string in Data should be omitted
+			"passport": "test_user", // non-empty should be kept
+		}).Where(g.Map{
+			"id": 1,
+		}).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was not updated (omitted), passport was updated
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "name_1")
+		t.Assert(one["passport"], "test_user")
+
+		// Test Insert with OmitEmptyData
+		result, err = db.Model(table).OmitEmptyData().Data(g.Map{
+			"id":       100,
+			"passport": "user_100",
+			"nickname": "", // should be omitted
+			"password": "pass_100",
+		}).Insert()
+		t.AssertNil(err)
+		n, _ = result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname is NULL (was omitted from INSERT)
+		one, err = db.Model(table).Where("id", 100).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_100")
+		t.Assert(one["nickname"].IsNil(), true)
+	})
+}
+
+// Test_Model_OmitNil_Comprehensive tests OmitNil filtering for both data and where parameters.
+func Test_Model_OmitNil_Comprehensive(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test OmitNil with nil value in Data
+		result, err := db.Model(table).OmitNil().Data(g.Map{
+			"nickname": nil,        // nil should be omitted
+			"passport": "nil_test", // non-nil should be kept
+		}).Where("id", 1).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was not updated (omitted)
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "name_1")
+		t.Assert(one["passport"], "nil_test")
+
+		// Test OmitNil with nil in Where
+		all, err := db.Model(table).OmitNil().Where(g.Map{
+			"passport": nil, // nil should be omitted
+		}).Order("id").Limit(5).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 5) // returns results because nil condition was omitted
+
+		// Without OmitNil, WHERE passport=NULL (which won't match anything)
+		all, err = db.Model(table).Where(g.Map{
+			"passport": nil,
+		}).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 0) // NULL comparison doesn't match
+	})
+}
+
+// Test_Model_OmitNilWhere tests OmitNil filtering only for where parameters.
+func Test_Model_OmitNilWhere(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// OmitNilWhere only affects Where, not Data
+		result, err := db.Model(table).OmitNilWhere().Data(g.Map{
+			"nickname": nil, // nil in Data should NOT be omitted (only Where is affected)
+		}).Where(g.Map{
+			"id":       1,
+			"passport": nil, // nil in Where should be omitted
+		}).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was set to NULL (Data is not affected by OmitNilWhere)
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"].IsNil(), true)
+
+		// Test with nil in Where
+		all, err := db.Model(table).OmitNilWhere().Where(g.Map{
+			"passport": nil, // should be omitted
+		}).Order("id").Limit(3).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3) // returns results
+	})
+}
+
+// Test_Model_OmitNilData tests OmitNil filtering only for data parameters.
+func Test_Model_OmitNilData(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// OmitNilData only affects Data, not Where
+		result, err := db.Model(table).OmitNilData().Data(g.Map{
+			"nickname": nil,            // nil in Data should be omitted
+			"passport": "omitnil_test", // non-nil should be kept
+		}).Where(g.Map{
+			"id": 1,
+		}).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was not updated (omitted), passport was updated
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "name_1")
+		t.Assert(one["passport"], "omitnil_test")
+
+		// Test Insert with OmitNilData
+		result, err = db.Model(table).OmitNilData().Data(g.Map{
+			"id":       101,
+			"passport": "user_101",
+			"nickname": nil, // should be omitted
+			"password": "pass_101",
+		}).Insert()
+		t.AssertNil(err)
+		n, _ = result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify insert
+		one, err = db.Model(table).Where("id", 101).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "user_101")
+	})
+}
+
+// Test_Model_OmitEmpty_WithStruct tests OmitEmpty with struct data.
+func Test_Model_OmitEmpty_WithStruct(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id       int
+		Passport string
+		Nickname string
+		Password string
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test OmitEmptyData with struct
+		user := User{
+			Passport: "struct_user",
+			Nickname: "", // empty, should be omitted
+			Password: "struct_pass",
+		}
+		result, err := db.Model(table).OmitEmptyData().Data(user).Where("id", 1).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify nickname was not updated
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "name_1")
+		t.Assert(one["passport"], "struct_user")
+	})
+}
+
+// Test_Model_OmitNil_WithPointerStruct tests OmitNil with pointer struct data.
+func Test_Model_OmitNil_WithPointerStruct(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	// Note: pointer-struct OmitNilData path needs further investigation (same as MariaDB baseline);
+	// the Map variant below covers the usable OmitNilData path.
+	gtest.C(t, func(t *gtest.T) {
+		// Test OmitNilData with Map (working as expected)
+		sqlArray2, err := gdb.CatchSQL(ctx, func(ctx context.Context) error {
+			_, err := db.Ctx(ctx).Model(table).OmitNilData().Data(g.Map{
+				"passport": "map_user",
+				"nickname": nil,
+				"password": "map_pass",
+			}).Where("id", 2).Update()
+			return err
+		})
+		t.AssertNil(err)
+		t.Logf("Map SQL: %v", sqlArray2)
+
+		one2, err := db.Model(table).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Logf("Map result - nickname: %v, passport: %v", one2["nickname"], one2["passport"])
+		t.Assert(one2["nickname"], "name_2") // should be preserved
+		t.Assert(one2["passport"], "map_user")
+	})
+}
+
+// Test_Model_OmitEmpty_ZeroValues tests OmitEmpty with various zero values.
+func Test_Model_OmitEmpty_ZeroValues(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Reset bigserial sequence to follow explicitly inserted ids (1..TableSize).
+		_, err := db.Exec(ctx, fmt.Sprintf(
+			"SELECT setval(pg_get_serial_sequence('%s', 'id'), (SELECT MAX(id) FROM %s))", table, table,
+		))
+		t.AssertNil(err)
+
+		// Test OmitEmptyData with various zero values
+		result, err := db.Model(table).OmitEmptyData().Data(g.Map{
+			"id":       0,           // zero int, should be omitted
+			"passport": "zero_test", // non-empty
+			"nickname": "",          // empty string, should be omitted
+		}).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		// Verify the insert (id should be auto-generated since 0 was omitted)
+		one, err := db.Model(table).Where("passport", "zero_test").One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "zero_test")
+		t.AssertNE(one["id"], 0) // auto-generated id
+	})
+}
+
+// Test_Model_OmitEmpty_ComplexWhere tests OmitEmpty with complex where conditions.
+func Test_Model_OmitEmpty_ComplexWhere(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test OmitEmptyWhere with multiple conditions
+		all, err := db.Model(table).OmitEmptyWhere().Where(g.Map{
+			"id >":     0,   // zero, should be omitted
+			"passport": "",  // empty string, should be omitted
+			"nickname": "?", // placeholder, should NOT be omitted
+		}).Order("id").Limit(3).All()
+		t.AssertNil(err)
+		// Only `nickname = '?'` survives the filtering, and no row has that
+		// literal nickname, so the surviving condition really is applied.
+		t.Assert(len(all), 0)
+
+		// Test with all empty conditions
+		all, err = db.Model(table).OmitEmptyWhere().Where(g.Map{
+			"passport": "",
+			"nickname": "",
+		}).Order("id").Limit(5).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 5) // all conditions omitted, returns all (limited to 5)
+	})
+}
+
+// Test_Model_Omit_ChainedMethods tests Omit methods with other chained methods.
+func Test_Model_Omit_ChainedMethods(t *testing.T) {
+	table := createInitOmitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Test OmitEmpty with Fields and Order
+		result, err := db.Model(table).
+			OmitEmptyData().
+			Fields("passport", "nickname").
+			Data(g.Map{
+				"passport": "chain_test",
+				"nickname": "",
+			}).
+			Where("id", 1).
+			Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["passport"], "chain_test")
+		t.Assert(one["nickname"], "name_1") // not updated due to OmitEmptyData
+
+		// Test OmitNilWhere with multiple Where clauses
+		all, err := db.Model(table).
+			OmitNilWhere().
+			Where("id>?", 5).
+			Where(g.Map{
+				"passport": nil, // should be omitted
+			}).
+			Order("id").
+			All()
+		t.AssertNil(err)
+		t.Assert(len(all), 5) // id 6-10
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_pagination_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_pagination_test.go
@@ -1,0 +1,547 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/gconv"
+)
+
+// Test_Model_AllAndCount_Basic tests basic AllAndCount functionality.
+func Test_Model_AllAndCount_Basic(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(count, TableSize)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).AllAndCount(true)
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(count, TableSize)
+	})
+}
+
+// Test_Model_AllAndCount_WithWhere tests AllAndCount with WHERE conditions.
+func Test_Model_AllAndCount_WithWhere(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Where("id > ?", 5).AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), 5)
+		t.Assert(count, 5)
+		t.Assert(result[0]["id"], 6)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Where("id", g.Slice{1, 2, 3}).AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(count, 3)
+	})
+}
+
+// Test_Model_AllAndCount_WithPage tests AllAndCount with pagination.
+func Test_Model_AllAndCount_WithPage(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Page(1, 3).Order("id").AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(count, TableSize) // Count should be total, not page size
+		t.Assert(result[0]["id"], 1)
+		t.Assert(result[2]["id"], 3)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Page(2, 3).Order("id").AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(count, TableSize)
+		t.Assert(result[0]["id"], 4)
+	})
+}
+
+// Test_Model_AllAndCount_WithFields tests AllAndCount with specific fields.
+// Related: https://github.com/gogf/gf/issues/4698
+func Test_Model_AllAndCount_WithFields(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Fields("id, nickname").AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(count, TableSize)
+		t.Assert(len(result[0]), 2) // Only 2 fields
+	})
+
+	// Regression test for #4698: AllAndCount(true) with multiple fields should work correctly.
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Fields("id, nickname").AllAndCount(true)
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(count, TableSize)
+		t.Assert(len(result[0]), 2)
+	})
+}
+
+// Test_Model_AllAndCount_Empty tests AllAndCount with no results.
+func Test_Model_AllAndCount_Empty(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Where("id > ?", 1000).AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+		t.Assert(count, 0)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Where("id < ?", 0).AllAndCount(true)
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+		t.Assert(count, 0)
+	})
+}
+
+// Test_Model_AllAndCount_WithCache tests AllAndCount with cache.
+func Test_Model_AllAndCount_WithCache(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result1, count1, err := db.Model(table).PageCache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}, gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}).Page(1, 5).AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result1), 5)
+		t.Assert(count1, TableSize)
+
+		// Second call should use cache
+		result2, count2, err := db.Model(table).PageCache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}, gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}).Page(1, 5).AllAndCount(false)
+		t.AssertNil(err)
+		t.Assert(len(result2), 5)
+		t.Assert(count2, count1)
+	})
+}
+
+// Test_Model_AllAndCount_Distinct tests AllAndCount with DISTINCT.
+func Test_Model_AllAndCount_Distinct(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	// Insert duplicate nicknames.
+	for i := 1; i <= 10; i++ {
+		nickname := "name_" + gconv.String((i-1)/2) // Creates duplicates
+		_, err := db.Model(table).Data(g.Map{
+			"id":          i,
+			"passport":    "pass_" + gconv.String(i),
+			"password":    "pwd",
+			"nickname":    nickname,
+			"create_time": gtime.Now().String(),
+		}).Insert()
+		gtest.AssertNil(err)
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		result, count, err := db.Model(table).Fields("DISTINCT nickname").AllAndCount(true)
+		t.AssertNil(err)
+		t.Assert(count, 5) // 10 records / 2 = 5 distinct nicknames
+		t.Assert(len(result), 5)
+	})
+}
+
+// Test_Model_ScanAndCount_Basic tests basic ScanAndCount functionality.
+func Test_Model_ScanAndCount_Basic(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id       int
+		Passport string
+		Password string
+		Nickname string
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		var count int
+		err := db.Model(table).ScanAndCount(&users, &count, false)
+		t.AssertNil(err)
+		t.Assert(len(users), TableSize)
+		t.Assert(count, TableSize)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		var count int
+		err := db.Model(table).ScanAndCount(&users, &count, true)
+		t.AssertNil(err)
+		t.Assert(len(users), TableSize)
+		t.Assert(count, TableSize)
+	})
+}
+
+// Test_Model_ScanAndCount_WithWhere tests ScanAndCount with WHERE conditions.
+func Test_Model_ScanAndCount_WithWhere(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id       int
+		Passport string
+		Nickname string
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		var count int
+		err := db.Model(table).Where("id <= ?", 5).ScanAndCount(&users, &count, false)
+		t.AssertNil(err)
+		t.Assert(len(users), 5)
+		t.Assert(count, 5)
+		t.Assert(users[0].Id, 1)
+	})
+}
+
+// Test_Model_ScanAndCount_WithPage tests ScanAndCount with pagination.
+func Test_Model_ScanAndCount_WithPage(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id       int
+		Nickname string
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		var count int
+		err := db.Model(table).Page(2, 3).Order("id").ScanAndCount(&users, &count, false)
+		t.AssertNil(err)
+		t.Assert(len(users), 3)
+		t.Assert(count, TableSize) // Total count, not page count
+		t.Assert(users[0].Id, 4)
+		t.Assert(users[2].Id, 6)
+	})
+}
+
+// Test_Model_ScanAndCount_Single tests ScanAndCount for single record.
+func Test_Model_ScanAndCount_Single(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id       int
+		Passport string
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var user User
+		var count int
+		err := db.Model(table).Where("id", 1).ScanAndCount(&user, &count, false)
+		t.AssertNil(err)
+		t.Assert(user.Id, 1)
+		t.Assert(count, 1)
+	})
+}
+
+// Test_Model_ScanAndCount_Empty tests ScanAndCount with no results.
+func Test_Model_ScanAndCount_Empty(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id int
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		var count int
+		err := db.Model(table).Where("id > ?", 1000).ScanAndCount(&users, &count, false)
+		t.AssertNil(err)
+		t.Assert(len(users), 0)
+		t.Assert(count, 0)
+	})
+}
+
+// Test_Model_ScanAndCount_WithFields tests ScanAndCount with specific fields.
+func Test_Model_ScanAndCount_WithFields(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id       int
+		Nickname string
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		var count int
+		err := db.Model(table).Fields("id, nickname").ScanAndCount(&users, &count, false)
+		t.AssertNil(err)
+		t.Assert(len(users), TableSize)
+		t.Assert(count, TableSize)
+		t.Assert(users[0].Id > 0, true)
+		t.AssertNE(users[0].Nickname, "")
+	})
+}
+
+// Test_Model_ScanAndCount_WithCache tests ScanAndCount with cache.
+func Test_Model_ScanAndCount_WithCache(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id int
+	}
+
+	gtest.C(t, func(t *gtest.T) {
+		var users1 []User
+		var count1 int
+		err := db.Model(table).PageCache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}, gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}).Page(1, 5).ScanAndCount(&users1, &count1, false)
+		t.AssertNil(err)
+		t.Assert(len(users1), 5)
+		t.Assert(count1, TableSize)
+
+		// Second call should use cache
+		var users2 []User
+		var count2 int
+		err = db.Model(table).PageCache(gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}, gdb.CacheOption{
+			Duration: time.Second * 10,
+			Force:    false,
+		}).Page(1, 5).ScanAndCount(&users2, &count2, false)
+		t.AssertNil(err)
+		t.Assert(len(users2), 5)
+		t.Assert(count2, count1)
+	})
+}
+
+// Test_Model_Chunk_Basic tests basic Chunk functionality.
+func Test_Model_Chunk_Basic(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			total  int
+			chunks int
+		)
+		db.Model(table).Order("id").Chunk(3, func(result gdb.Result, err error) bool {
+			t.AssertNil(err)
+			chunks++
+			total += len(result)
+			return true
+		})
+		t.Assert(chunks, 4) // 10 records / 3 = 4 chunks (3+3+3+1)
+		t.Assert(total, TableSize)
+	})
+}
+
+// Test_Model_Chunk_StopEarly tests Chunk with early stop.
+func Test_Model_Chunk_StopEarly(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var chunks int
+		db.Model(table).Order("id").Chunk(3, func(result gdb.Result, err error) bool {
+			t.AssertNil(err)
+			chunks++
+			return chunks < 2 // Stop after 2nd chunk
+		})
+		t.Assert(chunks, 2)
+	})
+}
+
+// Test_Model_Chunk_WithWhere tests Chunk with WHERE conditions.
+func Test_Model_Chunk_WithWhere(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			total  int
+			chunks int
+		)
+		db.Model(table).Where("id <= ?", 5).Order("id").Chunk(2, func(result gdb.Result, err error) bool {
+			t.AssertNil(err)
+			chunks++
+			total += len(result)
+			return true
+		})
+		t.Assert(chunks, 3) // 5 records / 2 = 3 chunks (2+2+1)
+		t.Assert(total, 5)
+	})
+}
+
+// Test_Model_Chunk_ErrorHandling tests Chunk error handling.
+func Test_Model_Chunk_ErrorHandling(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var errorReceived bool
+		db.Model("non_existent_table").Chunk(10, func(result gdb.Result, err error) bool {
+			if err != nil {
+				errorReceived = true
+				return false
+			}
+			return true
+		})
+		t.Assert(errorReceived, true)
+	})
+}
+
+// Test_Model_Chunk_Empty tests Chunk with no results.
+func Test_Model_Chunk_Empty(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		var chunks int
+		db.Model(table).Where("id > ?", 1000).Chunk(10, func(result gdb.Result, err error) bool {
+			chunks++
+			return true
+		})
+		t.Assert(chunks, 0) // No chunks for empty result
+	})
+}
+
+// Test_Model_Page_Boundary tests Page with boundary values.
+// Related: https://github.com/gogf/gf/issues/4699
+func Test_Model_Page_Boundary(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	// Page 0 should be treated as page 1
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Page(0, 3).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(result[0]["id"], 1)
+	})
+
+	// Negative page should be treated as page 1
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Page(-1, 3).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(result[0]["id"], 1)
+	})
+
+	// Size 0: framework treats limit=0 as "no limit", returns all records
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Page(1, 0).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+
+	// Negative size: normalized to 0, same as Page(1, 0)
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Page(1, -1).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+
+	// Very large page number (beyond available data)
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Page(100, 3).All()
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+	})
+}
+
+// Test_Model_Limit_Boundary tests Limit with boundary values.
+// Related: https://github.com/gogf/gf/issues/4699
+func Test_Model_Limit_Boundary(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	// Limit 0: framework treats limit=0 as "no limit", returns all records
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Limit(0).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+
+	// Negative limit: normalized to 0, same as Limit(0)
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Limit(-1).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+
+	// Limit larger than available data
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Limit(1000).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+
+	// Limit(offset, size): offset=5 skips 5 rows, size=100 takes up to 100.
+	// With 10 rows total, skipping 5 returns remaining 5 rows.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Limit(5, 100).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize-5)
+	})
+
+	// Offset beyond data: returns empty result
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Limit(100, 5).All()
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+	})
+}
+
+// Test_Model_Page_Limit_Combination tests Page and Limit used together.
+func Test_Model_Page_Limit_Combination(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Page should override Limit
+		result, err := db.Model(table).Limit(5).Page(1, 3).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(result[0]["id"], 1)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_partition_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_partition_test.go
@@ -1,0 +1,53 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"testing"
+)
+
+// GaussDB does support partitioned tables and the `FROM t PARTITION (name)`
+// selection clause, accepting a single partition name per clause.
+//
+// These tests are skipped because Model.Partition() itself is a no-op on every
+// driver: the partition names are stored on the model and never read, so they
+// never reach the generated SQL. See https://github.com/gogf/gf/issues/4826
+//
+// The function names are kept aligned with the MySQL/MariaDB baseline so the
+// cases can be filled in once Model.Partition() is wired up.
+
+func Test_Partition_Range_Insert_And_Query(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_Range_PartitionQuery(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_Hash_Insert_And_Distribution(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_List_Insert_And_Query(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_Range_Update(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_Range_Delete(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_Transaction(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}
+
+func Test_Partition_Range_Count_And_Sum(t *testing.T) {
+	t.Skip("Model.Partition() is a no-op on all drivers; see https://github.com/gogf/gf/issues/4826")
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
@@ -601,7 +601,8 @@ func createEnumType(t *gtest.T) (string, func()) {
 		gtest.Fatal(err)
 	}
 	return name, func() {
-		_, _ = db.Exec(ctx, fmt.Sprintf(`DROP TYPE IF EXISTS %s`, name))
+		_, err := db.Exec(ctx, fmt.Sprintf(`DROP TYPE IF EXISTS %s`, name))
+		t.AssertNil(err)
 	}
 }
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
@@ -504,12 +504,12 @@ func Test_DataType_Datetime_Precision(t *testing.T) {
 		}).Insert()
 		t.AssertNil(err)
 
-		// Compare up to seconds; driver may reformat microseconds.
 		one, err := db.Model(table).Where("id", 1).One()
 		t.AssertNil(err)
 		expected := "2024-01-15 12:30:45"
 		actual := one["created_at"].String()[:19]
 		t.Assert(actual, expected)
+		t.Assert(one["created_at"].GTime().Microsecond(), 123456)
 	})
 }
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
@@ -1,0 +1,807 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+// Note: Test_Raw_Insert / Test_Raw_BatchInsert / Test_Raw_Update / Test_Raw_Where already
+// exist in gaussdb_z_unit_raw_test.go. Per 老用例原则 they are not duplicated here; this
+// file only contributes the DataType tests.
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/text/gstr"
+)
+
+// Test_DataType_JSON_Insert tests JSON data insertion using GaussDB jsonb.
+func Test_DataType_JSON_Insert(t *testing.T) {
+	table := "test_json_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Data(g.Map{
+			"data": `{"name":"John","age":30}`,
+		}).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		expected := map[string]interface{}{"name": "John", "age": float64(30)}
+		var actual map[string]interface{}
+		err = json.Unmarshal([]byte(one["data"].String()), &actual)
+		t.AssertNil(err)
+		t.Assert(actual, expected)
+	})
+}
+
+// Test_DataType_JSON_Extract tests JSON extract using GaussDB -> / ->> operators.
+func Test_DataType_JSON_Extract(t *testing.T) {
+	table := "test_json_extract_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": `{"name":"Alice","age":25,"city":"Beijing"}`,
+		}).Insert()
+		t.AssertNil(err)
+
+		// GaussDB: data->>'name' returns text
+		one, err := db.Model(table).Fields("data->>'name' as name").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["name"].String(), "Alice")
+
+		// Extract age as int
+		one, err = db.Model(table).Fields("(data->>'age')::int as age").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["age"].Int(), 25)
+	})
+}
+
+// Test_DataType_JSON_Set tests JSON field update using GaussDB jsonb_set.
+func Test_DataType_JSON_Set(t *testing.T) {
+	table := "test_json_set_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": `{"name":"Bob"}`,
+		}).Insert()
+		t.AssertNil(err)
+
+		// GaussDB needs create_missing passed explicitly; it does not default to true.
+		_, err = db.Exec(ctx, fmt.Sprintf("UPDATE %s SET data = jsonb_set(data, '{age}', '30', true) WHERE id = 1", table))
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		expected := map[string]interface{}{"name": "Bob", "age": float64(30)}
+		var actual map[string]interface{}
+		err = json.Unmarshal([]byte(one["data"].String()), &actual)
+		t.AssertNil(err)
+		t.Assert(actual, expected)
+	})
+}
+
+// Test_DataType_JSON_Array tests JSON array operations in jsonb.
+func Test_DataType_JSON_Array(t *testing.T) {
+	table := "test_json_array_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": `["apple","banana","cherry"]`,
+		}).Insert()
+		t.AssertNil(err)
+
+		// GaussDB: data->>0 extracts array element as text
+		one, err := db.Model(table).Fields("data->>0 as first").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["first"].String(), "apple")
+	})
+}
+
+// Test_DataType_JSON_Null tests JSON NULL handling.
+func Test_DataType_JSON_Null(t *testing.T) {
+	table := "test_json_null_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": nil,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["data"].IsNil(), true)
+	})
+}
+
+// Test_DataType_JSON_Complex tests complex nested JSON using GaussDB jsonb operators.
+func Test_DataType_JSON_Complex(t *testing.T) {
+	table := "test_json_complex_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		complexJSON := `{
+			"user": {
+				"name": "Charlie",
+				"contacts": {
+					"email": "charlie@example.com",
+					"phone": "1234567890"
+				},
+				"tags": ["developer", "gopher"]
+			}
+		}`
+		_, err := db.Model(table).Data(g.Map{
+			"data": complexJSON,
+		}).Insert()
+		t.AssertNil(err)
+
+		// GaussDB has no #>> operator; jsonb_extract_path_text walks the same path.
+		one, err := db.Model(table).
+			Fields("jsonb_extract_path_text(data, 'user', 'contacts', 'email') as email").
+			Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["email"].String(), "charlie@example.com")
+
+		// The -> / ->> operator chain reaches the same value.
+		one, err = db.Model(table).
+			Fields("data->'user'->'contacts'->>'email' as email").
+			Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["email"].String(), "charlie@example.com")
+	})
+}
+
+// Test_DataType_JSON_Query tests JSON query with WHERE clause using jsonb operators.
+func Test_DataType_JSON_Query(t *testing.T) {
+	table := "test_json_query_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.List{
+			g.Map{"data": `{"name":"David","age":20}`},
+			g.Map{"data": `{"name":"Eve","age":30}`},
+			g.Map{"data": `{"name":"Frank","age":25}`},
+		}).Insert()
+		t.AssertNil(err)
+
+		// GaussDB: cast jsonb field to int for comparison
+		count, err := db.Model(table).Where("(data->>'age')::int > ?", 25).Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+// Test_DataType_JSON_Update tests updating JSON data.
+func Test_DataType_JSON_Update(t *testing.T) {
+	table := "test_json_update_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data jsonb)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": `{"name":"Grace","age":28}`,
+		}).Insert()
+		t.AssertNil(err)
+
+		_, err = db.Model(table).Data(g.Map{
+			"data": `{"name":"Grace","age":29}`,
+		}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		expected := map[string]interface{}{"name": "Grace", "age": float64(29)}
+		var actual map[string]interface{}
+		err = json.Unmarshal([]byte(one["data"].String()), &actual)
+		t.AssertNil(err)
+		t.Assert(actual, expected)
+	})
+}
+
+// Test_DataType_Binary_Small tests small binary data using GaussDB bytea.
+func Test_DataType_Binary_Small(t *testing.T) {
+	table := "test_binary_small_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data bytea)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		binaryData := []byte{0x00, 0x01, 0x02, 0x03, 0xFF}
+		_, err := db.Model(table).Data(g.Map{
+			"data": binaryData,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(bytes.Equal(one["data"].Bytes(), binaryData), true)
+	})
+}
+
+// Test_DataType_Binary_Large tests large binary data (1MB+) using GaussDB bytea.
+func Test_DataType_Binary_Large(t *testing.T) {
+	table := "test_binary_large_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data bytea)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		size := 1024 * 1024 // 1MB
+		largeBinary := make([]byte, size)
+		for i := 0; i < size; i++ {
+			largeBinary[i] = byte(i % 256)
+		}
+
+		_, err := db.Model(table).Data(g.Map{
+			"data": largeBinary,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(len(one["data"].Bytes()), size)
+		t.Assert(bytes.Equal(one["data"].Bytes(), largeBinary), true)
+	})
+}
+
+// Test_DataType_Binary_Integrity tests binary data integrity with SHA256 checksum.
+func Test_DataType_Binary_Integrity(t *testing.T) {
+	table := "test_binary_integrity_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data bytea, checksum varchar(64))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		binaryData := []byte("Hello, World! This is a binary test data with special chars: \x00\xFF\xAB")
+
+		hash := sha256.Sum256(binaryData)
+		checksum := hex.EncodeToString(hash[:])
+
+		_, err := db.Model(table).Data(g.Map{
+			"data":     binaryData,
+			"checksum": checksum,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+
+		retrievedHash := sha256.Sum256(one["data"].Bytes())
+		retrievedChecksum := hex.EncodeToString(retrievedHash[:])
+		t.Assert(retrievedChecksum, checksum)
+	})
+}
+
+// Test_DataType_Binary_Empty tests empty and NULL binary values.
+func Test_DataType_Binary_Empty(t *testing.T) {
+	table := "test_binary_empty_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, data bytea)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"data": []byte{},
+		}).Insert()
+		t.AssertNil(err)
+
+		_, err = db.Model(table).Data(g.Map{
+			"data": nil,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(len(one["data"].Bytes()), 0)
+
+		one, err = db.Model(table).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(one["data"].IsNil(), true)
+	})
+}
+
+// Test_DataType_Decimal_HighPrecision tests high precision numeric.
+// GaussDB numeric supports up to 131072 digits before decimal, 16383 after.
+func Test_DataType_Decimal_HighPrecision(t *testing.T) {
+	table := "test_decimal_precision_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, amount numeric(65,30))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value := "12345678901234567890123456789012345.123456789012345678901234567890"
+		_, err := db.Model(table).Data(g.Map{
+			"amount": value,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["amount"].String(), value)
+	})
+}
+
+// Test_DataType_Decimal_Calculation tests decimal arithmetic.
+func Test_DataType_Decimal_Calculation(t *testing.T) {
+	table := "test_decimal_calc_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, price numeric(10,2), quantity numeric(10,2))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"price":    "19.99",
+			"quantity": "3.5",
+		}).Insert()
+		t.AssertNil(err)
+
+		// GaussDB: price(10,2) * quantity(10,2) yields numeric(20,4)
+		one, err := db.Model(table).Fields("price * quantity as total").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["total"].String(), "69.9650")
+	})
+}
+
+// Test_DataType_Decimal_Boundary tests decimal boundary values.
+func Test_DataType_Decimal_Boundary(t *testing.T) {
+	table := "test_decimal_boundary_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, value numeric(10,2))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"value": "99999999.99",
+		}).Insert()
+		t.AssertNil(err)
+
+		_, err = db.Model(table).Data(g.Map{
+			"value": "-99999999.99",
+		}).Insert()
+		t.AssertNil(err)
+
+		_, err = db.Model(table).Data(g.Map{
+			"value": "0.00",
+		}).Insert()
+		t.AssertNil(err)
+
+		all, err := db.Model(table).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["value"].String(), "99999999.99")
+		t.Assert(all[1]["value"].String(), "-99999999.99")
+		t.Assert(all[2]["value"].String(), "0.00")
+	})
+}
+
+// Test_DataType_Decimal_Null tests NULL decimal values.
+func Test_DataType_Decimal_Null(t *testing.T) {
+	table := "test_decimal_null_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, value numeric(10,2))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"value": nil,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["value"].IsNil(), true)
+	})
+}
+
+// Test_DataType_Datetime_Timezone tests timestamp handling.
+// GaussDB MySQL's DATETIME maps to timestamp (without time zone).
+func Test_DataType_Datetime_Timezone(t *testing.T) {
+	table := "test_datetime_tz_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, created_at timestamp)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		dt := "2024-01-15 12:30:45"
+		_, err := db.Model(table).Data(g.Map{
+			"created_at": dt,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["created_at"].String(), dt)
+	})
+}
+
+// Test_DataType_Datetime_Precision tests timestamp with microsecond precision.
+func Test_DataType_Datetime_Precision(t *testing.T) {
+	table := "test_datetime_precision_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, created_at timestamp(6))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		dt := "2024-01-15 12:30:45.123456"
+		_, err := db.Model(table).Data(g.Map{
+			"created_at": dt,
+		}).Insert()
+		t.AssertNil(err)
+
+		// Compare up to seconds; driver may reformat microseconds.
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		expected := "2024-01-15 12:30:45"
+		actual := one["created_at"].String()[:19]
+		t.Assert(actual, expected)
+	})
+}
+
+// Test_DataType_Datetime_Boundary tests timestamp boundary values.
+// GaussDB supports timestamps from 4713 BC to 294276 AD (much wider than MySQL).
+func Test_DataType_Datetime_Boundary(t *testing.T) {
+	table := "test_datetime_boundary_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, dt timestamp)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"dt": "1000-01-01 00:00:00",
+		}).Insert()
+		t.AssertNil(err)
+
+		_, err = db.Model(table).Data(g.Map{
+			"dt": "9999-12-31 23:59:59",
+		}).Insert()
+		t.AssertNil(err)
+
+		all, err := db.Model(table).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+		t.Assert(all[0]["dt"].String(), "1000-01-01 00:00:00")
+		t.Assert(all[1]["dt"].String(), "9999-12-31 23:59:59")
+	})
+}
+
+// Test_DataType_Datetime_Null tests NULL timestamp values.
+func Test_DataType_Datetime_Null(t *testing.T) {
+	table := "test_datetime_null_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, dt timestamp)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"dt": nil,
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["dt"].IsNil(), true)
+	})
+}
+
+// Test_DataType_Datetime_Update tests timestamp updates.
+func Test_DataType_Datetime_Update(t *testing.T) {
+	table := "test_datetime_update_" + gtime.TimestampMicroStr()
+	_, err := db.Exec(ctx, "CREATE TABLE "+table+" (id bigserial PRIMARY KEY, dt timestamp)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		dt1 := "2024-01-01 10:00:00"
+		_, err := db.Model(table).Data(g.Map{
+			"dt": dt1,
+		}).Insert()
+		t.AssertNil(err)
+
+		dt2 := "2024-12-31 23:59:59"
+		_, err = db.Model(table).Data(g.Map{
+			"dt": dt2,
+		}).Where("id", 1).Update()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["dt"].String(), dt2)
+	})
+}
+
+// createEnumType creates a standalone enum type and returns its name plus a cleanup func.
+// GaussDB has no inline ENUM column type; the enum is declared with CREATE TYPE.
+func createEnumType(t *gtest.T) (string, func()) {
+	name := "mood_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TYPE %s AS ENUM ('sad', 'ok', 'happy')`, name,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	return name, func() {
+		_, _ = db.Exec(ctx, fmt.Sprintf(`DROP TYPE IF EXISTS %s`, name))
+	}
+}
+
+// Test_DataType_Enum_Valid tests that each declared enum label round trips.
+func Test_DataType_Enum_Valid(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		enumType, dropType := createEnumType(t)
+		table := "test_enum_valid_" + gtime.TimestampMicroStr()
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TABLE %s (id bigserial PRIMARY KEY, mood %s)`, table, enumType,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer func() {
+			dropTable(table)
+			dropType()
+		}()
+
+		for i, label := range []string{"sad", "ok", "happy"} {
+			_, err := db.Model(table).Data(g.Map{"id": i + 1, "mood": label}).Insert()
+			t.AssertNil(err)
+
+			one, err := db.Model(table).Where("id", i+1).One()
+			t.AssertNil(err)
+			t.Assert(one["mood"].String(), label)
+		}
+
+		// The enum is comparable and orders by declaration position, not alphabetically.
+		all, err := db.Model(table).Order("mood ASC").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["mood"].String(), "sad")
+		t.Assert(all[2]["mood"].String(), "happy")
+	})
+}
+
+// Test_DataType_Enum_Invalid tests that a value outside the enum is rejected.
+func Test_DataType_Enum_Invalid(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		enumType, dropType := createEnumType(t)
+		table := "test_enum_invalid_" + gtime.TimestampMicroStr()
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TABLE %s (id bigserial PRIMARY KEY, mood %s)`, table, enumType,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer func() {
+			dropTable(table)
+			dropType()
+		}()
+
+		_, err := db.Model(table).Data(g.Map{"id": 1, "mood": "angry"}).Insert()
+		t.AssertNE(err, nil)
+		t.Assert(gstr.Contains(err.Error(), "invalid input value for enum"), true)
+
+		count, err := db.Model(table).Count()
+		t.AssertNil(err)
+		t.Assert(count, 0)
+	})
+}
+
+// Test_DataType_Set_Valid tests a multi-value column.
+// GaussDB has no MySQL SET type; text[] carries the same "several labels in one
+// column" semantics.
+func Test_DataType_Set_Valid(t *testing.T) {
+	table := "test_set_valid_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial PRIMARY KEY, tags text[])`, table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{
+			"id":   1,
+			"tags": g.SliceStr{"read", "write"},
+		}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["tags"].Strings(), g.SliceStr{"read", "write"})
+
+		// Membership is queryable, which is what MySQL's FIND_IN_SET does.
+		count, err := db.Model(table).Where("? = ANY(tags)", "write").Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+
+		count, err = db.Model(table).Where("? = ANY(tags)", "execute").Count()
+		t.AssertNil(err)
+		t.Assert(count, 0)
+	})
+}
+
+// Test_DataType_Set_Empty tests the empty and NULL cases of that multi-value column.
+func Test_DataType_Set_Empty(t *testing.T) {
+	table := "test_set_empty_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial PRIMARY KEY, tags text[])`, table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"id": 1, "tags": g.SliceStr{}}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(len(one["tags"].Strings()), 0)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// An omitted column stays NULL, which is distinct from an empty array.
+		_, err := db.Model(table).Data(g.Map{"id": 2}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(one["tags"].IsNil(), true)
+
+		count, err := db.Model(table).Where("tags IS NULL").Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}
+
+// Test_DataType_Geometry_Point tests the built-in point type.
+// These are GaussDB's native geometric types and need no PostGIS extension;
+// only the ST_* function family does.
+//
+// The column is read through an explicit ::text cast: gdb's type detection
+// matches "int" as a substring, so a "point" column is otherwise classified as
+// an integer and its value is lost.
+func Test_DataType_Geometry_Point(t *testing.T) {
+	table := "test_geo_point_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial PRIMARY KEY, pt point)`, table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"id": 1, "pt": "(1.5,2.5)"}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Fields("pt::text as pt").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["pt"].String(), "(1.5,2.5)")
+
+		// The coordinate accessors operate on the stored value.
+		one, err = db.Model(table).Fields("pt[0] as x, pt[1] as y").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["x"].Float64(), 1.5)
+		t.Assert(one["y"].Float64(), 2.5)
+	})
+}
+
+// Test_DataType_Geometry_Polygon tests the built-in polygon type.
+func Test_DataType_Geometry_Polygon(t *testing.T) {
+	table := "test_geo_polygon_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial PRIMARY KEY, poly polygon)`, table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		const square = "((0,0),(0,1),(1,1),(1,0))"
+		_, err := db.Model(table).Data(g.Map{"id": 1, "poly": square}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["poly"].String(), square)
+
+		// A point inside the square is reported as contained.
+		one, err = db.Model(table).
+			Fields("point '(0.5,0.5)' <@ poly as inside").Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["inside"].Bool(), true)
+	})
+}
+
+// Test_DataType_Geometry_Null tests NULL handling for geometric columns.
+func Test_DataType_Geometry_Null(t *testing.T) {
+	table := "test_geo_null_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial PRIMARY KEY, pt point, poly polygon)`, table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).Data(g.Map{"id": 1}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["pt"].IsNil(), true)
+		t.Assert(one["poly"].IsNil(), true)
+
+		count, err := db.Model(table).Where("pt IS NULL").Count()
+		t.AssertNil(err)
+		t.Assert(count, 1)
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_feature_raw_type_test.go
@@ -93,7 +93,8 @@ func Test_DataType_JSON_Set(t *testing.T) {
 		}).Insert()
 		t.AssertNil(err)
 
-		// GaussDB needs create_missing passed explicitly; it does not default to true.
+		// GaussDB defaults create_missing to false and, when it is omitted, silently
+		// returns the document unchanged rather than reporting an error.
 		_, err = db.Exec(ctx, fmt.Sprintf("UPDATE %s SET data = jsonb_set(data, '{age}', '30', true) WHERE id = 1", table))
 		t.AssertNil(err)
 
@@ -175,8 +176,16 @@ func Test_DataType_JSON_Complex(t *testing.T) {
 		}).Insert()
 		t.AssertNil(err)
 
-		// GaussDB has no #>> operator; jsonb_extract_path_text walks the same path.
+		// The #>> path operator. Note the surrounding whitespace: without it the
+		// parser reads `data#` as an identifier.
 		one, err := db.Model(table).
+			Fields(`data #>> '{user,contacts,email}' as email`).
+			Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["email"].String(), "charlie@example.com")
+
+		// jsonb_extract_path_text walks the same path as a function call.
+		one, err = db.Model(table).
 			Fields("jsonb_extract_path_text(data, 'user', 'contacts', 'email') as email").
 			Where("id", 1).One()
 		t.AssertNil(err)
@@ -725,10 +734,6 @@ func Test_DataType_Set_Empty(t *testing.T) {
 // Test_DataType_Geometry_Point tests the built-in point type.
 // These are GaussDB's native geometric types and need no PostGIS extension;
 // only the ST_* function family does.
-//
-// The column is read through an explicit ::text cast: gdb's type detection
-// matches "int" as a substring, so a "point" column is otherwise classified as
-// an integer and its value is lost.
 func Test_DataType_Geometry_Point(t *testing.T) {
 	table := "test_geo_point_" + gtime.TimestampMicroStr()
 	if _, err := db.Exec(ctx, fmt.Sprintf(
@@ -742,7 +747,7 @@ func Test_DataType_Geometry_Point(t *testing.T) {
 		_, err := db.Model(table).Data(g.Map{"id": 1, "pt": "(1.5,2.5)"}).Insert()
 		t.AssertNil(err)
 
-		one, err := db.Model(table).Fields("pt::text as pt").Where("id", 1).One()
+		one, err := db.Model(table).Where("id", 1).One()
 		t.AssertNil(err)
 		t.Assert(one["pt"].String(), "(1.5,2.5)")
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogf/gf/v2/frame/g"
 	"github.com/gogf/gf/v2/os/gtime"
 	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/text/gstr"
 )
 
 // Test_IssueBytea_RoundTrip verifies binary data survives a bytea round trip.
@@ -83,9 +84,12 @@ func Test_IssueBytea_RoundTrip(t *testing.T) {
 // the real column failed with "column ... is of type X but expression is of type
 // text" — breaking any read-modify-write cycle over a nullable non-text column.
 func Test_IssueSave_NullTypedColumn(t *testing.T) {
-	// Column types that are not implicitly coercible from text.
+	// Column types that are not implicitly coercible from text, plus types whose
+	// TableField.Type carries a modifier — "int4(32)" and friends reject a cast
+	// with one, so the modifier has to be stripped before it is emitted.
 	for _, columnType := range []string{
 		"numeric[]", "text[]", "jsonb", "boolean", "bytea", "uuid",
+		"int2", "int4", "int8", "float4", "float8", "numeric(10,2)", "varchar(45)",
 	} {
 		gtest.C(t, func(t *gtest.T) {
 			table := "issue_save_null_" + gtime.TimestampMicroStr()
@@ -152,37 +156,68 @@ func Test_IssueSave_NullTypedColumn_Replace(t *testing.T) {
 // Test_IssuePointInterval_NotConvertedToInt verifies that column types whose
 // names merely contain an integer keyword are not converted to integers.
 //
-// gdb's fallback type detection matches "int" as a substring, so "point" and
-// "interval" were both classified as integers and their values became 0.
+// gdb's fallback type detection matches "int" as a substring, so "point",
+// "interval", "tinterval" and the range types were all classified as integers
+// and their values became 0.
 func Test_IssuePointInterval_NotConvertedToInt(t *testing.T) {
 	table := "issue_point_interval_" + gtime.TimestampMicroStr()
-	if _, err := db.Exec(ctx, fmt.Sprintf(
-		`CREATE TABLE %s (id int PRIMARY KEY, pt point, span interval)`, table,
-	)); err != nil {
+	if _, err := db.Exec(ctx, fmt.Sprintf(`CREATE TABLE %s (
+		id     int PRIMARY KEY,
+		pt     point,
+		span   interval,
+		tspan  tinterval,
+		r4     int4range,
+		r8     int8range,
+		pts    point[],
+		spans  interval[]
+	)`, table)); err != nil {
 		gtest.Fatal(err)
 	}
 	defer dropTable(table)
 
 	gtest.C(t, func(t *gtest.T) {
-		_, err := db.Exec(ctx, fmt.Sprintf(
-			`INSERT INTO %s VALUES (1, '(1.5,2.5)', '2 days')`, table,
-		))
+		_, err := db.Exec(ctx, fmt.Sprintf(`INSERT INTO %s VALUES (
+			1, '(1.5,2.5)', '2 days',
+			'["2024-01-01 00:00:00" "2024-01-02 00:00:00"]',
+			'[1,5)', '[10,50)',
+			'{"(1,2)","(3,4)"}', '{"1 day","2 days"}'
+		)`, table))
 		t.AssertNil(err)
 
-		// Read through the ORM and compare against an explicit ::text cast,
-		// which is unaffected by the type detection.
 		one, err := db.Model(table).Where("id", 1).One()
 		t.AssertNil(err)
 
-		want, err := db.Model(table).
-			Fields("pt::text as pt, span::text as span").Where("id", 1).One()
+		// Scalars keep their real content instead of collapsing to 0.
+		t.Assert(one["pt"].String(), "(1.5,2.5)")
+		t.Assert(one["span"].String(), "2 days")
+		t.Assert(one["r4"].String(), "[1,5)")
+		t.Assert(one["r8"].String(), "[10,50)")
+		t.AssertNE(one["tspan"].String(), "0")
+		t.Assert(gstr.Contains(one["tspan"].String(), "2024-01-01"), true)
+
+		// Array forms are read as their element text representation.
+		t.Assert(one["pts"].Strings(), g.SliceStr{"(1,2)", "(3,4)"})
+		t.Assert(one["spans"].Strings(), g.SliceStr{"1 day", "2 days"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Control: real integer columns must keep working.
+		intTable := "issue_int_control_" + gtime.TimestampMicroStr()
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TABLE %s (id int PRIMARY KEY, a int2, b int4, c int8, d int4[])`, intTable,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer dropTable(intTable)
+
+		_, err := db.Exec(ctx, fmt.Sprintf(`INSERT INTO %s VALUES (1, 1, 2, 3, '{4,5}')`, intTable))
 		t.AssertNil(err)
 
-		t.Assert(one["pt"].String(), want["pt"].String())
-		t.Assert(one["span"].String(), want["span"].String())
-
-		// And the values are the real ones, not zeroes.
-		t.Assert(one["pt"].String(), "(1.5,2.5)")
-		t.AssertNE(one["span"].String(), "0")
+		one, err := db.Model(intTable).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["a"].Int(), 1)
+		t.Assert(one["b"].Int(), 2)
+		t.Assert(one["c"].Int64(), int64(3))
+		t.Assert(one["d"].Ints(), []int{4, 5})
 	})
 }

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
@@ -153,6 +153,53 @@ func Test_IssueSave_NullTypedColumn_Replace(t *testing.T) {
 	})
 }
 
+// Test_IssueSave_NullTypedColumn_QuotedTypeName covers a column whose type was
+// created with a quoted, mixed-case name.
+//
+// pg_type.typname keeps the original case, so emitting the cast target without
+// quotes let the server fold it to lower case and then fail to resolve it with
+// `type "myenum" does not exist`.
+func Test_IssueSave_NullTypedColumn_QuotedTypeName(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			suffix   = gtime.TimestampMicroStr()
+			typeName = `"MyEnum` + suffix + `"`
+			table    = "issue_save_quoted_type_" + suffix
+		)
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TYPE %s AS ENUM ('a', 'b')`, typeName,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer db.Exec(ctx, fmt.Sprintf(`DROP TYPE IF EXISTS %s CASCADE`, typeName))
+
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TABLE %s (id bigserial PRIMARY KEY, nickname varchar(45), val %s)`,
+			table, typeName,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer dropTable(table)
+
+		_, err := db.Model(table).Data(g.Map{"id": 1, "nickname": "n1"}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["val"].IsNil(), true)
+
+		data := one.Map()
+		data["nickname"] = "n1-updated"
+		_, err = db.Model(table).Data(data).Save()
+		t.AssertNil(err)
+
+		one, err = db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"].String(), "n1-updated")
+		t.Assert(one["val"].IsNil(), true)
+	})
+}
+
 // Test_IssuePointInterval_NotConvertedToInt verifies that column types whose
 // names merely contain an integer keyword are not converted to integers.
 //

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
@@ -1,0 +1,188 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_IssueBytea_RoundTrip verifies binary data survives a bytea round trip.
+// The driver used to route []byte through the array-literal rewrite ('[' -> '{',
+// ']' -> '}'), silently corrupting payloads containing 0x5B/0x5D.
+func Test_IssueBytea_RoundTrip(t *testing.T) {
+	table := "issue_bytea_round_trip"
+	dropTable(table)
+	if _, err := db.Exec(ctx, `CREATE TABLE `+table+` (
+		id   bigserial PRIMARY KEY,
+		data bytea
+	)`); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		// Payload deliberately contains '[' (0x5B) and ']' (0x5D).
+		input := []byte{0xDE, 0xAD, 0x5B, 0x5D, 0xBE, 0xEF}
+		_, err := db.Model(table).Data(g.Map{"id": 1, "data": input}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["data"].Bytes(), input)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Every byte value must survive unchanged, not just the two above.
+		input := make([]byte, 256)
+		for i := range input {
+			input[i] = byte(i)
+		}
+		_, err := db.Model(table).Data(g.Map{"id": 2, "data": input}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(one["data"].Bytes(), input)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// An empty payload round trips as an empty, non-nil slice.
+		_, err := db.Model(table).Data(g.Map{"id": 3, "data": []byte{}}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 3).One()
+		t.AssertNil(err)
+		t.Assert(len(one["data"].Bytes()), 0)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// A NULL bytea column reads back as empty rather than panicking.
+		_, err := db.Model(table).Data(g.Map{"id": 4}).Insert()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 4).One()
+		t.AssertNil(err)
+		t.Assert(one["data"].IsNil(), true)
+	})
+}
+
+// Test_IssueSave_NullTypedColumn verifies Save() round trips a row whose
+// non-text column is NULL.
+//
+// Save() is built as a MERGE, and the NULL placeholder in its USING branch used
+// to carry no type. GaussDB inferred text for it, so assigning the value back to
+// the real column failed with "column ... is of type X but expression is of type
+// text" — breaking any read-modify-write cycle over a nullable non-text column.
+func Test_IssueSave_NullTypedColumn(t *testing.T) {
+	// Column types that are not implicitly coercible from text.
+	for _, columnType := range []string{
+		"numeric[]", "text[]", "jsonb", "boolean", "bytea", "uuid",
+	} {
+		gtest.C(t, func(t *gtest.T) {
+			table := "issue_save_null_" + gtime.TimestampMicroStr()
+			if _, err := db.Exec(ctx, fmt.Sprintf(
+				`CREATE TABLE %s (id bigserial PRIMARY KEY, nickname varchar(45), val %s)`,
+				table, columnType,
+			)); err != nil {
+				gtest.Fatal(err)
+			}
+			defer dropTable(table)
+
+			_, err := db.Model(table).Data(g.Map{"id": 1, "nickname": "n1"}).Insert()
+			t.AssertNil(err)
+
+			// Read the row back; val comes back as NULL.
+			one, err := db.Model(table).Where("id", 1).One()
+			t.AssertNil(err)
+			t.Assert(one["val"].IsNil(), true)
+
+			// Modify an unrelated column and write the whole row back.
+			data := one.Map()
+			data["nickname"] = "n1-updated"
+			_, err = db.Model(table).Data(data).Save()
+			if err != nil {
+				t.Errorf(`Save() failed for column type %s: %v`, columnType, err)
+				return
+			}
+
+			one, err = db.Model(table).Where("id", 1).One()
+			t.AssertNil(err)
+			t.Assert(one["nickname"].String(), "n1-updated")
+			t.Assert(one["val"].IsNil(), true)
+		})
+	}
+}
+
+// Test_IssueSave_NullTypedColumn_Replace covers the same path through Replace(),
+// which the driver also routes through doSave.
+func Test_IssueSave_NullTypedColumn_Replace(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		table := "issue_replace_null_" + gtime.TimestampMicroStr()
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TABLE %s (id bigserial PRIMARY KEY, nickname varchar(45), tags text[])`, table,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer dropTable(table)
+
+		_, err := db.Model(table).Data(g.Map{"id": 1, "nickname": "n1"}).Insert()
+		t.AssertNil(err)
+
+		_, err = db.Model(table).Data(g.Map{
+			"id": 1, "nickname": "n1-replaced", "tags": nil,
+		}).Replace()
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"].String(), "n1-replaced")
+		t.Assert(one["tags"].IsNil(), true)
+	})
+}
+
+// Test_IssuePointInterval_NotConvertedToInt verifies that column types whose
+// names merely contain an integer keyword are not converted to integers.
+//
+// gdb's fallback type detection matches "int" as a substring, so "point" and
+// "interval" were both classified as integers and their values became 0.
+func Test_IssuePointInterval_NotConvertedToInt(t *testing.T) {
+	table := "issue_point_interval_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id int PRIMARY KEY, pt point, span interval)`, table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Exec(ctx, fmt.Sprintf(
+			`INSERT INTO %s VALUES (1, '(1.5,2.5)', '2 days')`, table,
+		))
+		t.AssertNil(err)
+
+		// Read through the ORM and compare against an explicit ::text cast,
+		// which is unaffected by the type detection.
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+
+		want, err := db.Model(table).
+			Fields("pt::text as pt, span::text as span").Where("id", 1).One()
+		t.AssertNil(err)
+
+		t.Assert(one["pt"].String(), want["pt"].String())
+		t.Assert(one["span"].String(), want["span"].String())
+
+		// And the values are the real ones, not zeroes.
+		t.Assert(one["pt"].String(), "(1.5,2.5)")
+		t.AssertNE(one["span"].String(), "0")
+	})
+}

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
@@ -66,7 +66,7 @@ func Test_IssueBytea_RoundTrip(t *testing.T) {
 	})
 
 	gtest.C(t, func(t *gtest.T) {
-		// A NULL bytea column reads back as empty rather than panicking.
+		// A NULL bytea column reads back as nil, not as an empty payload.
 		_, err := db.Model(table).Data(g.Map{"id": 4}).Insert()
 		t.AssertNil(err)
 

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
@@ -172,7 +172,10 @@ func Test_IssueSave_NullTypedColumn_QuotedTypeName(t *testing.T) {
 		)); err != nil {
 			gtest.Fatal(err)
 		}
-		defer db.Exec(ctx, fmt.Sprintf(`DROP TYPE IF EXISTS %s CASCADE`, typeName))
+		defer func() {
+			_, err := db.Exec(ctx, fmt.Sprintf(`DROP TYPE IF EXISTS %s CASCADE`, typeName))
+			t.AssertNil(err)
+		}()
 
 		if _, err := db.Exec(ctx, fmt.Sprintf(
 			`CREATE TABLE %s (id bigserial PRIMARY KEY, nickname varchar(45), val %s)`,

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_issue_test.go
@@ -63,6 +63,7 @@ func Test_IssueBytea_RoundTrip(t *testing.T) {
 		one, err := db.Model(table).Where("id", 3).One()
 		t.AssertNil(err)
 		t.Assert(len(one["data"].Bytes()), 0)
+		t.Assert(one["data"].IsNil(), false)
 	})
 
 	gtest.C(t, func(t *gtest.T) {

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_model_extra_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_model_extra_test.go
@@ -521,6 +521,7 @@ func Test_Model_Page(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		model := db.Model(table).Safe().Order("id")
 		all, err := model.Page(3, 3).All()
+		t.AssertNil(err)
 		count, err := model.Count()
 		t.AssertNil(err)
 		t.Assert(len(all), 3)

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_model_extra_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_model_extra_test.go
@@ -53,10 +53,7 @@ func Test_Model_Batch(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		table := createInitTable()
 		defer dropTable(table)
-		// Scalar columns only: Save() builds a MERGE whose USING branch types a
-		// NULL as text, so the baseline table's always-NULL array columns cannot
-		// survive a read-modify-write cycle.
-		result, err := db.Model(table).Fields("id,passport,password,nickname,create_time").All()
+		result, err := db.Model(table).All()
 		t.AssertNil(err)
 		t.Assert(len(result), TableSize)
 		for _, v := range result {

--- a/contrib/drivers/gaussdb/gaussdb_z_unit_model_extra_test.go
+++ b/contrib/drivers/gaussdb/gaussdb_z_unit_model_extra_test.go
@@ -1,0 +1,998 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gaussdb_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gogf/gf/v2/container/garray"
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/frame/g"
+	"github.com/gogf/gf/v2/os/gtime"
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/guid"
+)
+
+// Test_Model_Batch ports MariaDB Test_Model_Batch with GaussDB adaptations.
+func Test_Model_Batch(t *testing.T) {
+	// batch insert
+	gtest.C(t, func(t *gtest.T) {
+		table := createTable()
+		defer dropTable(table)
+		result, err := db.Model(table).Data(g.List{
+			{
+				"id":          2,
+				"passport":    "t2",
+				"password":    "25d55ad283aa400af464c76d713c07ad",
+				"nickname":    "name_2",
+				"create_time": gtime.Now().String(),
+			},
+			{
+				"id":          3,
+				"passport":    "t3",
+				"password":    "25d55ad283aa400af464c76d713c07ad",
+				"nickname":    "name_3",
+				"create_time": gtime.Now().String(),
+			},
+		}).Batch(1).Insert()
+		if err != nil {
+			gtest.Error(err)
+		}
+		n, _ := result.RowsAffected()
+		t.Assert(n, 2)
+	})
+
+	// batch save
+	gtest.C(t, func(t *gtest.T) {
+		table := createInitTable()
+		defer dropTable(table)
+		// Scalar columns only: Save() builds a MERGE whose USING branch types a
+		// NULL as text, so the baseline table's always-NULL array columns cannot
+		// survive a read-modify-write cycle.
+		result, err := db.Model(table).Fields("id,passport,password,nickname,create_time").All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		for _, v := range result {
+			v["nickname"].Set(v["nickname"].String() + v["id"].String())
+		}
+		r, e := db.Model(table).Data(result).Save()
+		t.Assert(e, nil)
+		n, e := r.RowsAffected()
+		t.Assert(e, nil)
+		// GaussDB MERGE updates existing rows; affected rowcount varies by driver.
+		t.AssertGE(n, int64(TableSize))
+
+		// The modified nicknames were actually persisted.
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"].String(), "name_11")
+	})
+}
+
+func Test_Model_Clone(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		md := db.Model(table).Safe(true).Where("id IN(?)", g.Slice{1, 3})
+		count, err := md.Count()
+		t.AssertNil(err)
+
+		record, err := md.Safe(true).Order("id DESC").One()
+		t.AssertNil(err)
+
+		result, err := md.Safe(true).Order("id ASC").All()
+		t.AssertNil(err)
+
+		t.Assert(count, int64(2))
+		t.Assert(record["id"].Int(), 3)
+		t.Assert(len(result), 2)
+		t.Assert(result[0]["id"].Int(), 1)
+		t.Assert(result[1]["id"].Int(), 3)
+	})
+}
+
+func Test_Model_Safe(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		md := db.Model(table).Safe(false).Where("id IN(?)", g.Slice{1, 3})
+		count, err := md.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+
+		md.Where("id = ?", 1)
+		count, err = md.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(1))
+	})
+	gtest.C(t, func(t *gtest.T) {
+		md := db.Model(table).Safe(true).Where("id IN(?)", g.Slice{1, 3})
+		count, err := md.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+
+		md.Where("id = ?", 1)
+		count, err = md.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		md := db.Model(table).Safe().Where("id IN(?)", g.Slice{1, 3})
+		count, err := md.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+
+		md.Where("id = ?", 1)
+		count, err = md.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		md1 := db.Model(table).Safe()
+		md2 := md1.Where("id in (?)", g.Slice{1, 3})
+		count, err := md2.Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+
+		all, err := md2.All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+
+		all, err = md2.Page(1, 10).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+	})
+}
+
+// Test_Model_Fields ports MariaDB Test_Model_Fields with GaussDB CREATE TABLE syntax.
+func Test_Model_Fields(t *testing.T) {
+	tableName1 := createInitTable()
+	defer dropTable(tableName1)
+
+	tableName2 := "user_" + gtime.Now().TimestampNanoStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+	    CREATE TABLE %s (
+	        id    serial PRIMARY KEY,
+	        name  varchar(45) NULL,
+	        age   integer
+	    );
+	    `, tableName2,
+	)); err != nil {
+		gtest.AssertNil(err)
+	}
+	defer dropTable(tableName2)
+
+	r, err := db.Insert(ctx, tableName2, g.Map{
+		"id":   1,
+		"name": "table2_1",
+		"age":  18,
+	})
+	gtest.AssertNil(err)
+	n, _ := r.RowsAffected()
+	gtest.Assert(n, 1)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(tableName1).As("u").Fields("u.passport,u.id").Where("u.id<2").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+		t.Assert(len(all[0]), 2)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(tableName1).As("u1").
+			LeftJoin(tableName2, "u2", "u2.id=u1.id").
+			Fields("u1.passport,u1.id,u2.name,u2.age").
+			Where("u1.id<2").
+			All()
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+		t.Assert(len(all[0]), 4)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[0]["age"], 18)
+		t.Assert(all[0]["name"], "table2_1")
+		t.Assert(all[0]["passport"], "user_1")
+	})
+}
+
+func Test_Model_Value(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Fields("nickname").Where("id", 1).Value()
+		t.AssertNil(err)
+		t.Assert(value.String(), "name_1")
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Fields("nickname").Where("id", 0).Value()
+		t.AssertNil(err)
+		t.Assert(value, nil)
+	})
+}
+
+// Test_Model_Count_WithCache ports MariaDB Test_Model_Count cache branch.
+func Test_Model_Count_WithCache(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		for i := 0; i < 10; i++ {
+			count, err := db.Model(table).Cache(gdb.CacheOption{
+				Duration: time.Second * 10,
+				Name:     guid.S(),
+				Force:    false,
+			}).Count()
+			t.AssertNil(err)
+			t.Assert(count, int64(TableSize))
+		}
+	})
+	gtest.C(t, func(t *gtest.T) {
+		count, err := db.Model(table).FieldsEx("id").Where("id>8").Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(2))
+	})
+	// GaussDB has no COUNT(distinct a, b); counting a DISTINCT subquery is the
+	// equivalent formulation.
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.GetValue(ctx, fmt.Sprintf(
+			"SELECT COUNT(*) FROM (SELECT DISTINCT id, nickname FROM %s WHERE id>8) t", table,
+		))
+		t.AssertNil(err)
+		t.Assert(value.Int64(), int64(2))
+	})
+}
+
+func Test_Model_Select(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type User struct {
+		Id         int
+		Passport   string
+		Password   string
+		NickName   string
+		CreateTime gtime.Time
+	}
+	gtest.C(t, func(t *gtest.T) {
+		var users []User
+		err := db.Model(table).Scan(&users)
+		t.AssertNil(err)
+		t.Assert(len(users), TableSize)
+	})
+}
+
+func Test_Model_Struct(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime gtime.Time
+		}
+		user := new(User)
+		err := db.Model(table).Where("id=1").Scan(user)
+		t.AssertNil(err)
+		t.Assert(user.NickName, "name_1")
+		t.Assert(user.CreateTime.String(), "2018-10-24 10:00:00")
+	})
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime *gtime.Time
+		}
+		user := new(User)
+		err := db.Model(table).Where("id=1").Scan(user)
+		t.AssertNil(err)
+		t.Assert(user.NickName, "name_1")
+		t.Assert(user.CreateTime.String(), "2018-10-24 10:00:00")
+	})
+	// Auto creating struct object.
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime *gtime.Time
+		}
+		user := (*User)(nil)
+		err := db.Model(table).Where("id=1").Scan(&user)
+		t.AssertNil(err)
+		t.Assert(user.NickName, "name_1")
+		t.Assert(user.CreateTime.String(), "2018-10-24 10:00:00")
+	})
+	// sql.ErrNoRows
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime *gtime.Time
+		}
+		user := new(User)
+		err := db.Model(table).Where("id=-1").Scan(user)
+		t.Assert(err, sql.ErrNoRows)
+	})
+}
+
+func Test_Model_Structs(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime gtime.Time
+		}
+		var users []User
+		err := db.Model(table).Order("id asc").Scan(&users)
+		if err != nil {
+			gtest.Error(err)
+		}
+		t.Assert(len(users), TableSize)
+		t.Assert(users[0].Id, 1)
+		t.Assert(users[1].Id, 2)
+		t.Assert(users[2].Id, 3)
+		t.Assert(users[0].NickName, "name_1")
+		t.Assert(users[1].NickName, "name_2")
+		t.Assert(users[2].NickName, "name_3")
+		t.Assert(users[0].CreateTime.String(), "2018-10-24 10:00:00")
+	})
+	// Auto create struct slice.
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime *gtime.Time
+		}
+		var users []*User
+		err := db.Model(table).Order("id asc").Scan(&users)
+		if err != nil {
+			gtest.Error(err)
+		}
+		t.Assert(len(users), TableSize)
+		t.Assert(users[0].Id, 1)
+		t.Assert(users[1].Id, 2)
+		t.Assert(users[2].Id, 3)
+		t.Assert(users[0].NickName, "name_1")
+		t.Assert(users[1].NickName, "name_2")
+		t.Assert(users[2].NickName, "name_3")
+		t.Assert(users[0].CreateTime.String(), "2018-10-24 10:00:00")
+	})
+	// sql.ErrNoRows
+	gtest.C(t, func(t *gtest.T) {
+		type User struct {
+			Id         int
+			Passport   string
+			Password   string
+			NickName   string
+			CreateTime *gtime.Time
+		}
+		var users []*User
+		err := db.Model(table).Where("id<0").Scan(&users)
+		t.AssertNil(err)
+	})
+}
+
+func Test_Model_OrderBy(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Order("id DESC").All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(result[0]["nickname"].String(), fmt.Sprintf("name_%d", TableSize))
+	})
+
+	// GaussDB rejects `ORDER BY NULL` (the MySQL idiom for "no ordering");
+	// omitting Order entirely is the equivalent.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Order("nickname ASC").Order("id DESC").All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(result[0]["nickname"].String(), "name_1")
+	})
+
+	// GaussDB has no FIELD() function. Use CASE WHEN to emulate MySQL FIELD ordering.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Order(gdb.Raw(
+			"CASE id WHEN 10 THEN 1 WHEN 1 THEN 2 WHEN 2 THEN 3 WHEN 3 THEN 4 WHEN 4 THEN 5 " +
+				"WHEN 5 THEN 6 WHEN 6 THEN 7 WHEN 7 THEN 8 WHEN 8 THEN 9 WHEN 9 THEN 10 END",
+		)).All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(result[0]["nickname"].String(), "name_10")
+		t.Assert(result[1]["nickname"].String(), "name_1")
+		t.Assert(result[2]["nickname"].String(), "name_2")
+	})
+}
+
+func Test_Model_GroupBy(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Group("id").Order("id ASC").All()
+		t.AssertNil(err)
+		t.Assert(len(result), TableSize)
+		t.Assert(result[0]["nickname"].String(), "name_1")
+	})
+}
+
+func Test_Model_Data(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		table := createInitTable()
+		defer dropTable(table)
+		result, err := db.Model(table).Data("nickname=?", "test").Where("id=?", 3).Update()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 1)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		table := createTable()
+		defer dropTable(table)
+		users := make([]g.MapStrAny, 0)
+		for i := 1; i <= 10; i++ {
+			users = append(users, g.MapStrAny{
+				"id":          i,
+				"passport":    fmt.Sprintf(`passport_%d`, i),
+				"password":    fmt.Sprintf(`password_%d`, i),
+				"nickname":    fmt.Sprintf(`nickname_%d`, i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+		result, err := db.Model(table).Data(users).Batch(2).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 10)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		table := createTable()
+		defer dropTable(table)
+		users := garray.New()
+		for i := 1; i <= 10; i++ {
+			users.Append(g.MapStrAny{
+				"id":          i,
+				"passport":    fmt.Sprintf(`passport_%d`, i),
+				"password":    fmt.Sprintf(`password_%d`, i),
+				"nickname":    fmt.Sprintf(`nickname_%d`, i),
+				"create_time": gtime.Now().String(),
+			})
+		}
+		result, err := db.Model(table).Data(users).Batch(2).Insert()
+		t.AssertNil(err)
+		n, _ := result.RowsAffected()
+		t.Assert(n, 10)
+	})
+}
+
+func Test_Model_Offset(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Limit(2).Offset(5).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(result), 2)
+		t.Assert(result[0]["id"], 6)
+		t.Assert(result[1]["id"], 7)
+	})
+}
+
+func Test_Model_Page(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Page(3, 3).Order("id").All()
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(result[0]["id"], 7)
+		t.Assert(result[1]["id"], 8)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		model := db.Model(table).Safe().Order("id")
+		all, err := model.Page(3, 3).All()
+		count, err := model.Count()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["id"], "7")
+		t.Assert(count, int64(TableSize))
+	})
+}
+
+// Test_Model_OmitEmpty ports MariaDB version with GaussDB CREATE TABLE syntax.
+func Test_Model_OmitEmpty(t *testing.T) {
+	table := fmt.Sprintf(`table_%s`, gtime.TimestampNanoStr())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+    CREATE TABLE IF NOT EXISTS %s (
+        id serial PRIMARY KEY,
+        name varchar(45) NOT NULL
+    );
+    `, table)); err != nil {
+		gtest.Error(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).OmitEmpty().Data(g.Map{
+			"id":   1,
+			"name": "",
+		}).Save()
+		t.AssertNE(err, nil)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).OmitEmptyData().Data(g.Map{
+			"id":   1,
+			"name": "",
+		}).Save()
+		t.AssertNE(err, nil)
+	})
+}
+
+func Test_Model_OmitNil(t *testing.T) {
+	table := fmt.Sprintf(`table_%s`, gtime.TimestampNanoStr())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+    CREATE TABLE IF NOT EXISTS %s (
+        id serial PRIMARY KEY,
+        name varchar(45) NOT NULL
+    );
+    `, table)); err != nil {
+		gtest.Error(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).OmitNil().Data(g.Map{
+			"id":   1,
+			"name": nil,
+		}).Save()
+		t.AssertNE(err, nil)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Model(table).OmitNil().Data(g.Map{
+			"id":   1,
+			"name": "",
+		}).Save()
+		t.AssertNil(err)
+	})
+}
+
+func Test_Model_FieldsEx(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	// Select.
+	gtest.C(t, func(t *gtest.T) {
+		r, err := db.Model(table).FieldsEx("create_time, create_date, favorite_movie, favorite_music, numeric_values, decimal_values, id").
+			Where("id in (?)", g.Slice{1, 2}).Order("id asc").All()
+		t.AssertNil(err)
+		t.Assert(len(r), 2)
+		t.Assert(r[0]["passport"], "user_1")
+		t.Assert(r[0]["password"], "pass_1")
+		t.Assert(r[0]["nickname"], "name_1")
+		t.Assert(r[1]["passport"], "user_2")
+	})
+	// Update.
+	gtest.C(t, func(t *gtest.T) {
+		r, err := db.Model(table).FieldsEx("password").Data(g.Map{"nickname": "123", "password": "456"}).Where("id", 3).Update()
+		t.AssertNil(err)
+		n, _ := r.RowsAffected()
+		t.Assert(n, 1)
+
+		one, err := db.Model(table).Where("id", 3).One()
+		t.AssertNil(err)
+		t.Assert(one["nickname"], "123")
+		t.AssertNE(one["password"], "456")
+	})
+}
+
+// Test_Model_Join_SubQuery uses GaussDB-style double-quoted identifier.
+func Test_Model_Join_SubQuery(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+	gtest.C(t, func(t *gtest.T) {
+		subQuery := fmt.Sprintf(`select * from "%s"`, table)
+		r, err := db.Model(table, "t1").Fields("t2.id").LeftJoin(subQuery, "t2", "t2.id=t1.id").Array()
+		t.AssertNil(err)
+		t.Assert(len(r), TableSize)
+		t.Assert(r[0], "1")
+		t.Assert(r[TableSize-1], TableSize)
+	})
+}
+
+// Test_Model_Having tests the Having clause.
+// Unlike MySQL, GaussDB requires every HAVING column to be grouped or aggregated,
+// so each case pairs Having with a matching Group.
+func Test_Model_Having(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").Where("id > 1").Group("id").Having("id > 8").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").Where("id > 1").Group("id").Having("id > ?", 8).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").Where("id > ?", 1).Group("id").Having("id", 8).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 1)
+	})
+	// Having on an aggregate needs no matching Group column.
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).
+			Fields("nickname, COUNT(*) as cnt").
+			Group("nickname").
+			Having("COUNT(*) > ?", 0).
+			All()
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+	})
+}
+
+func Test_Model_Distinct(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table, "t").
+			Fields("distinct t.id").Where("id > 1").Group("t.id").Having("t.id > 8").All()
+		t.AssertNil(err)
+		t.Assert(len(all), 2)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		count, err := db.Model(table).Where("id > 1").Distinct().Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(9))
+	})
+}
+
+func Test_Model_Min_Max(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table, "t").Fields("min(t.id)").Where("id > 1").Value()
+		t.AssertNil(err)
+		t.Assert(value.Int(), 2)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table, "t").Fields("max(t.id)").Where("id > 1").Value()
+		t.AssertNil(err)
+		t.Assert(value.Int(), 10)
+	})
+}
+
+func Test_Model_Fields_AutoMapping(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Fields("ID").Where("id", 2).Value()
+		t.AssertNil(err)
+		t.Assert(value.Int(), 2)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := db.Model(table).Fields("NICK_NAME").Where("id", 2).Value()
+		t.AssertNil(err)
+		t.Assert(value.String(), "name_2")
+	})
+	// Map
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Fields(g.Map{
+			"ID":        1,
+			"NICK_NAME": 1,
+		}).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 2)
+		t.Assert(one["id"], 2)
+		t.Assert(one["nickname"], "name_2")
+	})
+	// Struct
+	gtest.C(t, func(t *gtest.T) {
+		type T struct {
+			ID       int
+			NICKNAME int
+		}
+		one, err := db.Model(table).Fields(&T{
+			ID:       0,
+			NICKNAME: 0,
+		}).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 2)
+		t.Assert(one["id"], 2)
+		t.Assert(one["nickname"], "name_2")
+	})
+}
+
+func Test_Model_Fields_Struct(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	type A struct {
+		Passport string
+		Password string
+	}
+	type B struct {
+		A
+		NickName string
+	}
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Fields(A{}).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 2)
+		t.Assert(one["passport"], "user_2")
+		t.Assert(one["password"], "pass_2")
+	})
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Fields(&A{}).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 2)
+		t.Assert(one["passport"], "user_2")
+		t.Assert(one["password"], "pass_2")
+	})
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Fields(B{}).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 3)
+		t.Assert(one["passport"], "user_2")
+		t.Assert(one["password"], "pass_2")
+		t.Assert(one["nickname"], "name_2")
+	})
+	gtest.C(t, func(t *gtest.T) {
+		one, err := db.Model(table).Fields(&B{}).Where("id", 2).One()
+		t.AssertNil(err)
+		t.Assert(len(one), 3)
+		t.Assert(one["passport"], "user_2")
+		t.Assert(one["password"], "pass_2")
+		t.Assert(one["nickname"], "name_2")
+	})
+}
+
+func Test_Model_HasTable(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		t.AssertNil(db.GetCore().ClearCacheAll(ctx))
+		result, err := db.GetCore().HasTable(table)
+		t.Assert(result, true)
+		t.AssertNil(err)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		t.AssertNil(db.GetCore().ClearCacheAll(ctx))
+		result, err := db.GetCore().HasTable("table12321")
+		t.Assert(result, false)
+		t.AssertNil(err)
+	})
+}
+
+func Test_Model_HasField(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).HasField("id")
+		t.Assert(result, true)
+		t.AssertNil(err)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).HasField("id123")
+		t.Assert(result, false)
+		t.AssertNil(err)
+	})
+}
+
+// Test_Model_UpdateAndGetAffected ports MySQL Test_Model_UpdateAndGetAffected.
+func Test_Model_UpdateAndGetAffected(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		n, err := db.Model(table).Data("nickname", "T100").
+			Where(1).Order("id desc").
+			UpdateAndGetAffected()
+		t.AssertNil(err)
+		t.Assert(n, TableSize)
+	})
+}
+
+// Test_Model_InsertAndGetId ports MySQL Test_Model_InsertAndGetId.
+func Test_Model_InsertAndGetId(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		id, err := db.Model(table).Data(g.Map{
+			"passport":    "user_1",
+			"password":    "pass_1",
+			"nickname":    "name_1",
+			"create_time": "2020-10-10 20:09:18",
+		}).InsertAndGetId()
+		t.AssertNil(err)
+		t.Assert(id, 1)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		id, err := db.Model(table).Data(g.Map{
+			"passport":    "user_2",
+			"password":    "pass_2",
+			"nickname":    "name_2",
+			"create_time": "2020-10-10 20:09:18",
+		}).InsertAndGetId()
+		t.AssertNil(err)
+		t.Assert(id, 2)
+	})
+}
+
+// Test_Model_Raw ports MySQL Test_Model_Raw.
+func Test_Model_Raw(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Raw(fmt.Sprintf("select * from %s where id>=?", table), 5).All()
+		t.AssertNil(err)
+		t.Assert(len(all), 6)
+		t.Assert(all[0]["id"], 5)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		count, err := db.Raw(fmt.Sprintf("select * from %s where id>=?", table), 5).Count()
+		t.AssertNil(err)
+		t.Assert(count, int64(6))
+	})
+}
+
+// Test_Model_Handler ports MySQL Test_Model_Handler.
+func Test_Model_Handler(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		m := db.Model(table).Safe().Handler(
+			func(m *gdb.Model) *gdb.Model {
+				return m.Page(0, 3)
+			},
+			func(m *gdb.Model) *gdb.Model {
+				return m.Where("id", g.Slice{1, 2, 3, 4, 5, 6})
+			},
+			func(m *gdb.Model) *gdb.Model {
+				return m.OrderDesc("id")
+			},
+		)
+		all, err := m.All()
+		t.AssertNil(err)
+		t.Assert(len(all), 3)
+		t.Assert(all[0]["id"], 6)
+		t.Assert(all[2]["id"], 4)
+	})
+}
+
+// Test_Model_FieldCount ports MySQL Test_Model_FieldCount.
+func Test_Model_FieldCount(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").FieldCount("id", "total").Group("id").OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[0]["total"].Int(), 1)
+	})
+}
+
+// Test_Model_FieldMax ports MySQL Test_Model_FieldMax.
+func Test_Model_FieldMax(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").FieldMax("id", "total").Group("id").OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[0]["total"].Int(), 1)
+	})
+}
+
+// Test_Model_FieldMin ports MySQL Test_Model_FieldMin.
+func Test_Model_FieldMin(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").FieldMin("id", "total").Group("id").OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[0]["total"].Int(), 1)
+	})
+}
+
+// Test_Model_FieldAvg ports MySQL Test_Model_FieldAvg.
+func Test_Model_FieldAvg(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		all, err := db.Model(table).Fields("id").FieldAvg("id", "total").Group("id").OrderAsc("id").All()
+		t.AssertNil(err)
+		t.Assert(len(all), TableSize)
+		t.Assert(all[0]["id"], 1)
+		t.Assert(all[0]["total"].Float32(), 1)
+	})
+}
+
+// Test_Model_CountColumn ports MySQL Test_Model_CountColumn.
+func Test_Model_CountColumn(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		count, err := db.Model(table).CountColumn("id")
+		t.AssertNil(err)
+		t.Assert(count, TableSize)
+	})
+}
+
+// Test_Model_Min_Max_Avg_Sum ports MySQL Test_Model_Min_Max_Avg_Sum.
+func Test_Model_Min_Max_Avg_Sum(t *testing.T) {
+	table := createInitTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Min("id")
+		t.AssertNil(err)
+		t.Assert(result, 1)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Max("id")
+		t.AssertNil(err)
+		t.Assert(result, 10)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Avg("id")
+		t.AssertNil(err)
+		t.Assert(result, 5.5)
+	})
+	gtest.C(t, func(t *gtest.T) {
+		result, err := db.Model(table).Sum("id")
+		t.AssertNil(err)
+		t.Assert(result, 55)
+	})
+}

--- a/contrib/drivers/mariadb/mariadb_z_unit_feature_cache_test.go
+++ b/contrib/drivers/mariadb/mariadb_z_unit_feature_cache_test.go
@@ -208,12 +208,13 @@ func Test_Model_PageCache(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		// First page query with cache
-		all, err := db.Model(table).PageCache(
+		all, count, err := db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
 		t.Assert(len(all), 3)
+		t.Assert(count, 10)
 
 		// Insert new record
 		_, err = db.Model(table).Data(g.Map{
@@ -223,12 +224,14 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query again - should return cached results
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // cached results
+		t.Assert(len(all), 3)
+		// Count comes from the cache, so it still reports the pre-insert value.
+		t.Assert(count, 10)
 
 		// Clear page cache by updating with Duration=-1
 		_, err = db.Model(table).Cache(gdb.CacheOption{
@@ -238,17 +241,19 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query with fresh cache - should return updated count
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // still 3 items per page
+		t.Assert(len(all), 3)
+		// Count cache was cleared above, so the new row is visible.
+		t.Assert(count, 11)
 
 		// Verify total count increased
-		count, err := db.Model(table).Count()
+		totalCount, err := db.Model(table).Count()
 		t.AssertNil(err)
-		t.Assert(count, 11)
+		t.Assert(totalCount, 11)
 	})
 }
 

--- a/contrib/drivers/mysql/mysql_z_unit_feature_cache_test.go
+++ b/contrib/drivers/mysql/mysql_z_unit_feature_cache_test.go
@@ -208,12 +208,13 @@ func Test_Model_PageCache(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		// First page query with cache
-		all, err := db.Model(table).PageCache(
+		all, count, err := db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
 		t.Assert(len(all), 3)
+		t.Assert(count, 10)
 
 		// Insert new record
 		_, err = db.Model(table).Data(g.Map{
@@ -223,12 +224,14 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query again - should return cached results
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // cached results
+		t.Assert(len(all), 3)
+		// Count comes from the cache, so it still reports the pre-insert value.
+		t.Assert(count, 10)
 
 		// Clear page cache by updating with Duration=-1
 		_, err = db.Model(table).Cache(gdb.CacheOption{
@@ -238,17 +241,19 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query with fresh cache - should return updated count
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // still 3 items per page
+		t.Assert(len(all), 3)
+		// Count cache was cleared above, so the new row is visible.
+		t.Assert(count, 11)
 
 		// Verify total count increased
-		count, err := db.Model(table).Count()
+		totalCount, err := db.Model(table).Count()
 		t.AssertNil(err)
-		t.Assert(count, 11)
+		t.Assert(totalCount, 11)
 	})
 }
 

--- a/contrib/drivers/pgsql/pgsql_convert.go
+++ b/contrib/drivers/pgsql/pgsql_convert.go
@@ -116,12 +116,14 @@ func (d *Driver) CheckLocalTypeForField(ctx context.Context, fieldType string, f
 		return gdb.LocalTypeBytes, nil
 
 	// Types whose names merely contain "int" must be listed explicitly: Core's
-	// fallback detection matches that substring, so "point" and "interval" would
-	// otherwise be classified as integers and read back as 0.
-	case "point", "interval":
+	// fallback detection matches that substring, so these would otherwise be
+	// classified as integers and read back as 0.
+	case "point", "interval",
+		"int4range", "int8range", "int4multirange", "int8multirange":
 		return gdb.LocalTypeString, nil
 
-	case "_point", "_interval":
+	case "_point", "_interval",
+		"_int4range", "_int8range", "_int4multirange", "_int8multirange":
 		return gdb.LocalTypeStringSlice, nil
 
 	case "_bytea":
@@ -221,9 +223,10 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 
 	// []string
 	case "_varchar", "_text", "_char", "_bpchar",
-		// Geometric/interval arrays have no dedicated pq scanner; their elements
-		// are read as their text representation.
-		"_point", "_interval":
+		// Geometric/interval/range arrays have no dedicated pq scanner; their
+		// elements are read as their text representation.
+		"_point", "_interval",
+		"_int4range", "_int8range", "_int4multirange", "_int8multirange":
 		var result pq.StringArray
 		if err := result.Scan(fieldValue); err != nil {
 			return nil, err

--- a/contrib/drivers/pgsql/pgsql_convert.go
+++ b/contrib/drivers/pgsql/pgsql_convert.go
@@ -115,6 +115,15 @@ func (d *Driver) CheckLocalTypeForField(ctx context.Context, fieldType string, f
 	case "bytea":
 		return gdb.LocalTypeBytes, nil
 
+	// Types whose names merely contain "int" must be listed explicitly: Core's
+	// fallback detection matches that substring, so "point" and "interval" would
+	// otherwise be classified as integers and read back as 0.
+	case "point", "interval":
+		return gdb.LocalTypeString, nil
+
+	case "_point", "_interval":
+		return gdb.LocalTypeStringSlice, nil
+
 	case "_bytea":
 		return gdb.LocalTypeBytesSlice, nil
 
@@ -211,7 +220,10 @@ func (d *Driver) ConvertValueForLocal(ctx context.Context, fieldType string, fie
 		return []bool(result), nil
 
 	// []string
-	case "_varchar", "_text", "_char", "_bpchar":
+	case "_varchar", "_text", "_char", "_bpchar",
+		// Geometric/interval arrays have no dedicated pq scanner; their elements
+		// are read as their text representation.
+		"_point", "_interval":
 		var result pq.StringArray
 		if err := result.Scan(fieldValue); err != nil {
 			return nil, err

--- a/contrib/drivers/pgsql/pgsql_z_unit_feature_cache_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_feature_cache_test.go
@@ -68,16 +68,10 @@ func Test_Model_Cache_TTL(t *testing.T) {
 		_, err = db.Model(table).Data(g.Map{"passport": "ttl_test"}).Where("id", 1).Update()
 		t.AssertNil(err)
 
-		// Immediate query - cache still valid
-		one, err = db.Model(table).Cache(gdb.CacheOption{
-			Duration: time.Millisecond * 100,
-			Name:     "test_cache_ttl",
-		}).Where("id", 1).One()
-		t.AssertNil(err)
-		t.Assert(one["passport"], "user_1") // cached value
-
-		// Wait for cache to expire
-		time.Sleep(time.Millisecond * 150)
+		// Wait for cache to expire. Serving the cached value before it expires is
+		// covered by Test_Model_Cache_Basic, whose TTL is wide enough that a slow
+		// database round trip cannot exhaust it.
+		time.Sleep(time.Millisecond * 300)
 
 		// Query after expiration - should get fresh data
 		one, err = db.Model(table).Cache(gdb.CacheOption{

--- a/contrib/drivers/pgsql/pgsql_z_unit_feature_cache_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_feature_cache_test.go
@@ -204,12 +204,13 @@ func Test_Model_PageCache(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		// First page query with cache
-		all, err := db.Model(table).PageCache(
+		all, count, err := db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
 		t.Assert(len(all), 3)
+		t.Assert(count, 10)
 
 		// Insert new record
 		_, err = db.Model(table).Data(g.Map{
@@ -219,12 +220,14 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query again - should return cached results
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // cached results
+		t.Assert(len(all), 3)
+		// Count comes from the cache, so it still reports the pre-insert value.
+		t.Assert(count, 10)
 
 		// Clear page cache by updating with Duration=-1
 		_, err = db.Model(table).Cache(gdb.CacheOption{
@@ -234,17 +237,19 @@ func Test_Model_PageCache(t *testing.T) {
 		t.AssertNil(err)
 
 		// Query with fresh cache - should return updated count
-		all, err = db.Model(table).PageCache(
+		all, count, err = db.Model(table).PageCache(
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_count"},
 			gdb.CacheOption{Duration: time.Second * 10, Name: "test_page_data"},
-		).Page(1, 3).All()
+		).Page(1, 3).AllAndCount(false)
 		t.AssertNil(err)
-		t.Assert(len(all), 3) // still 3 items per page
+		t.Assert(len(all), 3)
+		// Count cache was cleared above, so the new row is visible.
+		t.Assert(count, 11)
 
 		// Verify total count increased
-		count, err := db.Model(table).Count()
+		totalCount, err := db.Model(table).Count()
 		t.AssertNil(err)
-		t.Assert(count, 11)
+		t.Assert(totalCount, 11)
 	})
 }
 

--- a/contrib/drivers/pgsql/pgsql_z_unit_issue_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_issue_test.go
@@ -2221,3 +2221,59 @@ func Test_Issue4698(t *testing.T) {
 func Test_Issue2231(t *testing.T) {
 	t.Skip("MariaDB-specific regex link test not applicable to PostgreSQL")
 }
+
+// Test_IssuePointInterval_NotConvertedToInt verifies that column types whose
+// names merely contain an integer keyword are not converted to integers.
+//
+// gdb's fallback type detection matches "int" as a substring, so "point" and
+// "interval" were both classified as integers and their values became 0.
+func Test_IssuePointInterval_NotConvertedToInt(t *testing.T) {
+	table := "issue_point_interval_" + gtime.TimestampMicroStr()
+	if _, err := db.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id int PRIMARY KEY, pt point, span interval, pts point[], spans interval[])`,
+		table,
+	)); err != nil {
+		gtest.Fatal(err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		_, err := db.Exec(ctx, fmt.Sprintf(
+			`INSERT INTO %s VALUES (1, '(1.5,2.5)', '2 days', '{"(1,2)","(3,4)"}', '{"1 day","2 days"}')`,
+			table,
+		))
+		t.AssertNil(err)
+
+		one, err := db.Model(table).Where("id", 1).One()
+		t.AssertNil(err)
+
+		// Scalar values keep their real content instead of collapsing to 0.
+		t.Assert(one["pt"].String(), "(1.5,2.5)")
+		t.Assert(one["span"].String(), "2 days")
+
+		// Array forms are read as their element text representation.
+		t.Assert(one["pts"].Strings(), g.SliceStr{"(1,2)", "(3,4)"})
+		t.Assert(one["spans"].Strings(), g.SliceStr{"1 day", "2 days"})
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		// Real integer columns are unaffected.
+		intTable := "issue_int_control_" + gtime.TimestampMicroStr()
+		if _, err := db.Exec(ctx, fmt.Sprintf(
+			`CREATE TABLE %s (id int PRIMARY KEY, a int2, b int4, c int8, d int4[])`, intTable,
+		)); err != nil {
+			gtest.Fatal(err)
+		}
+		defer dropTable(intTable)
+
+		_, err := db.Exec(ctx, fmt.Sprintf(`INSERT INTO %s VALUES (1, 1, 2, 3, '{4,5}')`, intTable))
+		t.AssertNil(err)
+
+		one, err := db.Model(intTable).Where("id", 1).One()
+		t.AssertNil(err)
+		t.Assert(one["a"].Int(), 1)
+		t.Assert(one["b"].Int(), 2)
+		t.Assert(one["c"].Int64(), int64(3))
+		t.Assert(one["d"].Ints(), []int{4, 5})
+	})
+}

--- a/contrib/drivers/pgsql/pgsql_z_unit_issue_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_issue_test.go
@@ -2230,7 +2230,11 @@ func Test_Issue2231(t *testing.T) {
 func Test_IssuePointInterval_NotConvertedToInt(t *testing.T) {
 	table := "issue_point_interval_" + gtime.TimestampMicroStr()
 	if _, err := db.Exec(ctx, fmt.Sprintf(
-		`CREATE TABLE %s (id int PRIMARY KEY, pt point, span interval, pts point[], spans interval[])`,
+		`CREATE TABLE %s (
+			id int PRIMARY KEY, pt point, span interval,
+			r4 int4range, r8 int8range, mr int4multirange,
+			pts point[], spans interval[]
+		)`,
 		table,
 	)); err != nil {
 		gtest.Fatal(err)
@@ -2239,7 +2243,11 @@ func Test_IssuePointInterval_NotConvertedToInt(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		_, err := db.Exec(ctx, fmt.Sprintf(
-			`INSERT INTO %s VALUES (1, '(1.5,2.5)', '2 days', '{"(1,2)","(3,4)"}', '{"1 day","2 days"}')`,
+			`INSERT INTO %s VALUES (
+				1, '(1.5,2.5)', '2 days',
+				'[1,5)', '[10,50)', '{[1,5)}',
+				'{"(1,2)","(3,4)"}', '{"1 day","2 days"}'
+			)`,
 			table,
 		))
 		t.AssertNil(err)
@@ -2250,6 +2258,9 @@ func Test_IssuePointInterval_NotConvertedToInt(t *testing.T) {
 		// Scalar values keep their real content instead of collapsing to 0.
 		t.Assert(one["pt"].String(), "(1.5,2.5)")
 		t.Assert(one["span"].String(), "2 days")
+		t.Assert(one["r4"].String(), "[1,5)")
+		t.Assert(one["r8"].String(), "[10,50)")
+		t.Assert(one["mr"].String(), "{[1,5)}")
 
 		// Array forms are read as their element text representation.
 		t.Assert(one["pts"].Strings(), g.SliceStr{"(1,2)", "(3,4)"})


### PR DESCRIPTION
## Summary

Ports the remaining feature suites from the MySQL/PgSQL baseline to GaussDB.
Doing so surfaced 8 bugs — in the driver, in the ported tests, and in the
existing tests they were ported from — all fixed here.

Test functions go from 260 to 496. 488 pass, 0 fail, 8 skip against openGauss
7.0.0-RC1 (the image CI uses). The 8 skips are the partition suite, because
`Model.Partition()` is a no-op on every driver (#4826).

Nothing under `database/` is touched.

## Bugs found and fixed

**1. Binary data written to a `bytea` column could come back corrupted.**

Any byte that happened to be `[` or `]` was silently rewritten, because the
driver treated every byte slice as a PostgreSQL array literal and ran a
character replacement over it. So a PNG, a gzip blob or an encrypted payload
would round trip fine right up until it happened to contain 0x5B.

The driver now passes `[]byte` straight through. PgSQL had the identical bug
and got it fixed in #4678; gaussdb was missed at the time.

**2. Reading a row and writing it back failed if any column was NULL.**

`Save` and `Replace` are built as a `MERGE`. The NULL placeholder inside it
carries no type, GaussDB assumes `text`, and assigning text back to a real
column fails:

```
pq: column "tags" is of type numeric[] but expression is of type text
```

So the ordinary read-modify-write cycle was broken for any nullable column that
wasn't text. NULL placeholders are now cast to the column's actual type.

Non-NULL values have the same problem for the same reason, with a wider blast
radius — that one is tracked separately in #4843.

**3. Values in `point` and `interval` columns were read back as 0.**

gdb decides whether a column is an integer by looking for `int` inside its type
name. `point` contains "int". So does `interval`, `tinterval`, `int4range` and
their array forms — all of them were converted to integers, and the value
became 0.

These types are now listed in each driver's override table, alongside the ones
already there for the same reason. Changing the shared fallback instead would
affect drivers this was never tested against.

silently useless.

**4. `Test_Model_PageCache` never actually tested `PageCache`** — in gaussdb,
mysql, mariadb and pgsql.

`PageCache` only has an effect on `AllAndCount` and `ScanAndCount`, but the test
called `All()`, so the setting was ignored. Even so the test couldn't tell:
it asserted "the first page still has 3 rows" after inserting an 11th row —
which is true whether the cache works or not.

It now calls `AllAndCount` and asserts the **count**, which is what the cache
actually changes: right after the insert the cached count must still say 10, and
only after the cache is cleared may it say 11.

All four copies are fixed. The test is identical across the drivers, so fixing
one would leave three of them asserting nothing.

**5. `Test_Model_Cache_TTL` failed at random** — in gaussdb and pgsql.

It gave a cached entry a 100ms lifetime and then expected it to still be there
after a database round trip. On a busy runner the entry expires first. The run
that caught this spent ~320ms in the database.

That assertion was also redundant — `Test_Model_Cache_Basic`, two functions
above, already covers it with a 10s TTL. Removing it leaves this test covering
only expiry, which just needs a long enough sleep.

Only gaussdb and pgsql are touched here. mysql and mariadb have the same 100ms
pattern from #4706, but there it's plain flakiness rather than an inconsistency
introduced by this branch, so it's left for a separate change.

**6. An empty `bytea` was accepted even if it came back as nil.**

It was checked with `len(...) == 0`, which `nil` also satisfies — even though
the comment right above promises "non-nil", and the very next test is the NULL
case. Now also asserts it is not nil.

**7. A test named "datetime precision" only compared down to the second.**

It wrote `.123456` into a `timestamp(6)` and then truncated the comparison, so
losing or mangling the microseconds went unnoticed. Now asserts them.

**8. `All()`'s error was overwritten by `Count()`'s before being checked.**

A failed query showed up as "0 != 3" instead of the actual database error.

## Dialect notes

Upsert uses `MERGE` (GaussDB has no `ON CONFLICT`). JSON uses `->`, `->>` and
`json_agg`, since `jsonb || jsonb` and the SQL/JSON path functions don't exist.
`ENUM` comes from `CREATE TYPE`, and the geometric types are built in — no
PostGIS needed. `HAVING` requires its columns grouped or aggregated.

Concurrency assertions run after `Wait()` instead of inside the workers: a
gtest assertion panics on failure, and a panic in a spawned goroutine isn't
recovered — it aborted the entire test binary instead of failing one case.

The twelve `t.Skip` stubs inherited from the PgSQL baseline are now real tests.
Two of their claims turned out to be wrong: `UPDATE ... ORDER BY` does work, and
`ENUM` and the geometric types are natively available.

## Test plan

- [x] 488 pass / 0 fail / 8 skip on openGauss 7.0.0-RC1; the full pgsql suite passes
- [x] Main CI green on all 6 jobs, so the tightened assertions in 4 and 6-8 are
