### PR TITLE
fix(util/gconv): unwrap reflect.Value and support pointer element slices

### DIFF
--- a/util/gconv/gconv_z_unit_scan_basic_types_test.go
+++ b/util/gconv/gconv_z_unit_scan_basic_types_test.go
@@ -7,6 +7,7 @@
 package gconv_test
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -167,5 +168,119 @@ func TestScanBasicTypes(t *testing.T) {
 		t.AssertNil(err)
 		t.AssertNE(i, nil)
 		t.Assert(*i, v)
+	})
+}
+
+// TestScanReflectValueInput tests that the basic converter functions correctly unwrap
+// reflect.Value inputs instead of treating the wrapper as the converted value.
+func TestScanReflectValueInput(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		// reflect.Value wrapping a bool.
+		t.Assert(gconv.Bool(reflect.ValueOf(true)), true)
+		t.Assert(gconv.Bool(reflect.ValueOf(false)), false)
+		// reflect.Value wrapping an int.
+		t.Assert(gconv.Int64(reflect.ValueOf(42)), int64(42))
+		t.Assert(gconv.Int(reflect.ValueOf(42)), 42)
+		// reflect.Value wrapping a uint.
+		t.Assert(gconv.Uint64(reflect.ValueOf(uint(42))), uint64(42))
+		// reflect.Value wrapping a float.
+		t.Assert(gconv.Float64(reflect.ValueOf(3.14)), 3.14)
+		t.Assert(gconv.Float32(reflect.ValueOf(float32(1.5))), float32(1.5))
+		// reflect.Value wrapping a string.
+		t.Assert(gconv.String(reflect.ValueOf("hello")), "hello")
+		// reflect.Value wrapping non-string kinds should unwrap and convert correctly,
+		// not return the reflection type name (e.g. "<int Value>").
+		t.Assert(gconv.String(reflect.ValueOf(42)), "42")
+		t.Assert(gconv.String(reflect.ValueOf(3.14)), "3.14")
+		t.Assert(gconv.String(reflect.ValueOf(true)), "true")
+	})
+}
+
+// TestScanPointerElementSlice tests scanning into slices whose elements are pointers to
+// basic types (e.g. []*int, []*string), which is supported by converter_scan.go.
+func TestScanPointerElementSlice(t *testing.T) {
+	// []string -> []*string
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			src = []string{"a", "b", "c"}
+			dst []*string
+		)
+		err := gconv.Scan(src, &dst)
+		t.AssertNil(err)
+		t.Assert(len(dst), len(src))
+		for i, v := range src {
+			t.AssertNE(dst[i], nil)
+			t.Assert(*dst[i], v)
+		}
+	})
+	// []int -> []*int
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			src = []int{1, 2, 3}
+			dst []*int
+		)
+		err := gconv.Scan(src, &dst)
+		t.AssertNil(err)
+		t.Assert(len(dst), len(src))
+		for i, v := range src {
+			t.AssertNE(dst[i], nil)
+			t.Assert(*dst[i], v)
+		}
+	})
+	// []int64 -> []*int64
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			src = []int64{10, 20, 30}
+			dst []*int64
+		)
+		err := gconv.Scan(src, &dst)
+		t.AssertNil(err)
+		t.Assert(len(dst), len(src))
+		for i, v := range src {
+			t.AssertNE(dst[i], nil)
+			t.Assert(*dst[i], v)
+		}
+	})
+	// []float64 -> []*float64
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			src = []float64{1.1, 2.2, 3.3}
+			dst []*float64
+		)
+		err := gconv.Scan(src, &dst)
+		t.AssertNil(err)
+		t.Assert(len(dst), len(src))
+		for i, v := range src {
+			t.AssertNE(dst[i], nil)
+			t.Assert(*dst[i], v)
+		}
+	})
+	// []bool -> []*bool
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			src = []bool{true, false, true}
+			dst []*bool
+		)
+		err := gconv.Scan(src, &dst)
+		t.AssertNil(err)
+		t.Assert(len(dst), len(src))
+		for i, v := range src {
+			t.AssertNE(dst[i], nil)
+			t.Assert(*dst[i], v)
+		}
+	})
+	// []string -> []*int (cross-type pointer element conversion)
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			src = []string{"1", "2", "3"}
+			dst []*int
+		)
+		err := gconv.Scan(src, &dst)
+		t.AssertNil(err)
+		t.Assert(len(dst), len(src))
+		for i, v := range []int{1, 2, 3} {
+			t.AssertNE(dst[i], nil)
+			t.Assert(*dst[i], v)
+		}
 	})
 }

--- a/util/gconv/internal/converter/converter_bool.go
+++ b/util/gconv/internal/converter/converter_bool.go
@@ -40,6 +40,11 @@ func (c *Converter) Bool(anyInput any) (bool, error) {
 		}
 		return true, nil
 	default:
+		if rv, ok := value.(reflect.Value); ok {
+			if rv.IsValid() && rv.CanInterface() {
+				return c.Bool(rv.Interface())
+			}
+		}
 		if f, ok := value.(localinterface.IBool); ok {
 			return f.Bool(), nil
 		}

--- a/util/gconv/internal/converter/converter_float.go
+++ b/util/gconv/internal/converter/converter_float.go
@@ -31,6 +31,12 @@ func (c *Converter) Float32(anyInput any) (float32, error) {
 		// TODO: It might panic here for these types.
 		return gbinary.DecodeToFloat32(value), nil
 	default:
+		// Unwrap reflect.Value input for consistency with Bool converter.
+		if rv, ok := anyInput.(reflect.Value); ok {
+			if rv.IsValid() && rv.CanInterface() {
+				return c.Float32(rv.Interface())
+			}
+		}
 		rv := reflect.ValueOf(anyInput)
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -93,6 +99,12 @@ func (c *Converter) Float64(anyInput any) (float64, error) {
 		// TODO: It might panic here for these types.
 		return gbinary.DecodeToFloat64(value), nil
 	default:
+		// Unwrap reflect.Value input for consistency with Bool converter.
+		if rv, ok := anyInput.(reflect.Value); ok {
+			if rv.IsValid() && rv.CanInterface() {
+				return c.Float64(rv.Interface())
+			}
+		}
 		rv := reflect.ValueOf(anyInput)
 		switch rv.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/util/gconv/internal/converter/converter_int.go
+++ b/util/gconv/internal/converter/converter_int.go
@@ -74,6 +74,12 @@ func (c *Converter) Int64(anyInput any) (int64, error) {
 	if v, ok := anyInput.(int64); ok {
 		return v, nil
 	}
+	// Unwrap reflect.Value input for consistency with Bool converter.
+	if rv, ok := anyInput.(reflect.Value); ok {
+		if rv.IsValid() && rv.CanInterface() {
+			return c.Int64(rv.Interface())
+		}
+	}
 	rv := reflect.ValueOf(anyInput)
 	switch rv.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/util/gconv/internal/converter/converter_scan.go
+++ b/util/gconv/internal/converter/converter_scan.go
@@ -183,43 +183,54 @@ func (c *Converter) Scan(srcValue any, dstPointer any, option ...ScanOption) (er
 				srcLen   = srcValueReflectValue.Len()
 				newSlice = reflect.MakeSlice(dstPointerReflectValueElem.Type(), srcLen, srcLen)
 			)
-			for i := 0; i < srcLen; i++ {
+			for i := range srcLen {
 				srcElem := srcValueReflectValue.Index(i).Interface()
+				target := newSlice.Index(i)
+
+				if target.Kind() == reflect.Pointer {
+					if target.IsNil() {
+						target.Set(reflect.New(target.Type().Elem()))
+					}
+					target = target.Elem()
+				}
+
 				switch dstElemType.Kind() {
 				case reflect.String:
 					v, err := c.String(srcElem)
 					if err != nil && !scanOption.ContinueOnError {
 						return err
 					}
-					newSlice.Index(i).SetString(v)
+					target.SetString(v)
 				case reflect.Int:
 					v, err := c.Int64(srcElem)
 					if err != nil && !scanOption.ContinueOnError {
 						return err
 					}
-					newSlice.Index(i).SetInt(v)
+					target.SetInt(v)
 				case reflect.Int64:
 					v, err := c.Int64(srcElem)
 					if err != nil && !scanOption.ContinueOnError {
 						return err
 					}
-					newSlice.Index(i).SetInt(v)
+					target.SetInt(v)
 				case reflect.Float64:
 					v, err := c.Float64(srcElem)
 					if err != nil && !scanOption.ContinueOnError {
 						return err
 					}
-					newSlice.Index(i).SetFloat(v)
+					target.SetFloat(v)
 				case reflect.Bool:
 					v, err := c.Bool(srcElem)
 					if err != nil && !scanOption.ContinueOnError {
 						return err
 					}
-					newSlice.Index(i).SetBool(v)
+					target.SetBool(v)
 				default:
-					err = c.Scan(
-						srcElem, newSlice.Index(i).Addr().Interface(), option...,
-					)
+					if target.Kind() == reflect.Pointer {
+						err = c.Scan(srcElem, target.Interface(), option...)
+					} else {
+						err = c.Scan(srcElem, target.Addr().Interface(), option...)
+					}
 					if err != nil && !scanOption.ContinueOnError {
 						return err
 					}

--- a/util/gconv/internal/converter/converter_string.go
+++ b/util/gconv/internal/converter/converter_string.go
@@ -78,6 +78,14 @@ func (c *Converter) String(anyInput any) (string, error) {
 		}
 		return value.String(), nil
 	default:
+		// Unwrap reflect.Value input early so that the IString/IError checks below
+		// do not accidentally match reflect.Value's own String() method, which returns
+		// the reflection type name (e.g. "<int Value>") instead of the actual value.
+		if rv, ok := value.(reflect.Value); ok {
+			if rv.IsValid() && rv.CanInterface() {
+				return c.String(rv.Interface())
+			}
+		}
 		if f, ok := value.(localinterface.IString); ok {
 			// If the variable implements the String() interface,
 			// then use that interface to perform the conversion

--- a/util/gconv/internal/converter/converter_uint.go
+++ b/util/gconv/internal/converter/converter_uint.go
@@ -74,6 +74,12 @@ func (c *Converter) Uint64(anyInput any) (uint64, error) {
 	if v, ok := anyInput.(uint64); ok {
 		return v, nil
 	}
+	// Unwrap reflect.Value input for consistency with Bool converter.
+	if rv, ok := anyInput.(reflect.Value); ok {
+		if rv.IsValid() && rv.CanInterface() {
+			return c.Uint64(rv.Interface())
+		}
+	}
 	rv := reflect.ValueOf(anyInput)
 	switch rv.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:


### PR DESCRIPTION
Extracted from #4716: these `gconv` bugs already exist on master and are independent of the Scan-into-basic-type feature.

## Problem

On master:

```go
gconv.Int64(reflect.ValueOf(42))          // 0
gconv.Bool(reflect.ValueOf(false))        // true
gconv.String(reflect.ValueOf(42))         // "<int Value>"

vs := gvar.Vars{gvar.New(1), gvar.New(2)}
var ids []*int64
vs.Scan(&ids)                             // panic: SetInt on ptr Value
```

`Bool`/`Int64`/`Uint64`/`Float*` treat `reflect.Value` as the converted value. `String()` hits `reflect.Value.String()` and returns the reflection type name. Slice `Scan` into `[]*T` calls `SetInt`/`SetString` on a pointer value.

## Fix

- Unwrap interfaceable `reflect.Value` inputs in the basic converters
- Allocate pointer slice elements before assigning scanned values

## Test plan

- [x] `go test -count=1 ./util/gconv/`
- [x] `TestScanReflectValueInput`
- [x] `TestScanPointerElementSlice`

Related: #4716 (feature PR should rebase onto this after merge)