### PR TITLE
fix(database/gdb): stop reporting an aborted row iteration as success

### DIFF
--- a/database/gdb/gdb_core_underlying.go
+++ b/database/gdb/gdb_core_underlying.go
@@ -459,6 +459,14 @@ func (c *Core) RowsToResult(ctx context.Context, rows *sql.Rows) (Result, error)
 		}
 	}()
 	if !rows.Next() {
+		// A false return from rows.Next() has two meanings: the result set is exhausted,
+		// or the iteration was interrupted by an error, which is only retrievable through
+		// rows.Err(). Without this check an error that aborts the iteration, such as a
+		// deadlock hit while scanning a `SELECT ... FOR UPDATE`, is silently reported to
+		// the caller as an empty result set with a nil error.
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 	// Column names and types.
@@ -503,6 +511,12 @@ func (c *Core) RowsToResult(ctx context.Context, rows *sql.Rows) (Result, error)
 		}
 		result = append(result, record)
 		if !rows.Next() {
+			// Same as above. Without this check the caller receives a silently truncated
+			// result set together with a nil error, which is even harder to notice than
+			// an empty one.
+			if err = rows.Err(); err != nil {
+				return nil, err
+			}
 			break
 		}
 	}

--- a/database/gdb/gdb_z_unit_rows_err_test.go
+++ b/database/gdb/gdb_z_unit_rows_err_test.go
@@ -108,7 +108,9 @@ func mockRowsErrQuery(t *gtest.T, dsn string) *sql.Rows {
 	db, err := sql.Open(mockRowsErrDriverName, dsn)
 	t.AssertNil(err)
 	// sql.Open starts a connection opener goroutine that only exits on Close.
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() {
+		t.AssertNil(db.Close())
+	})
 	rows, err := db.Query("select")
 	t.AssertNil(err)
 	return rows

--- a/database/gdb/gdb_z_unit_rows_err_test.go
+++ b/database/gdb/gdb_z_unit_rows_err_test.go
@@ -1,0 +1,149 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gdb
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+const mockRowsErrDriverName = "gdb-mock-rows-err"
+
+// errRowsIterationBroken simulates a server side error that aborts an ongoing result set
+// iteration, for example ER_LOCK_DEADLOCK raised while scanning a `SELECT ... FOR UPDATE`.
+var errRowsIterationBroken = errors.New("iteration interrupted")
+
+func init() {
+	sql.Register(mockRowsErrDriverName, &mockRowsErrDriver{})
+}
+
+// mockRowsErrDriver produces a result set that yields a configurable number of rows and
+// then fails, which makes sql.Rows.Next() report false while sql.Rows.Err() reports the
+// error. The DSN is "<rows>" to fail after that many rows, or "<rows>:eof" to end normally.
+type mockRowsErrDriver struct{}
+
+func (d *mockRowsErrDriver) Open(dsn string) (driver.Conn, error) {
+	var (
+		parts = strings.Split(dsn, ":")
+		conn  = &mockRowsErrConn{endWithEOF: len(parts) > 1 && parts[1] == "eof"}
+	)
+	rowCount, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	conn.rowCount = rowCount
+	return conn, nil
+}
+
+type mockRowsErrConn struct {
+	rowCount   int
+	endWithEOF bool
+}
+
+func (c *mockRowsErrConn) Prepare(query string) (driver.Stmt, error) {
+	return &mockRowsErrStmt{conn: c}, nil
+}
+
+func (c *mockRowsErrConn) Close() error { return nil }
+
+func (c *mockRowsErrConn) Begin() (driver.Tx, error) { return nil, driver.ErrSkip }
+
+type mockRowsErrStmt struct {
+	conn *mockRowsErrConn
+}
+
+func (s *mockRowsErrStmt) Close() error { return nil }
+
+func (s *mockRowsErrStmt) NumInput() int { return 0 }
+
+func (s *mockRowsErrStmt) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, driver.ErrSkip
+}
+
+func (s *mockRowsErrStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return &mockRowsErrRows{conn: s.conn}, nil
+}
+
+type mockRowsErrRows struct {
+	conn *mockRowsErrConn
+	sent int
+}
+
+func (r *mockRowsErrRows) Columns() []string { return []string{"id"} }
+
+func (r *mockRowsErrRows) Close() error { return nil }
+
+// ColumnTypeScanType keeps the produced values on the builtin type fast path of
+// Core.columnValueToLocalValue, so that this test needs no real database driver.
+func (r *mockRowsErrRows) ColumnTypeScanType(index int) reflect.Type {
+	return reflect.TypeOf(int64(0))
+}
+
+func (r *mockRowsErrRows) Next(dest []driver.Value) error {
+	if r.sent >= r.conn.rowCount {
+		if r.conn.endWithEOF {
+			return io.EOF
+		}
+		return errRowsIterationBroken
+	}
+	r.sent++
+	dest[0] = int64(r.sent)
+	return nil
+}
+
+func mockRowsErrQuery(t *gtest.T, dsn string) *sql.Rows {
+	db, err := sql.Open(mockRowsErrDriverName, dsn)
+	t.AssertNil(err)
+	// sql.Open starts a connection opener goroutine that only exits on Close.
+	t.Cleanup(func() { _ = db.Close() })
+	rows, err := db.Query("select")
+	t.AssertNil(err)
+	return rows
+}
+
+// Test_Core_RowsToResult_IterationError asserts that an error which aborts the row
+// iteration is returned to the caller instead of being reported as an empty or a
+// truncated result set with a nil error.
+func Test_Core_RowsToResult_IterationError(t *testing.T) {
+	// The iteration fails before any row is produced.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := (&Core{}).RowsToResult(context.Background(), mockRowsErrQuery(t, "0"))
+		t.AssertNE(err, nil)
+		t.Assert(errors.Is(err, errRowsIterationBroken), true)
+		t.Assert(len(result), 0)
+	})
+	// The iteration fails after some rows have already been produced.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := (&Core{}).RowsToResult(context.Background(), mockRowsErrQuery(t, "3"))
+		t.AssertNE(err, nil)
+		t.Assert(errors.Is(err, errRowsIterationBroken), true)
+		t.Assert(len(result), 0)
+	})
+	// A result set that ends normally keeps working as before.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := (&Core{}).RowsToResult(context.Background(), mockRowsErrQuery(t, "3:eof"))
+		t.AssertNil(err)
+		t.Assert(len(result), 3)
+		t.Assert(result[0]["id"].Int(), 1)
+		t.Assert(result[2]["id"].Int(), 3)
+	})
+	// An empty result set is not mistaken for a failure.
+	gtest.C(t, func(t *gtest.T) {
+		result, err := (&Core{}).RowsToResult(context.Background(), mockRowsErrQuery(t, "0:eof"))
+		t.AssertNil(err)
+		t.Assert(len(result), 0)
+	})
+}


### PR DESCRIPTION
`(*Core).RowsToResult` drives `sql.Rows` without ever calling `rows.Err()`:

```go
if !rows.Next() {
    return nil, nil        // (A) error before the first row -> empty result, nil error
}
...
    result = append(result, record)
    if !rows.Next() {
        break              // (B) error mid-stream -> truncated result, nil error
    }
```

A false return from `rows.Next()` has two meanings: the result set is exhausted, or the
iteration was aborted by an error, which `database/sql` exposes only through `rows.Err()`.
Every error of the second kind is currently dropped, and the caller is handed either an
empty or a silently truncated result set together with a `nil` error.

### Why this is reachable in normal operation

MySQL streams the rows of a `SELECT ... FOR UPDATE` as it locks them, so a deadlock or a
lock wait timeout hit part way through the scan ends the row stream and delivers the error
out of band — exactly the shape above.

We hit this in production code as `ER_LOCK_DEADLOCK`. A `SELECT ... FOR UPDATE` inside a
transaction intermittently returned zero rows with a nil error under load; instrumenting
`rows.Err()` in a local build of gdb showed:

```
Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction
```

That variant is worse than a wrong result: on `ER_LOCK_DEADLOCK` the server has already
rolled the entire transaction back. The application never learns this, keeps running inside
what it believes is a transaction, and every subsequent statement is executed in autocommit
and committed permanently — so the first half of the transaction is rolled back, the second
half is durably committed, and `Transaction()` still reports success. Deadlock retry
wrappers cannot help either, because the 1213 never reaches them as an error.

### Reproduction

Deterministic, no concurrency race: one connection holds a row lock, and the victim
connection runs `SELECT ... FOR UPDATE` with `innodb_lock_wait_timeout=1`. Locking row 1
exercises path (A), locking row 3000 of 5000 exercises path (B). The same query is run
through GoFrame and through `database/sql` side by side.

On MySQL 8.4.9 with `net_buffer_length=16384`, against v2.10.2:

```
===== locked row id = 1 (table has 5000 rows) =====
GoFrame  (Model.All):       rows=0     err=<nil>
database/sql + rows.Err():  rows=0     err=Error 1205 (HY000): Lock wait timeout exceeded; try restarting transaction

===== locked row id = 3000 (table has 5000 rows) =====
GoFrame  (Model.All):       rows=2999  err=<nil>
database/sql + rows.Err():  rows=2999  err=Error 1205 (HY000): Lock wait timeout exceeded; try restarting transaction
```

With this PR applied, both cases report the error instead of success.

<details>
<summary>Complete runnable program</summary>

Creates and drops its own database `gf_rowserr_repro`.

```go
package main

import (
	"context"
	"database/sql"
	"fmt"
	"os"

	_ "github.com/go-sql-driver/mysql"
	_ "github.com/gogf/gf/contrib/drivers/mysql/v2"
	"github.com/gogf/gf/v2/database/gdb"
)

// adjust if needed; must end with "/"
const base = "root:@tcp(127.0.0.1:3306)/"

const (
	dbName   = "gf_rowserr_repro"
	rowCount = 5000
	query    = "SELECT id, pad FROM t ORDER BY id FOR UPDATE"
)

// unknown DSN params are applied as session system variables by go-sql-driver,
// so the blocked scan fails after ~1s instead of the default 50s
func victimDSN() string { return base + dbName + "?innodb_lock_wait_timeout=1" }

func main() {
	ctx := context.Background()
	if err := setup(ctx); err != nil {
		fmt.Println("setup failed:", err)
		os.Exit(1)
	}
	defer teardown()

	for _, lockedID := range []int{1, 3000} {
		fmt.Printf("\n===== locked row id = %d (table has %d rows) =====\n", lockedID, rowCount)

		stop, err := holdRowLock(lockedID)
		if err != nil {
			fmt.Println("cannot hold row lock:", err)
			return
		}

		db, err := gdb.New(gdb.ConfigNode{Type: "mysql", Link: "mysql:" + victimDSN()})
		if err != nil {
			fmt.Println(err)
			return
		}
		all, gfErr := db.Ctx(ctx).Raw(query).All()
		fmt.Printf("GoFrame  (Model.All):       rows=%-5d err=%v\n", len(all), gfErr)

		n, stdErr := selectViaDatabaseSQL(ctx)
		fmt.Printf("database/sql + rows.Err():  rows=%-5d err=%v\n", n, stdErr)

		stop()
	}
}

func selectViaDatabaseSQL(ctx context.Context) (int, error) {
	db, err := sql.Open("mysql", victimDSN())
	if err != nil {
		return 0, err
	}
	defer db.Close()
	rows, err := db.QueryContext(ctx, query)
	if err != nil {
		return 0, err
	}
	defer rows.Close()
	n := 0
	for rows.Next() {
		n++
	}
	return n, rows.Err() // <- the error GoFrame drops
}

func holdRowLock(id int) (stop func(), err error) {
	db, err := sql.Open("mysql", base+dbName)
	if err != nil {
		return nil, err
	}
	tx, err := db.Begin()
	if err != nil {
		db.Close()
		return nil, err
	}
	if _, err = tx.Exec("SELECT id FROM t WHERE id = ? FOR UPDATE", id); err != nil {
		tx.Rollback()
		db.Close()
		return nil, err
	}
	return func() { tx.Rollback(); db.Close() }, nil
}

func setup(ctx context.Context) error {
	db, err := sql.Open("mysql", base)
	if err != nil {
		return err
	}
	defer db.Close()
	for _, s := range []string{
		"CREATE DATABASE IF NOT EXISTS " + dbName,
		"USE " + dbName,
		"DROP TABLE IF EXISTS t",
		"CREATE TABLE t (id INT PRIMARY KEY, pad CHAR(255) NOT NULL) ENGINE=InnoDB",
	} {
		if _, err = db.ExecContext(ctx, s); err != nil {
			return fmt.Errorf("%s: %w", s, err)
		}
	}
	pad := make([]byte, 255)
	for i := range pad {
		pad[i] = 'x'
	}
	for i := 1; i <= rowCount; i += 500 {
		vals, args := "", []any{}
		for j := i; j < i+500 && j <= rowCount; j++ {
			if vals != "" {
				vals += ","
			}
			vals += "(?,?)"
			args = append(args, j, string(pad))
		}
		if _, err = db.ExecContext(ctx, "INSERT INTO "+dbName+".t(id,pad) VALUES "+vals, args...); err != nil {
			return err
		}
	}
	return nil
}

func teardown() {
	db, err := sql.Open("mysql", base)
	if err != nil {
		return
	}
	defer db.Close()
	db.Exec("DROP DATABASE IF EXISTS " + dbName)
}
```

</details>

### The change

Both `rows.Next()` call sites now check `rows.Err()` and return the error. Nothing changes
for result sets that end normally: when `rows.Err()` is nil the existing `return nil, nil`
and `break` paths are taken unchanged.

On the truncation path the partial result is dropped in favour of `return nil, err`, which
follows the existing error convention of the function and keeps callers from consuming a
partial result set by accident.

### Test

`Test_Core_RowsToResult_IterationError` in `database/gdb/gdb_z_unit_rows_err_test.go` uses a
mock `database/sql` driver whose rows fail after a configurable number of records, so it
needs no database. It covers four cases: the iteration failing before any row, failing after
some rows, a normal result set, and an empty result set. The two failure cases fail without
the change in this PR and pass with it.