### PR TITLE
ci: make the Apollo and nacos containers actually ready before tests run

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -243,7 +243,7 @@ jobs:
         # data after boot, and until that finishes the config service answers
         # normally but without the keys the tests read.
         for i in $(seq 1 60); do
-          if curl -sf "http://localhost:8080/configs/SampleApp/default/application" | grep -q '"server.address"'; then
+          if curl -fsS --connect-timeout 2 --max-time 5 "http://localhost:8080/configs/SampleApp/default/application" | grep -Fq '"server.address"'; then
             echo "Apollo is serving configuration."
             exit 0
           fi

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -236,6 +236,22 @@ jobs:
 
     - name: Start Apollo Containers
       run:  docker compose -f ".github/workflows/apollo/docker-compose.yml" up -d --build
+
+    - name: Wait for Apollo to serve configuration
+      run: |
+        # A running container is not enough: apollo-quick-start imports its seed
+        # data after boot, and until that finishes the config service answers
+        # normally but without the keys the tests read.
+        for i in $(seq 1 60); do
+          if curl -sf "http://localhost:8080/configs/SampleApp/default/application" | grep -q '"server.address"'; then
+            echo "Apollo is serving configuration."
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "Apollo did not start serving configuration within 5 minutes."
+        docker compose -f ".github/workflows/apollo/docker-compose.yml" logs --tail=50
+        exit 1
       
     - name: Start Nacos Containers
       run:  docker compose -f ".github/workflows/nacos/docker-compose.yml" up -d --build

--- a/.github/workflows/nacos/docker-compose.yml
+++ b/.github/workflows/nacos/docker-compose.yml
@@ -11,10 +11,15 @@ services:
       - "9848:9848"
       - "9555:9555"
     healthcheck:
-      test: [ "CMD", "curl" ,"http://localhost:8848/nacos" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8848/nacos" ]
       interval: 5s
       timeout: 3s
       retries: 10
+      # Nacos is a JVM service and needs well over the 50s that interval*retries
+      # allows on a loaded runner. Without start_period those early failures
+      # count towards retries, the container is declared unhealthy, and the
+      # initializer that depends on it never runs.
+      start_period: 180s
 
   initializer:
     image: alpine/curl:latest

--- a/.github/workflows/nacos/docker-compose.yml
+++ b/.github/workflows/nacos/docker-compose.yml
@@ -15,11 +15,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
-      # Nacos is a JVM service and needs well over the 50s that interval*retries
-      # allows on a loaded runner. Without start_period those early failures
-      # count towards retries, the container is declared unhealthy, and the
-      # initializer that depends on it never runs.
-      start_period: 180s
+      start_period: 60s
 
   initializer:
     image: alpine/curl:latest

--- a/contrib/config/apollo/go.mod
+++ b/contrib/config/apollo/go.mod
@@ -3,7 +3,7 @@ module github.com/gogf/gf/contrib/config/apollo/v2
 go 1.23.0
 
 require (
-	github.com/apolloconfig/agollo/v4 v4.3.1
+	github.com/apolloconfig/agollo/v4 v4.4.0
 	github.com/gogf/gf/v2 v2.10.2
 )
 

--- a/contrib/config/apollo/go.sum
+++ b/contrib/config/apollo/go.sum
@@ -41,9 +41,11 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
+github.com/agiledragon/gomonkey/v2 v2.11.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/apolloconfig/agollo/v4 v4.3.1 h1:NHjd7KqOPmTvYwJidISc9MPBRO8m9UNrH3tijcEVNAY=
-github.com/apolloconfig/agollo/v4 v4.3.1/go.mod h1:n/7qxpKOTbegygLmO5OKmFWCdy3T+S/zioBGlo457Dk=
+github.com/apolloconfig/agollo/v4 v4.4.0 h1:bIIRTEN4f7HgLx97/cNpduEvP9qQ7BkCyDOI2j800VM=
+github.com/apolloconfig/agollo/v4 v4.4.0/go.mod h1:6WjI68IzqMk/Y6ghMtrj5AX6Uewo20ZnncvRhTceQqg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
## The flake

`TestApollo` fails at random on pull requests that touch neither Apollo nor `contrib/` — recently on #4844, #4851 and #4854.

```
[ASSERT] EXPECT  == :8000
--- FAIL: TestApollo (10.01s)
```

What passes right before it is the interesting part:

```go
adapter, err := apollo.New(ctx, apollo.Config{...})
t.AssertNil(err)                      // passes
t.Assert(config.Available(ctx), true) // passes

v, err := config.Get(ctx, `server.address`)
t.AssertNil(err)                      // passes
t.Assert(v.String(), ":8000")         // fails, the value is empty
```

The client connects and the server answers; the key simply is not there yet. `loads/apollo-quick-start` boots MySQL, imports its seed data, then starts the config service — a `running` container does not mean the configuration is queryable.

The adapter cannot report this either:

```go
return c.value.Val().(*gjson.Json).Get(pattern).Val(), nil
```

A missing key yields `nil` from `gjson`, and there is no error to return, so an empty value and a genuinely absent key look identical to the caller.

## The fix

Nothing waited for the data. The compose file declares no `healthcheck` (`grep -c healthcheck` returns 0) and the workflow moved straight on after `up -d`. Services declared under `services:` in the workflow get the runner built-in health waiting; compose-started ones do not.

The new step polls the exact key the test reads, so "ready" means the same thing to CI as it does to the test, and it fails loudly with container logs instead of letting the test fail on its behalf:

```yaml
- name: Wait for Apollo to serve configuration
  run: |
    for i in $(seq 1 60); do
      if curl -sf "http://localhost:8080/configs/SampleApp/default/application" | grep -q server.address; then
        echo "Apollo is serving configuration."
        exit 0
      fi
      sleep 5
    done
    echo "Apollo did not start serving configuration within 5 minutes."
    docker compose -f ".github/workflows/apollo/docker-compose.yml" logs --tail=50
    exit 1
```

## Also: agollo v4.3.1 -> v4.4.0

Unrelated to the flake — the empty value comes from the server, not the client — but `v4.3.1` is from 2023-07-30 and upstream has had `v4.4.0` since 2024-05-05. Builds and vets clean.

`v5.0.0` is left alone: it moves to the `agollo/v5` module path, so it needs import changes and belongs in its own PR.

closes #4855

## Also: the nacos healthcheck has no `start_period`

Same theme, opposite failure. Apollo had no healthcheck at all and let an unready service through; nacos has one that is too tight and rejects a service that would have become ready.

```
Container nacos  Started
Container nacos  Waiting
Container nacos  Error
dependency failed to start: container nacos is unhealthy
```

The probe allowed `interval 5s * retries 10` = 50 seconds in total, with no `start_period`. Without it, failures during startup count towards `retries`, so a JVM service that needs longer than 50s on a loaded runner is declared unhealthy — and the `initializer` that waits on `service_healthy` never runs, taking the whole compose down before Go is even installed.

`start_period` exists precisely for this: probe failures inside it are not counted. Set to 180s.

The probe also lacked `-f`, so `curl` exited 0 for any HTTP status as long as the connection succeeded — a 404 or a 500 would have been reported as healthy.

This has hit #4852 and #4856, neither of which touches nacos.
