### PR TITLE
ci: wait for the Apollo database before starting Apollo

### DIFF
--- a/.github/workflows/apollo/docker-compose.yml
+++ b/.github/workflows/apollo/docker-compose.yml
@@ -1,11 +1,10 @@
-version: '2'
-
 services:
   apollo-quick-start:
     image: "loads/apollo-quick-start:latest"
     container_name: apollo-quick-start
     depends_on:
-      - apollo-db
+      apollo-db:
+        condition: service_healthy
     ports:
       - "8080:8080"
       - "8070:8070"
@@ -34,6 +33,12 @@ services:
       - ./sql:/docker-entrypoint-initdb.d
     volumes_from:
       - apollo-dbdata
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
 
   apollo-dbdata:
     image: "alpine:3.8"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -247,6 +247,13 @@ jobs:
             echo "Apollo is serving configuration."
             exit 0
           fi
+          # The container gives up on its own after 120 seconds. Once it has,
+          # nothing will ever answer, so stop burning the remaining budget.
+          if docker compose -f ".github/workflows/apollo/docker-compose.yml" logs apollo-quick-start 2>/dev/null | grep -Fq 'Config service failed to start'; then
+            echo "Apollo config service gave up during startup."
+            docker compose -f ".github/workflows/apollo/docker-compose.yml" logs --tail=50
+            exit 1
+          fi
           sleep 5
         done
         echo "Apollo did not start serving configuration within 5 minutes."

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -247,13 +247,6 @@ jobs:
             echo "Apollo is serving configuration."
             exit 0
           fi
-          # The container gives up on its own after 120 seconds. Once it has,
-          # nothing will ever answer, so stop burning the remaining budget.
-          if docker compose -f ".github/workflows/apollo/docker-compose.yml" logs apollo-quick-start 2>/dev/null | grep -Fq 'Config service failed to start'; then
-            echo "Apollo config service gave up during startup."
-            docker compose -f ".github/workflows/apollo/docker-compose.yml" logs --tail=50
-            exit 1
-          fi
           sleep 5
         done
         echo "Apollo did not start serving configuration within 5 minutes."


### PR DESCRIPTION
Everything here is CI configuration; no library code is touched.

## The problem

`GoFrame Main CI` is red on `master` and on every PR that reruns it. The Apollo container never
finishes starting, and it says so itself:

```
apollo-quick-start  | Config service failed to start in 120 seconds!
...
apollo-db           | mysqld: ready for connections.    <- only afterwards
```

`apollo-quick-start` depended on the `apollo-db` *container*, not on the database being *usable*:

```yaml
depends_on:
  - apollo-db     # waits for "started", not for "usable"
```

`apollo-db` is `mysql:5.7` with 48KB of seed SQL in `/docker-entrypoint-initdb.d`. On a cold volume
the entrypoint initialises the data directory, runs the seed files against a temporary server, and
only then starts the real one. That exceeds Apollo's own 120 second budget on a GitHub runner, so
the job passed or failed depending on how fast the runner's disk happened to be.

This is the half that #4857 missed: it added a readiness gate for nacos but left the Apollo compose
file alone.

## Changes

`apollo/docker-compose.yml`:

- `apollo-db` gets a healthcheck; Apollo is gated on `condition: service_healthy`
- the probe is `mysqladmin ping -h 127.0.0.1`, over TCP rather than the socket, **on purpose**: the
  temporary server used while importing the seed files listens only on the socket, so a successful
  TCP probe also proves the seed data is already in place
- the obsolete `version: '2'` key is removed. It has to go for `depends_on` conditions to be
  honoured, and it was already emitting a deprecation warning on every run. `volumes_from` still
  resolves without it — verified with `docker compose config`.

## Verification

Run locally from a clean volume:

```
apollo-db Waiting -> apollo-db Healthy -> apollo-quick-start Starting
```

The gate holds, and the endpoint the tests read answers correctly:

```
$ curl -fsS http://localhost:8080/configs/SampleApp/default/application
{"appId":"SampleApp","cluster":"default","namespaceName":"application","configurations":
{"timeout":"100","server.address":":8000", ... }}
```

Note that the failure itself does not reproduce locally — MySQL reached healthy in 18 seconds here,
so the race never opens. The root cause is established from the CI logs instead, where Apollo's
give-up message is timestamped before MySQL reports `ready for connections`.

closes #4859
