### PR TITLE
fix(net/goai): nil pointer dereference when an array with enum has an interface element (#4746)

### DIFF
--- a/net/goai/goai_shema_ref.go
+++ b/net/goai/goai_shema_ref.go
@@ -123,7 +123,14 @@ func (oai *OpenApiV3) newSchemaRefWithGolangType(golangType reflect.Type, tagMap
 		}
 		schema.Items = subSchemaRef
 		if len(schema.Enum) > 0 {
-			schema.Items.Value.Enum = schema.Enum
+			if schema.Items.Value != nil {
+				schema.Items.Value.Enum = schema.Enum
+			} else {
+				schema.Items = &SchemaRef{Value: &Schema{
+					AllOf: SchemaRefs{*subSchemaRef},
+					Enum:  schema.Enum,
+				}}
+			}
 			schema.Enum = nil
 		}
 

--- a/net/goai/goai_z_unit_issue_test.go
+++ b/net/goai/goai_z_unit_issue_test.go
@@ -483,3 +483,90 @@ func Test_Issue4247(t *testing.T) {
 		t.Assert(j.Get(`paths./cluster/{cluster_id}/node/{name}/join.post.requestBody`).String(), requestBody)
 	})
 }
+
+// https://github.com/gogf/gf/issues/4746
+func Test_Issue4746(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type Issue4746InterfaceReq struct {
+			g.Meta `path:"/interface" method:"post"`
+			Values []any `json:"values" v:"in:a,b"`
+		}
+		type Issue4746InterfaceRes struct{}
+
+		f := func(ctx context.Context, req *Issue4746InterfaceReq) (res *Issue4746InterfaceRes, err error) {
+			return
+		}
+
+		oai := goai.New()
+		err := oai.Add(goai.AddInput{Object: f})
+		t.AssertNil(err)
+
+		schemaRef := oai.Components.Schemas.Get(`github.com.gogf.gf.v2.net.goai_test.Issue4746InterfaceReq`)
+		t.AssertNE(schemaRef, nil)
+		values := schemaRef.Value.Properties.Get(`values`)
+		t.AssertNE(values, nil)
+		t.Assert(values.Value.Type, goai.TypeArray)
+		t.Assert(len(values.Value.Enum), 0)
+		t.AssertNE(values.Value.Items, nil)
+		t.AssertNE(values.Value.Items.Value, nil)
+		t.Assert(values.Value.Items.Value.Enum, g.Slice{"a", "b"})
+		t.Assert(len(values.Value.Items.Value.AllOf), 1)
+		t.AssertNE(values.Value.Items.Value.AllOf[0].Ref, "")
+
+		b, err := values.MarshalJSON()
+		t.AssertNil(err)
+		j := gjson.New(b)
+		t.Assert(j.Get(`enum`).IsNil(), true)
+		t.Assert(j.Get(`items.enum`).Strings(), g.SliceStr{"a", "b"})
+		t.AssertNE(j.Get(`items.allOf.0.$ref`).String(), "")
+	})
+	gtest.C(t, func(t *gtest.T) {
+		type Issue4746StringReq struct {
+			g.Meta `path:"/string" method:"post"`
+			Values []string `json:"values" v:"in:a,b"`
+		}
+		type Issue4746StringRes struct{}
+
+		f := func(ctx context.Context, req *Issue4746StringReq) (res *Issue4746StringRes, err error) {
+			return
+		}
+
+		oai := goai.New()
+		err := oai.Add(goai.AddInput{Object: f})
+		t.AssertNil(err)
+
+		schemaRef := oai.Components.Schemas.Get(`github.com.gogf.gf.v2.net.goai_test.Issue4746StringReq`)
+		t.AssertNE(schemaRef, nil)
+		values := schemaRef.Value.Properties.Get(`values`)
+		t.AssertNE(values, nil)
+		t.Assert(values.Value.Type, goai.TypeArray)
+		t.Assert(len(values.Value.Enum), 0)
+		t.AssertNE(values.Value.Items, nil)
+		t.AssertNE(values.Value.Items.Value, nil)
+		t.Assert(values.Value.Items.Value.Enum, g.Slice{"a", "b"})
+	})
+	gtest.C(t, func(t *gtest.T) {
+		type Issue4746NoEnumReq struct {
+			g.Meta `path:"/no-enum" method:"post"`
+			Values []any `json:"values"`
+		}
+		type Issue4746NoEnumRes struct{}
+
+		f := func(ctx context.Context, req *Issue4746NoEnumReq) (res *Issue4746NoEnumRes, err error) {
+			return
+		}
+
+		oai := goai.New()
+		err := oai.Add(goai.AddInput{Object: f})
+		t.AssertNil(err)
+
+		schemaRef := oai.Components.Schemas.Get(`github.com.gogf.gf.v2.net.goai_test.Issue4746NoEnumReq`)
+		t.AssertNE(schemaRef, nil)
+		values := schemaRef.Value.Properties.Get(`values`)
+		t.AssertNE(values, nil)
+		t.Assert(values.Value.Type, goai.TypeArray)
+		t.Assert(len(values.Value.Enum), 0)
+		t.AssertNE(values.Value.Items, nil)
+		t.AssertNil(values.Value.Items.Value)
+	})
+}


### PR DESCRIPTION
## Summary

Setting `openapiPath` panics with `invalid memory address or nil pointer dereference` when a request/response struct has a slice-of-interface field carrying an enum:

```go
type Req struct {
    g.Meta `path:"/test" method:"post"`
    Values []any `json:"values" v:"in:a,b"`
}
```

The panic happens while building the spec, so it only surfaces once `openapiPath` is set — that is what triggers `initOpenApi`. The stack in the issue shows no `gf` frames because `gerror` was in brief mode, which is why it was reported as an OpenTelemetry incompatibility.

## Root cause

In `newSchemaRefWithGolangType`, an array moves its enum down to the items, because `v:"in:a,b"` on a slice field constrains each element and OpenAPI expects that on `items.enum`:

```go
schema.Items = subSchemaRef
if len(schema.Enum) > 0 {
    schema.Items.Value.Enum = schema.Enum
    schema.Enum = nil
}
```

This assumes the items always have a `Value`. An interface element takes the `reflect.Interface` branch of that same function, which returns a Ref-only `SchemaRef` (`Ref` set, `Value = nil`), so the assignment dereferences a nil pointer.

## Changes

When the items are Ref-only, wrap the reference in `allOf` and put the enum on that wrapper. The enum still ends up constraining the elements, and the `$ref` is preserved — OpenAPI 3.0 ignores keywords that sit as siblings of `$ref`, so `allOf` is the standard way to attach them.

```json
// []any with v:"in:a,b"
{"type":"array","items":{"allOf":[{"$ref":"#/components/schemas/interface"}],"enum":["a","b"]}}

// []string with v:"in:a,b" — unchanged
{"type":"array","items":{"enum":["a","b"],"type":"string"}}
```

Only the previously panicking path is affected; arrays whose items are inline keep the existing behaviour.

## Tests

`Test_Issue4746` covers an interface element with an enum (panics before this change, and the serialized form is asserted through `MarshalJSON`), a string element with an enum (must still move down to the items), and an interface element without an enum.