### PR TITLE
fix(contrib/nacos): move to the upstream commit that fixes the RpcClient data race

### DIFF
--- a/contrib/config/nacos/go.mod
+++ b/contrib/config/nacos/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/gogf/gf/v2 v2.10.2
-	github.com/nacos-group/nacos-sdk-go/v2 v2.3.3
+	github.com/nacos-group/nacos-sdk-go/v2 v2.3.6-0.20260713020125-4ba94455701e
 )
 
 require (

--- a/contrib/config/nacos/go.sum
+++ b/contrib/config/nacos/go.sum
@@ -267,8 +267,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nacos-group/nacos-sdk-go/v2 v2.3.3 h1:lvkBZcYkKENLVR1ubO+vGxTP2L4VtVSArLvYZKuu4Pk=
-github.com/nacos-group/nacos-sdk-go/v2 v2.3.3/go.mod h1:ygUBdt7eGeYBt6Lz2HO3wx7crKXk25Mp80568emGMWU=
+github.com/nacos-group/nacos-sdk-go/v2 v2.3.6-0.20260713020125-4ba94455701e h1:Sxkj82HWwWTCC09MRCiKLMOa/aRqlIVdPa8RWoqXnWw=
+github.com/nacos-group/nacos-sdk-go/v2 v2.3.6-0.20260713020125-4ba94455701e/go.mod h1:ygUBdt7eGeYBt6Lz2HO3wx7crKXk25Mp80568emGMWU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
 github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=

--- a/contrib/registry/nacos/go.mod
+++ b/contrib/registry/nacos/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/gogf/gf/v2 v2.10.2
-	github.com/nacos-group/nacos-sdk-go/v2 v2.3.5
+	github.com/nacos-group/nacos-sdk-go/v2 v2.3.6-0.20260713020125-4ba94455701e
 )
 
 require (

--- a/contrib/registry/nacos/go.sum
+++ b/contrib/registry/nacos/go.sum
@@ -267,8 +267,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nacos-group/nacos-sdk-go/v2 v2.3.5 h1:Hux7C4N4rWhwBF5Zm4yyYskrs9VTgrRTA8DZjoEhQTs=
-github.com/nacos-group/nacos-sdk-go/v2 v2.3.5/go.mod h1:ygUBdt7eGeYBt6Lz2HO3wx7crKXk25Mp80568emGMWU=
+github.com/nacos-group/nacos-sdk-go/v2 v2.3.6-0.20260713020125-4ba94455701e h1:Sxkj82HWwWTCC09MRCiKLMOa/aRqlIVdPa8RWoqXnWw=
+github.com/nacos-group/nacos-sdk-go/v2 v2.3.6-0.20260713020125-4ba94455701e/go.mod h1:ygUBdt7eGeYBt6Lz2HO3wx7crKXk25Mp80568emGMWU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
 github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=


### PR DESCRIPTION
## Summary

CI fails at random in `contrib/registry/nacos` with a data race that lives entirely inside the SDK:

```
WARNING: DATA RACE
Read at 0x00c00037e848 by goroutine 22:
  (*RpcClient).notifyConnectionEvent()  rpc_client.go:487
Previous write at 0x00c00037e848 by goroutine 23:
  (*RpcClient).reconnect()              rpc_client.go:449
```

No `gf` frame takes part in the racing accesses — this repository only appears at the call entry, `nacos.go:93` calling `clients.NewNamingClient()`. Reported as #4846.

## Why pin a commit

In `v2.3.5` the field is plain:

```go
currentConnection           IConnection      // v2.3.5
```

Upstream made it atomic, which is exactly the right fix:

```go
currentConnection           atomic.Value     // master, stores IConnection
```

That fix is not in any release. `v2.3.5` was published 2025-10-26 and master is 11 commits ahead of it, so pinning the commit is the only way to pick it up right now. The `go.mod` entries resolve to `v2.3.6-0.20260713020125-4ba94455701e`, and should be moved back to a tag once upstream publishes one.

`contrib/config/nacos` was still on `v2.3.3`, two releases behind `contrib/registry/nacos`. Both modules now reference the same version, so the two nacos modules cannot drift apart again.

## Verification

- Both modules build and `go vet` clean.
- `TestRegistry` and `TestWatch` fail identically before and after the change on a machine with no nacos server running, so the upgrade introduces no regression. Verified against a clean `master` worktree.
- The race itself needs a reconnect to trigger, so CI is the real test.

closes #4846