### PR TITLE
fix(os/grpool): stop Test_Limit4 asserting a sum that has a race window

### DIFF
--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -18,6 +18,17 @@ import (
 	"github.com/gogf/gf/v2/test/gtest"
 )
 
+// assertNoJobLost checks that no job went missing, without requiring an exact sum.
+// A job leaves the queue before it appends to the array, so during that window it
+// is counted in neither Jobs() nor the array. inFlightLimit bounds how many jobs
+// can be in that window: the peak worker count the pool has had, not its current
+// Cap(), because jobs left over from before a shrink are still in flight.
+func assertNoJobLost(t *gtest.T, pool *grpool.Pool, array *garray.Array, size, inFlightLimit int) {
+	sum := pool.Jobs() + array.Len()
+	t.AssertLE(sum, size)
+	t.AssertGE(sum, size-inFlightLimit)
+}
+
 func waitUntil(timeout time.Duration, condition func() bool) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -152,14 +163,14 @@ func Test_Limit4(t *testing.T) {
 		t.Assert(waitUntil(2*time.Second, func() bool {
 			return pool.Size() == 100 && pool.Jobs() <= 900 && array.Len() > 0
 		}), true)
-		t.Assert(pool.Jobs()+array.Len(), size)
+		assertNoJobLost(t, pool, array, size, 100)
 
 		limit.Store(50)
 		t.Assert(waitUntil(4*time.Second, func() bool {
 			return pool.Size() <= 50 && pool.Size() >= 0
 		}), true)
 		t.Assert(pool.Size(), 50)
-		t.Assert(pool.Jobs()+array.Len(), size)
+		assertNoJobLost(t, pool, array, size, 100)
 
 		jobsBeforeIncrease := pool.Jobs()
 		arrayBeforeIncrease := array.Len()
@@ -171,7 +182,7 @@ func Test_Limit4(t *testing.T) {
 		t.AssertGT(pool.Jobs(), 0)
 		t.AssertLT(pool.Jobs(), jobsBeforeIncrease)
 		t.AssertGT(array.Len(), arrayBeforeIncrease)
-		t.Assert(pool.Jobs()+array.Len(), size)
+		assertNoJobLost(t, pool, array, size, 100)
 
 		pool.Close()
 		t.Assert(waitUntil(5*time.Second, func() bool {


### PR DESCRIPTION
## Summary

`Test_Limit4` fails intermittently on loaded CI runners, and because `fail-fast` is on, it cancels the rest of the matrix and makes unrelated pull requests look broken.

```
[ASSERT] EXPECT 998 == 1000
[ASSERT] EXPECT 962 == 1000
--- FAIL: Test_Limit4
```

## Why it fails

```go
pool.Add(ctx, func(ctx context.Context) {
    array.Append(1)          // a job is in neither place until it reaches here
    time.Sleep(2 * time.Second)
})
...
t.Assert(pool.Jobs()+array.Len(), size)
```

A job leaves the queue before it appends to the array. In that window it is counted in neither `Jobs()` nor `array.Len()`, so while the pool is running the sum can only be bounded:

```
size - limit  <=  Jobs() + array.Len()  <=  size
```

With a limit of 100, up to 100 jobs can sit in that window at once — matching the observed shortfalls of 2 and 38. The two values are also read separately, so the sum is not a consistent snapshot either.

It is load dependent, which is why it only shows up on CI: 11 local runs with and without `-race` were all green.

## Changes

The three assertions taken while jobs are running now bound the sum through a small helper. The fourth one, after `pool.Close()` when `Size()` is 0 and no worker can be in the window, keeps the exact equality — there the invariant does hold.

closes #4853