### PR TITLE
ci: update the CI/CD dependency versions and scripts

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -260,8 +260,10 @@ jobs:
 
     - name: Install the protocol compiler plugins for Go
       run: |
-        go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        # Pinned: protoc-gen-go-grpc v1.6.0 requires Go >= 1.24 and v1.6.2 requires
+        # Go >= 1.25, either of which breaks the older matrix entries.
+        go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.12
+        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
         export PATH="$PATH:$(go env GOPATH)/bin"
 
     - name: Before Script

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -223,7 +223,7 @@ jobs:
         timezoneLinux: "Asia/Shanghai"
 
     - name: Checkout Repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Setup tmate Session
       uses: mxschmitt/action-tmate@v3
@@ -251,7 +251,7 @@ jobs:
       run:  docker compose -f ".github/workflows/consul/docker-compose.yml" up -d --build
 
     - name: Setup Golang ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: '**/go.sum'
@@ -292,7 +292,7 @@ jobs:
       run:  docker compose -f ".github/workflows/consul/docker-compose.yml" down
 
     - name: Report Coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       # Only report coverage on the latest go version
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.go-version == env.LATEST_GO_VERSION }}
       with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -36,7 +36,7 @@ concurrency:
 env:
   TZ: "Asia/Shanghai"
   # for unit testing cases of some components that only execute on the latest go version.
-  LATEST_GO_VERSION: "1.25"
+  LATEST_GO_VERSION: "1.26"
 
 jobs:
   code-test:
@@ -46,7 +46,7 @@ jobs:
         # When adding new go version to the list, make sure:
         # 1. Update the `LATEST_GO_VERSION` env variable.
         # 🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
-        go-version: [ "1.23", "1.24", "1.25" ]
+        go-version: [ "1.23", "1.24", "1.25", "1.26" ]
         goarch: [ "386", "amd64" ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -215,12 +215,8 @@ jobs:
           - 2181:2181
 
     steps:
-    # TODO: szenius/set-timezone update to node16
-    # sudo ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
     - name: Setup Timezone
-      uses: szenius/set-timezone@v2.0
-      with:
-        timezoneLinux: "Asia/Shanghai"
+      run:  sudo ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
     - name: Checkout Repository
       uses: actions/checkout@v7

--- a/.github/workflows/ci-sub.yml
+++ b/.github/workflows/ci-sub.yml
@@ -30,7 +30,7 @@ concurrency:
 env:
   TZ: "Asia/Shanghai"
   # for unit testing cases of some components that only execute on the latest go version.
-  LATEST_GO_VERSION: "1.25"
+  LATEST_GO_VERSION: "1.26"
 
 jobs:
   code-test:
@@ -40,7 +40,7 @@ jobs:
         # When adding new go version to the list, make sure:
         # 1. Update the `LATEST_GO_VERSION` env variable.
         # 🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
-        go-version: [ "1.23", "1.24", "1.25" ]
+        go-version: [ "1.23", "1.24", "1.25", "1.26" ]
         goarch: [ "386", "amd64" ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-sub.yml
+++ b/.github/workflows/ci-sub.yml
@@ -47,9 +47,7 @@ jobs:
 
     steps:
     - name: Setup Timezone
-      uses: szenius/set-timezone@v2.0
-      with:
-        timezoneLinux: "Asia/Shanghai"
+      run:  sudo ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
 
     - name: Checkout Repository
       uses: actions/checkout@v7

--- a/.github/workflows/ci-sub.yml
+++ b/.github/workflows/ci-sub.yml
@@ -52,13 +52,13 @@ jobs:
         timezoneLinux: "Asia/Shanghai"
 
     - name: Checkout Repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     - name: Start Minikube
       uses: medyagh/setup-minikube@master
 
     - name: Setup Golang ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
         cache-dependency-path: '**/go.sum' 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/format-code-on-push.yml
+++ b/.github/workflows/format-code-on-push.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Setup Golang ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install gci

--- a/.github/workflows/format-code-on-push.yml
+++ b/.github/workflows/format-code-on-push.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install gci
-        run: go install github.com/daixiang0/gci@latest
+        run: go install github.com/daixiang0/gci@v0.13.6 # keep in sync with scripts/before_script.sh
       - name: Run gci
         run: |
           gci write --custom-order \

--- a/.github/workflows/gitee-sync.yml
+++ b/.github/workflows/gitee-sync.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Mirror GitHub to Gitee
-        uses: Yikun/hub-mirror-action@v1.4
+        uses: Yikun/hub-mirror-action@v1.5
         with:
           src: github/gogf
           dst: gitee/johng

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -35,15 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Setup Golang ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
       - name: golang-ci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           # Required: specify the golangci-lint version without the patch version to always use the latest patch.
           only-new-issues: true

--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -14,15 +14,40 @@ permissions:
 jobs:
   issue-check-inactive:
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-     # pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to add the inactive label
     runs-on: ubuntu-latest
     steps:
       - name: check-inactive
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: 'check-inactive'
-          inactive-label: 'inactive'
-          inactive-day: 30
-          issue-state: open
-          exclude-labels: 'bug,planned,$exclude-empty'
+          script: |
+            const INACTIVE_LABEL = 'inactive'
+            const EXCLUDE_LABELS = ['bug', 'planned']
+            const INACTIVE_DAYS = 30
+            const cutoff = new Date(Date.now() - INACTIVE_DAYS * 24 * 60 * 60 * 1000)
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            })
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue
+              if (new Date(issue.updated_at) > cutoff) continue
+
+              const labels = issue.labels.map(l => (typeof l === 'string' ? l : l.name))
+              // Issues carrying no label at all are left alone, matching the
+              // previous `$exclude-empty` entry in exclude-labels.
+              if (labels.length === 0) continue
+              if (labels.some(l => EXCLUDE_LABELS.includes(l))) continue
+              if (labels.includes(INACTIVE_LABEL)) continue
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [INACTIVE_LABEL],
+              })
+            }

--- a/.github/workflows/issue-close-inactive.yml
+++ b/.github/workflows/issue-close-inactive.yml
@@ -10,14 +10,41 @@ env: # Set environment variables
 
 jobs:
   close-issues:
+    permissions:
+      issues: write # to close inactive issues
     runs-on: ubuntu-latest
     steps:
       - name: need close
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: "close-issues"
-#          token: ${{ secrets.GF_TOKEN }}
-          labels: 'inactive'
-          inactive-day: 30
-          exclude-labels: 'bug,$exclude-empty'
-          close-reason: 'not active'
+          script: |
+            const INACTIVE_LABEL = 'inactive'
+            const EXCLUDE_LABELS = ['bug']
+            const INACTIVE_DAYS = 30
+            const cutoff = new Date(Date.now() - INACTIVE_DAYS * 24 * 60 * 60 * 1000)
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: INACTIVE_LABEL,
+              per_page: 100,
+            })
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue
+              if (new Date(issue.updated_at) > cutoff) continue
+
+              const labels = issue.labels.map(l => (typeof l === 'string' ? l : l.name))
+              // Same `$exclude-empty` semantics as the check-inactive workflow.
+              if (labels.length === 0) continue
+              if (labels.some(l => EXCLUDE_LABELS.includes(l))) continue
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              })
+            }

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -11,15 +11,22 @@ env: # Set environment variables
 
 jobs:
   reply-labeled:
+    permissions:
+      issues: write # to comment on the issue
     runs-on: ubuntu-latest
     steps:
       - name: contribution welcome
         if: github.event.label.name == 'help wanted'
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: "create-comment, remove-labels"
-#          token: ${{ secrets.GF_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Hello @${{ github.event.issue.user.login }}. We like your proposal/feedback and would appreciate a contribution via a Pull Request by you or another community member. We thank you in advance for your contribution and are looking forward to reviewing it!
-            你好 @${{ github.event.issue.user.login }}。我们喜欢您的提案/反馈，并希望您或其他社区成员通过拉取请求做出贡献。我们提前感谢您的贡献，并期待对其进行审查。
+          script: |
+            const author = context.payload.issue.user.login
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                `Hello @${author}. We like your proposal/feedback and would appreciate a contribution via a Pull Request by you or another community member. We thank you in advance for your contribution and are looking forward to reviewing it!`,
+                `你好 @${author}。我们喜欢您的提案/反馈，并希望您或其他社区成员通过拉取请求做出贡献。我们提前感谢您的贡献，并期待对其进行审查。`,
+              ].join('\n'),
+            })

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -16,14 +16,21 @@ permissions:
 jobs:
   issue-remove-inactive:
     permissions:
-      issues: write  # for actions-cool/issues-helper to update issues
-     # pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to remove the inactive label
     runs-on: ubuntu-latest
     steps:
       - name: remove inactive
         if: github.event.issue.state == 'open'
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: 'remove-labels'
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'inactive'
+          script: |
+            const LABEL = 'inactive'
+            const labels = context.payload.issue.labels.map(l => l.name)
+            if (!labels.includes(LABEL)) return
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              name: LABEL,
+            })

--- a/.github/workflows/issue-remove-need-more-details.yml
+++ b/.github/workflows/issue-remove-need-more-details.yml
@@ -16,14 +16,21 @@ permissions:
 jobs:
   issue-remove-need-more-details:
     permissions:
-      issues: write # for actions-cool/issues-helper to update issues
-     # pull-requests: write # for actions-cool/issues-helper to update PRs
+      issues: write # to remove the need more details label
     runs-on: ubuntu-latest
     steps:
       - name: remove need more details
         if: github.event.issue.state == 'open' && github.actor == github.event.issue.user.login
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v9
         with:
-          actions: 'remove-labels'
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'need more details'
+          script: |
+            const LABEL = 'need more details'
+            const labels = context.payload.issue.labels.map(l => l.name)
+            if (!labels.includes(LABEL)) return
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              name: LABEL,
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set Up Golang Environment
         uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache: false
       
       - name: Build CLI Binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Github Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set Up Golang Environment
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 1.26
           cache: false
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Github Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -59,7 +59,7 @@ jobs:
       
       - name: Upload Release Asset
         id:   upload-release-asset
-        uses: alexellis/upload-assets@0.4.0
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.1
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -66,7 +66,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v7
         with:
           name: SARIF file
           path: results.sarif
@@ -75,6 +75,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scripts/before_script.sh
+++ b/.github/workflows/scripts/before_script.sh
@@ -2,7 +2,8 @@
 
 # Install gci
 echo "Installing gci..."
-go install github.com/daixiang0/gci@latest
+# Pinned: gci v0.14.0 requires Go >= 1.24, which breaks the 1.23 matrix entries.
+go install github.com/daixiang0/gci@v0.13.6
 
 # Check if the GCI is installed successfully
 if ! command -v gci &> /dev/null

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Github Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Auto Creating Tags For Contrib Packages
         run: |
           git config --global user.email "tagrobot@goframe.org"
@@ -32,7 +32,7 @@ jobs:
           go env -w GOPRIVATE=github.com/gogf/gf
           .github/workflows/scripts/update_version.sh ./cmd/gf ${{ github.ref_name }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'update gf cli to ${{ github.ref_name }}'
           title: 'fix: update gf cli to ${{ github.ref_name }}'


### PR DESCRIPTION
Everything here is CI configuration; no library code is touched.

## Go 1.26 was missing from the matrix

Go 1.26 is the current release (`go1.26.6`) but nothing was ever built or tested against it.

- `ci-main.yml` / `ci-sub.yml`: add `"1.26"` to the matrix
- `ci-main.yml` / `ci-sub.yml`: `LATEST_GO_VERSION` `"1.25"` -> `"1.26"`
- `release.yml`: pinned `go-version` `1.25` -> `1.26`

`LATEST_GO_VERSION` has to move together with the matrix. `scripts/ci-main.sh:28` gates the entire `contrib/` tree on it, so leaving it behind would make the new jobs skip every contrib module and test nothing extra. It also gates coverage reporting.

Existing versions are kept. Whether to drop the now-EOL 1.23/1.24 is a compatibility decision, raised in #4850.

## Actions were on retiring runtimes

Every run warned that `actions/checkout@v4` and `actions/setup-go@v5` declare node20, and that `github/codeql-action` v3 is removed in December 2026. Rather than bumping only those, all actions are brought to their latest major so they stop drifting apart:

| action | before | after |
| --- | --- | --- |
| `actions/checkout` | v4, v4.2.2, v5 | **v7** |
| `actions/setup-go` | v5 | **v7** |
| `github/codeql-action/*` | v3 | **v4** |
| `codecov/codecov-action` | v4 | **v7** |
| `actions/upload-artifact` | v4.6.1 | **v7** |
| `peter-evans/create-pull-request` | v4 | **v8** |
| `softprops/action-gh-release` | v1 | **v3** |
| `golangci/golangci-lint-action` | v8 | **v9** |
| `ossf/scorecard-action` | v2.4.1 | **v2.4.4** |
| `Yikun/hub-mirror-action` | v1.4 | **v1.5** |
| `alexellis/upload-assets` | 0.4.0 | **0.5.0** |

Inputs were checked against each new major — `golangci-lint-action@v9` still accepts `only-new-issues` / `skip-cache` / `github-token` / `args` and `.golangci.yml` is already `version: "2"`; `upload-artifact`, `create-pull-request`, `action-gh-release` and `codecov-action` all keep the inputs this repository passes.

`szenius/set-timezone` had no newer release to move to, so it is replaced by the shell command it wraps — the file already carried that command, commented out.

## `actions-cool/issues-helper` is gone

**Its repository has been blocked by GitHub for a TOS violation** since 2026-05-19, so the five workflows using it cannot resolve the action. Their last successful runs are all dated 2026-05-18 — the daily inactive-issue cron has been silently dead for three months.

Replaced with `actions/github-script@v9`, keeping behaviour as close as possible: same label names, same 30-day thresholds, same cron schedules, same `if` conditions.

Two details worth flagging:

- `exclude-labels` contained `$exclude-empty`, a private token of that action meaning "skip issues carrying no label at all". Its documentation went offline with the repository, so this is implemented from the literal reading — the one place behaviour could shift.
- `issue-labeled` declared `actions: "create-comment, remove-labels"` but never passed a `labels` input, so the removal half was a no-op. Only the comment is reproduced.

## Tooling installed with `@latest` had already broken the older jobs

Re-running the 1.23/1.24 jobs surfaced a pre-existing breakage that has nothing to do with Go 1.26. CI installs developer tooling with `@latest`, and those tools keep raising their Go floor:

```
gci@v0.14.0                requires go >= 1.24.0  (running go 1.23.12)
protoc-gen-go-grpc@v1.6.2  requires go >= 1.25.0  (running go 1.24.13)
```

With `fail-fast` on, either one takes all 16 jobs down. Pinned to the last releases that still build on Go 1.21+:

- `gci` -> `v0.13.6`, in both `scripts/before_script.sh` and `format-code-on-push.yml`, so the version used to check formatting cannot drift from the one used to apply it
- `protoc-gen-go` -> `v1.36.12`, `protoc-gen-go-grpc` -> `v1.5.1`

This is present on master as well; nothing had re-run those jobs recently enough to hit it.

closes #4850
