### PR TITLE
fix(os/grpool): read the array before the queue in Test_Limit4 assertions

### DIFF
--- a/os/grpool/grpool_z_unit_test.go
+++ b/os/grpool/grpool_z_unit_test.go
@@ -23,8 +23,10 @@ import (
 // is counted in neither Jobs() nor the array. inFlightLimit bounds how many jobs
 // can be in that window: the peak worker count the pool has had, not its current
 // Cap(), because jobs left over from before a shrink are still in flight.
+// The array must be read before the queue, otherwise a job leaving the queue
+// between the two reads is counted twice and the sum exceeds size.
 func assertNoJobLost(t *gtest.T, pool *grpool.Pool, array *garray.Array, size, inFlightLimit int) {
-	sum := pool.Jobs() + array.Len()
+	sum := array.Len() + pool.Jobs()
 	t.AssertLE(sum, size)
 	t.AssertGE(sum, size-inFlightLimit)
 }


### PR DESCRIPTION
@
closes #4861

## Summary

`Test_Limit4` still fails on CI after #4854, now on the upper bound instead of the lower one:

```
[ASSERT] EXPECT 1001 <= 1000
1.  github.com/gogf/gf/v2/os/grpool_test.assertNoJobLost
    /home/runner/work/gf/gf/os/grpool/grpool_z_unit_test.go:28
2.  github.com/gogf/gf/v2/os/grpool_test.Test_Limit4.func1
    /home/runner/work/gf/gf/os/grpool/grpool_z_unit_test.go:185
3.  github.com/gogf/gf/v2/os/grpool_test.Test_Limit4
    /home/runner/work/gf/gf/os/grpool/grpool_z_unit_test.go:142
--- FAIL: Test_Limit4 (2.98s)
```

## Why it still fails

#4854 noted that "the two values are also read separately, so the sum is not a consistent snapshot either", but only allowed for one direction of that skew. The two reads are not atomic and they can drift both ways:

```go
sum := pool.Jobs() + array.Len()
```

- **Undercount** — a job has left the queue but has not reached `array.Append` yet, so it is counted in neither. `inFlightLimit` already covers this.
- **Overcount** — the job is still queued when `Jobs()` is read, then pops and appends before `array.Len()` is read, so it is counted twice and `sum == size + 1`. Nothing covered this.

The failing assertion is the third one, right after the limit goes back from 50 to 100. `supervisor` forks the missing 50 workers in a tight loop, and each one immediately pops a job and appends before sleeping, so this checkpoint always lands on a burst of queue-to-array transitions, the worst possible moment for a non-atomic pair of reads.

## Evidence

The window is one mutex acquisition wide, so it does not reproduce by repetition locally (`-count=20` is green). Sampling both read orders continuously across that burst does reproduce it:

```
samples=63041882  overcount hits: jobs-first=0  array-first=0
samples=64081414  overcount hits: jobs-first=1  array-first=0
samples=64092314  overcount hits: jobs-first=1  array-first=0
samples=64423949  overcount hits: jobs-first=0  array-first=0
samples=63243132  overcount hits: jobs-first=0  array-first=0
samples=64351015  overcount hits: jobs-first=0  array-first=0
samples=64137867  overcount hits: jobs-first=0  array-first=0
samples=63864664  overcount hits: jobs-first=1  array-first=0
```

3 of 8 runs reproduce `sum == 1001`, all of them with the queue read first. The array-first order never overcounts in ~510M samples.

## Changes

Read the array before the queue. A job only enters the array after leaving the queue, and it never returns to the queue afterwards, since the single `PushBack` in `asynchronousWorker` happens before `Func` runs. With this order `sum <= size` holds by construction, and the only remaining skew is the undercount that `inFlightLimit` already bounds.

Follow-up to #4854, refs #4853.
@