### PR TITLE
fix(util/gvalid): measure a container by its element count in length …

### DIFF
--- a/util/gvalid/gvalid_z_unit_length_container_test.go
+++ b/util/gvalid/gvalid_z_unit_length_container_test.go
@@ -1,0 +1,113 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+package gvalid_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogf/gf/v2/test/gtest"
+	"github.com/gogf/gf/v2/util/gvalid"
+)
+
+// runLengthRule validates a single `value` against a single length related `rule`
+// and reports whether it passed.
+func runLengthRule(rule string, value any) bool {
+	return gvalid.New().
+		Rules(map[string]string{"f": rule}).
+		Data(map[string]any{"f": value}).
+		Run(context.Background()) == nil
+}
+
+// Test_LengthRules_Container asserts that the length related rules measure a slice,
+// an array and a map by the number of their elements.
+//
+// Before this behavior existed those rules measured the number of unicode runes of
+// the JSON text a container is serialized into, so the verdict depended on how wide
+// the elements happened to print: `[]int{1}` passed `size:3` because `[1]` is three
+// characters long, while `[]int{1, 2, 3}` failed it because `[1,2,3]` is seven.
+func Test_LengthRules_Container(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		type item struct{ Id int }
+		twoStrings := []string{"a", "b"}
+
+		// The element count is what decides, whatever the elements print like.
+		t.Assert(runLengthRule("size:3", []int{1, 2, 3}), true)
+		t.Assert(runLengthRule("size:3", []int{1}), false)
+		t.Assert(runLengthRule("size:3", []string{"a", "b", "c"}), true)
+		t.Assert(runLengthRule("size:3", []uint64{100000, 100001, 100002}), true)
+		t.Assert(runLengthRule("size:3", []*item{{1}, {2}, {3}}), true)
+
+		// Wide elements no longer make a short slice look long.
+		t.Assert(runLengthRule("max-length:3", []uint64{100000, 100001}), true)
+		t.Assert(runLengthRule("max-length:3", []uint64{1, 2, 3, 4}), false)
+		t.Assert(runLengthRule("min-length:2", []string{"a"}), false)
+		t.Assert(runLengthRule("min-length:2", []string{"a", "b"}), true)
+		t.Assert(runLengthRule("length:1,5", []int{1, 2, 3}), true)
+		t.Assert(runLengthRule("length:1,5", []int{1, 2, 3, 4, 5, 6}), false)
+
+		// Arrays and maps are measured the same way.
+		t.Assert(runLengthRule("size:3", [3]int{1, 2, 3}), true)
+		t.Assert(runLengthRule("size:3", map[string]int{"a": 1, "b": 2, "c": 3}), true)
+		t.Assert(runLengthRule("size:3", map[string]int{"a": 1}), false)
+
+		// A pointer to a container is dereferenced, as `required` does.
+		t.Assert(runLengthRule("size:2", &twoStrings), true)
+		t.Assert(runLengthRule("size:3", &twoStrings), false)
+
+		// A rune slice needs no special case: its element count is its rune count.
+		t.Assert(runLengthRule("size:3", []rune("你好吗")), true)
+	})
+}
+
+// Test_LengthRules_Container_AgreesWithRequired asserts that `required` and the length
+// rules apply the same notion of length to one and the same value.
+//
+// `required` reports a container as empty by reflect.Value.Len, see isRequiredEmpty, so
+// an empty slice must be rejected by `min-length:1` for the two rules of a tag such as
+// `required|min-length:1` to agree.
+func Test_LengthRules_Container_AgreesWithRequired(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		empty := []string{}
+		t.Assert(runLengthRule("required", empty), false)
+		t.Assert(runLengthRule("min-length:1", empty), false)
+		t.Assert(runLengthRule("size:0", empty), true)
+
+		one := []string{"a"}
+		t.Assert(runLengthRule("required", one), true)
+		t.Assert(runLengthRule("min-length:1", one), true)
+	})
+}
+
+// Test_LengthRules_String_Unchanged pins the behavior that must not move.
+//
+// Without these the change could not be told apart from an implementation that measures
+// every value by reflect.Value.Len, which would silently redefine the length of a string
+// as its byte count and that of a byte slice as its number of bytes.
+func Test_LengthRules_String_Unchanged(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		text := "abc"
+
+		// A string is still measured in unicode runes, not in bytes.
+		t.Assert(runLengthRule("size:3", "abc"), true)
+		t.Assert(runLengthRule("size:3", "你好吗"), true)
+		t.Assert(runLengthRule("size:9", "你好吗"), false)
+		t.Assert(runLengthRule("length:1,5", "abcdefg"), false)
+		t.Assert(runLengthRule("size:3", &text), true)
+
+		// A byte slice carries text, so it stays on the string side and is measured
+		// in the unicode runes of that text rather than in its number of bytes.
+		t.Assert(runLengthRule("size:3", []byte("abc")), true)
+		t.Assert(runLengthRule("size:2", []byte("你好")), true)
+		t.Assert(runLengthRule("size:6", []byte("你好")), false)
+		t.Assert(runLengthRule("length:1,5", []byte("abcdefg")), false)
+
+		// A number keeps being measured by the width of its decimal form.
+		t.Assert(runLengthRule("size:3", 123), true)
+		t.Assert(runLengthRule("size:1", 123), false)
+	})
+}

--- a/util/gvalid/internal/builtin/builtin.go
+++ b/util/gvalid/internal/builtin/builtin.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 
 	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/util/gconv"
 )
 
 type Rule interface {
@@ -55,4 +56,39 @@ func Register(rule Rule) {
 // GetRule retrieves and returns rule by `name`.
 func GetRule(name string) Rule {
 	return ruleMap[name]
+}
+
+// valueLength returns the length of `value` for the length related rules, that is
+// `length`, `min-length`, `max-length` and `size`.
+//
+// For a slice, an array or a map it returns the number of elements. That is the same
+// notion of length that `required` already applies to the very same value, see
+// isRequiredEmpty, so that both rules in a tag like `required|min-length:2` agree on
+// what the length of a container is.
+//
+// For anything else it returns the number of unicode runes of its string form, which
+// keeps the historical behavior: one chinese character or letter both has the length
+// of 1.
+//
+// A byte slice is deliberately measured as a string. gconv converts it to a string
+// directly instead of serializing it, so `[]byte("GoFrame")` has always had the length
+// of its text and keeps it here.
+func valueLength(value any) int {
+	reflectValue := reflect.ValueOf(value)
+	for reflectValue.Kind() == reflect.Pointer {
+		reflectValue = reflectValue.Elem()
+	}
+	switch reflectValue.Kind() {
+	case reflect.Slice, reflect.Array:
+		if reflectValue.Type().Elem().Kind() == reflect.Uint8 {
+			break
+		}
+		return reflectValue.Len()
+
+	case reflect.Map:
+		return reflectValue.Len()
+
+	default:
+	}
+	return len(gconv.Runes(gconv.String(value)))
 }

--- a/util/gvalid/internal/builtin/builtin_length.go
+++ b/util/gvalid/internal/builtin/builtin_length.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 
 	"github.com/gogf/gf/v2/text/gstr"
-	"github.com/gogf/gf/v2/util/gconv"
 )
 
 // RuleLength implements `length` rule:
 // Length between :min and :max.
 // The length is calculated using unicode string, which means one chinese character or letter both has the length of 1.
+// For a slice, an array or a map the length is the number of its elements.
 //
 // Format: length:min,max
 type RuleLength struct{}
@@ -35,10 +35,7 @@ func (r RuleLength) Message() string {
 }
 
 func (r RuleLength) Run(in RunInput) error {
-	var (
-		valueRunes = gconv.Runes(in.Value.String())
-		valueLen   = len(valueRunes)
-	)
+	valueLen := valueLength(in.Value.Val())
 	var (
 		min   = 0
 		max   = 0

--- a/util/gvalid/internal/builtin/builtin_max_length.go
+++ b/util/gvalid/internal/builtin/builtin_max_length.go
@@ -11,12 +11,12 @@ import (
 	"strconv"
 
 	"github.com/gogf/gf/v2/text/gstr"
-	"github.com/gogf/gf/v2/util/gconv"
 )
 
 // RuleMaxLength implements `max-length` rule:
 // Length is equal or lesser than :max.
 // The length is calculated using unicode string, which means one chinese character or letter both has the length of 1.
+// For a slice, an array or a map the length is the number of its elements.
 //
 // Format: max-length:max
 type RuleMaxLength struct{}
@@ -34,10 +34,7 @@ func (r RuleMaxLength) Message() string {
 }
 
 func (r RuleMaxLength) Run(in RunInput) error {
-	var (
-		valueRunes = gconv.Runes(in.Value.String())
-		valueLen   = len(valueRunes)
-	)
+	valueLen := valueLength(in.Value.Val())
 	max, err := strconv.Atoi(in.RulePattern)
 	if valueLen > max || err != nil {
 		return errors.New(gstr.Replace(in.Message, "{max}", strconv.Itoa(max)))

--- a/util/gvalid/internal/builtin/builtin_min_length.go
+++ b/util/gvalid/internal/builtin/builtin_min_length.go
@@ -11,12 +11,12 @@ import (
 	"strconv"
 
 	"github.com/gogf/gf/v2/text/gstr"
-	"github.com/gogf/gf/v2/util/gconv"
 )
 
 // RuleMinLength implements `min-length` rule:
 // Length is equal or greater than :min.
 // The length is calculated using unicode string, which means one chinese character or letter both has the length of 1.
+// For a slice, an array or a map the length is the number of its elements.
 //
 // Format: min-length:min
 type RuleMinLength struct{}
@@ -34,10 +34,7 @@ func (r RuleMinLength) Message() string {
 }
 
 func (r RuleMinLength) Run(in RunInput) error {
-	var (
-		valueRunes = gconv.Runes(in.Value.String())
-		valueLen   = len(valueRunes)
-	)
+	valueLen := valueLength(in.Value.Val())
 	min, err := strconv.Atoi(in.RulePattern)
 	if valueLen < min || err != nil {
 		return errors.New(gstr.Replace(in.Message, "{min}", strconv.Itoa(min)))

--- a/util/gvalid/internal/builtin/builtin_size.go
+++ b/util/gvalid/internal/builtin/builtin_size.go
@@ -10,13 +10,12 @@ import (
 	"errors"
 	"strconv"
 	"strings"
-
-	"github.com/gogf/gf/v2/util/gconv"
 )
 
 // RuleSize implements `size` rule:
 // Length must be :size.
 // The length is calculated using unicode string, which means one chinese character or letter both has the length of 1.
+// For a slice, an array or a map the length is the number of its elements.
 //
 // Format: size:size
 type RuleSize struct{}
@@ -34,10 +33,7 @@ func (r RuleSize) Message() string {
 }
 
 func (r RuleSize) Run(in RunInput) error {
-	var (
-		valueRunes = gconv.Runes(in.Value.String())
-		valueLen   = len(valueRunes)
-	)
+	valueLen := valueLength(in.Value.Val())
 	size, err := strconv.Atoi(in.RulePattern)
 	if valueLen != size || err != nil {
 		return errors.New(strings.ReplaceAll(in.Message, "{size}", strconv.Itoa(size)))


### PR DESCRIPTION
The `length`, `min-length`, `max-length` and `size` rules all derive their length the same way:

```go
valueRunes = gconv.Runes(in.Value.String())
valueLen   = len(valueRunes)
```

That is the number of unicode runes of the *string form* of the value. For a slice, an array or a map the string form is the JSON text it serializes into, so the verdict is decided by how wide the elements happen to print rather than by how many of them there are:

```
size:3  []int{1}        -> passes    // "[1]"     is three characters
size:3  []int{1, 2, 3}  -> fails     // "[1,2,3]" is seven
```

The threshold of a rule as ordinary as `max-length:500` on a slice of ids therefore moves as the ids grow wider ‚Äî measured against v2.10.2:

```
ids around 1            rejected from  152 elements on
ids around 100          rejected from  125 elements on
ids around 100000       rejected from   72 elements on
ids around 10000000000  rejected from   42 elements on
```

### Why this is a bug rather than a convention

The same package already measures a container by its element count elsewhere: `required` reports one as empty through `reflect.Value.Len`, see `isRequiredEmpty`. So a tag as ordinary as `required|min-length:2` applies two different notions of length to one and the same field, and they disagree on the simplest possible value:

```
required      []uint64{}  -> fails      // empty by reflect.Value.Len
min-length:2  []uint64{}  -> passes     // "[]" is two characters long
```

Measuring a container by its element count is not a new semantic being introduced here; it is the one the package already uses.

### Reproduction

No database or fixture needed, `go run .` against v2.10.2.

<details>
<summary>Complete runnable program</summary>

```go
package main

import (
	"context"
	"fmt"

	"github.com/gogf/gf/v2/util/gvalid"
)

func passes(rule string, value any) bool {
	return gvalid.New().
		Rules(map[string]string{"f": rule}).
		Data(map[string]any{"f": value}).
		Run(context.Background()) == nil
}

func verdict(ok bool) string {
	if ok {
		return "passes"
	}
	return "fails "
}

func main() {
	fmt.Println("== the same rule, opposite verdicts ==")
	fmt.Printf("size:3  []int{1}        -> %s\n", verdict(passes("size:3", []int{1})))
	fmt.Printf("size:3  []int{1, 2, 3}  -> %s\n", verdict(passes("size:3", []int{1, 2, 3})))

	fmt.Println("\n== one tag, two notions of length ==")
	empty := []uint64{}
	fmt.Printf("required     []uint64{} -> %s\n", verdict(passes("required", empty)))
	fmt.Printf("min-length:2 []uint64{} -> %s\n", verdict(passes("min-length:2", empty)))

	fmt.Println("\n== max-length:500 on a slice of ids, by how wide the ids print ==")
	for _, base := range []uint64{1, 100, 100000, 10000000000} {
		n := 1
		for passes("max-length:500", ids(base, n)) {
			n++
			if n > 5000 {
				break
			}
		}
		fmt.Printf("ids around %-12d rejected from %4d elements on\n", base, n)
	}

	fmt.Println("\n== nil is out of range: the rules are not executed at all ==")
	var nilSlice []string
	fmt.Printf("size:3       nil          -> %s\n", verdict(passes("size:3", nilSlice)))
	fmt.Printf("size:3       []string{}   -> %s\n", verdict(passes("size:3", []string{})))
}

func ids(base uint64, n int) []uint64 {
	out := make([]uint64, n)
	for i := range out {
		out[i] = base + uint64(i)
	}
	return out
}
```

</details>

Against v2.10.2:

```
== the same rule, opposite verdicts ==
size:3  []int{1}        -> passes
size:3  []int{1, 2, 3}  -> fails

== one tag, two notions of length ==
required     []uint64{} -> fails
min-length:2 []uint64{} -> passes

== max-length:500 on a slice of ids, by how wide the ids print ==
ids around 1            rejected from  152 elements on
ids around 100          rejected from  125 elements on
ids around 100000       rejected from   72 elements on
ids around 10000000000  rejected from   42 elements on

== nil is out of range: the rules are not executed at all ==
size:3       nil          -> passes
size:3       []string{}   -> fails
```

With this PR applied:

```
== the same rule, opposite verdicts ==
size:3  []int{1}        -> fails
size:3  []int{1, 2, 3}  -> passes

== one tag, two notions of length ==
required     []uint64{} -> fails
min-length:2 []uint64{} -> fails

== max-length:500 on a slice of ids, by how wide the ids print ==
ids around 1            rejected from  501 elements on
ids around 100          rejected from  501 elements on
ids around 100000       rejected from  501 elements on
ids around 10000000000  rejected from  501 elements on

== nil is out of range: the rules are not executed at all ==
size:3       nil          -> passes
size:3       []string{}   -> fails
```

### The change

All four rules now go through one helper, `valueLength`, which returns the number of elements of a slice, an array or a map, and keeps counting unicode runes of the string form for everything else. A pointer to a container is dereferenced, as `isRequiredEmpty` does.

A byte slice deliberately stays on the string side. `gconv` converts it to a string directly instead of serializing it, so `[]byte("GoFrame")` has always had the length of its text, and `reflect.Value.Len` would silently redefine `[]byte("‰Ω†Â•Ω")` from 2 to 6. A rune slice needs no special case, since its element count is its rune count.

### Compatibility

Nothing changes for strings, byte slices, numbers, or for a nil container, whose length rules are not executed at all ‚Äî the last one is worth stating explicitly, since it means a field that is simply absent is unaffected.

Validation of a *non nil* container does change, and in both directions. Any container serializes into at least two characters (`[]`), so `min-length:1` and `min-length:2` are rules that today pass for every value including the empty one:

```
[]string{}    min-length:2   passes today  ->  fails afterwards      (tightening)
[]int{1,2,3}  size:3         fails today   ->  passes afterwards     (loosening)
```

The tightening direction is the one to weigh: a `required|min-length:1` tag on a slice starts rejecting the empty slice it used to let through ‚Äî which is the very agreement with `required` this PR is about.

### Test

`util/gvalid/gvalid_z_unit_length_container_test.go` adds three tests:

- `Test_LengthRules_Container` covers the four rules over slices, arrays, maps, a pointer to a slice and a rune slice.
- `Test_LengthRules_String_Unchanged` pins the string and byte slice behaviour that must not move. Without it the change could not be told apart from an implementation that measures every value by `reflect.Value.Len`.
- `Test_LengthRules_Container_AgreesWithRequired` pins the agreement with `required` on one and the same value.

The container assertions fail without the change in this PR and pass with it.
