### PR TITLE
feat(database/gdb): support generated primary key values

### DIFF
--- a/contrib/drivers/pgsql/pgsql_do_exec.go
+++ b/contrib/drivers/pgsql/pgsql_do_exec.go
@@ -4,6 +4,8 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file executes PostgreSQL statements and captures returned primary keys.
+
 package pgsql
 
 import (
@@ -72,21 +74,24 @@ func (d *Driver) DoExec(ctx context.Context, link gdb.Link, sql string, args ...
 	}
 	affected := len(records)
 	if affected > 0 {
+		lastInsertPrimaryKeyValue := records[affected-1][primaryKey]
 		if !strings.Contains(pkField.Type, "int") {
 			return Result{
-				affected:     int64(affected),
-				lastInsertId: 0,
+				affected:                  int64(affected),
+				lastInsertId:              0,
+				lastInsertPrimaryKeyValue: lastInsertPrimaryKeyValue,
 				lastInsertIdError: gerror.NewCodef(
 					gcode.CodeNotSupported,
 					"LastInsertId is not supported by primary key type: %s", pkField.Type),
 			}, nil
 		}
 
-		if records[affected-1][primaryKey] != nil {
-			lastInsertId := records[affected-1][primaryKey].Int64()
+		if lastInsertPrimaryKeyValue != nil {
+			lastInsertId := lastInsertPrimaryKeyValue.Int64()
 			return Result{
-				affected:     int64(affected),
-				lastInsertId: lastInsertId,
+				affected:                  int64(affected),
+				lastInsertId:              lastInsertId,
+				lastInsertPrimaryKeyValue: lastInsertPrimaryKeyValue,
 			}, nil
 		}
 	}

--- a/contrib/drivers/pgsql/pgsql_result.go
+++ b/contrib/drivers/pgsql/pgsql_result.go
@@ -4,21 +4,40 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file defines PostgreSQL execution results and generated primary-key values.
+
 package pgsql
 
-import "database/sql"
+import (
+	"database/sql"
 
+	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/database/gdb"
+)
+
+// Result implements SQL execution result access for PostgreSQL statements.
 type Result struct {
 	sql.Result
-	affected          int64
-	lastInsertId      int64
-	lastInsertIdError error
+	affected                  int64     // affected stores the number of returned rows.
+	lastInsertId              int64     // lastInsertId stores an integer primary key.
+	lastInsertIdError         error     // lastInsertIdError reports unsupported primary-key types.
+	lastInsertPrimaryKeyValue gdb.Value // lastInsertPrimaryKeyValue stores the returned primary key.
 }
 
+// RowsAffected returns the number of rows returned by the executed statement.
 func (pgr Result) RowsAffected() (int64, error) {
 	return pgr.affected, nil
 }
 
+// LastInsertId returns an integer primary key or the recorded unsupported error.
 func (pgr Result) LastInsertId() (int64, error) {
 	return pgr.lastInsertId, pgr.lastInsertIdError
+}
+
+// LastInsertPrimaryKeyValue returns the primary key value produced by INSERT ... RETURNING.
+func (pgr Result) LastInsertPrimaryKeyValue() (gdb.Value, error) {
+	if pgr.lastInsertPrimaryKeyValue == nil {
+		return gvar.New(nil), nil
+	}
+	return pgr.lastInsertPrimaryKeyValue, nil
 }

--- a/contrib/drivers/pgsql/pgsql_result_primary_key_value_test.go
+++ b/contrib/drivers/pgsql/pgsql_result_primary_key_value_test.go
@@ -1,0 +1,54 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+// This file verifies PostgreSQL generated primary-key value result behavior.
+
+package pgsql
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/database/gdb"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// TestResultLastInsertPrimaryKeyValue verifies UUID values and empty result handling.
+func TestResultLastInsertPrimaryKeyValue(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		const expectedUUID = "4262b9b5-bc41-418a-a668-9201d72b069f"
+
+		var result sql.Result = Result{lastInsertPrimaryKeyValue: gvar.New(expectedUUID)}
+		valueResult, ok := result.(gdb.ResultWithPrimaryKeyValue)
+		t.Assert(ok, true)
+		value, err := valueResult.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(value.String(), expectedUUID)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result := Result{}
+		value, err := result.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(value.IsNil(), true)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		expectedError := errors.New("UUID is not an integer ID")
+		result := Result{
+			lastInsertIdError:         expectedError,
+			lastInsertPrimaryKeyValue: gvar.New("f93d9363-5cb8-4751-9b62-ad145f61cc30"),
+		}
+		_, err := result.LastInsertId()
+		t.Assert(errors.Is(err, expectedError), true)
+
+		value, err := result.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(value.String(), "f93d9363-5cb8-4751-9b62-ad145f61cc30")
+	})
+}

--- a/contrib/drivers/pgsql/pgsql_z_unit_feature_pgsql_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_feature_pgsql_test.go
@@ -4,12 +4,16 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file verifies PostgreSQL-specific query and returning features.
+
 package pgsql_test
 
 import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/gogf/gf/v2/database/gdb"
 	"github.com/gogf/gf/v2/frame/g"
@@ -284,6 +288,50 @@ func Test_PgSQL_Returning_Insert(t *testing.T) {
 		count, err := db.Model(table).Count()
 		t.AssertNil(err)
 		t.Assert(count, 2)
+	})
+}
+
+// Test_PgSQL_Returning_InsertAndGetPrimaryKeyValue_UUID tests UUID keys across insert API layers.
+func Test_PgSQL_Returning_InsertAndGetPrimaryKeyValue_UUID(t *testing.T) {
+	table := fmt.Sprintf(`%s_%d`, TablePrefix+"returning_uuid", gtime.TimestampNano())
+	if _, err := db.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+			name varchar(100)
+		);`, table)); err != nil {
+		t.Skipf("PostgreSQL UUID generation is unavailable: %v", err)
+	}
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		modelValue, err := db.Model(table).Data(g.Map{"name": "model"}).InsertAndGetPrimaryKeyValue()
+		t.AssertNil(err)
+		_, err = uuid.Parse(modelValue.String())
+		t.AssertNil(err)
+
+		result, err := db.Model(table).Data(g.Map{"name": "optional-result"}).Insert()
+		t.AssertNil(err)
+		valueResult, ok := result.(gdb.ResultWithPrimaryKeyValue)
+		t.Assert(ok, true)
+		resultValue, err := valueResult.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		_, err = uuid.Parse(resultValue.String())
+		t.AssertNil(err)
+
+		dbValue, err := db.InsertAndGetPrimaryKeyValue(ctx, table, g.Map{"name": "database"})
+		t.AssertNil(err)
+		_, err = uuid.Parse(dbValue.String())
+		t.AssertNil(err)
+
+		err = db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			txValue, txErr := tx.InsertAndGetPrimaryKeyValue(table, g.Map{"name": "transaction"})
+			if txErr != nil {
+				return txErr
+			}
+			_, txErr = uuid.Parse(txValue.String())
+			return txErr
+		})
+		t.AssertNil(err)
 	})
 }
 

--- a/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
+++ b/contrib/drivers/sqlite/sqlite_z_unit_model_test.go
@@ -4,6 +4,8 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file verifies SQLite model operations and generic database API behavior.
+
 package sqlite_test
 
 import (
@@ -3428,6 +3430,53 @@ func Test_Model_InsertAndGetId(t *testing.T) {
 		}).InsertAndGetId()
 		t.AssertNil(err)
 		t.Assert(id, 2)
+	})
+}
+
+// Test_InsertAndGetPrimaryKeyValue verifies integer fallbacks across model, database, and transaction APIs.
+func Test_InsertAndGetPrimaryKeyValue(t *testing.T) {
+	table := createTable()
+	defer dropTable(table)
+
+	gtest.C(t, func(t *gtest.T) {
+		modelValue, err := db.Model(table).Data(g.Map{"passport": "model"}).InsertAndGetPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(modelValue.Int64(), int64(1))
+
+		modelValue, err = db.Model(table).InsertAndGetPrimaryKeyValue(g.Map{"passport": "model-data"})
+		t.AssertNil(err)
+		t.Assert(modelValue.Int64(), int64(2))
+
+		dbValue, err := db.InsertAndGetPrimaryKeyValue(ctx, table, g.Map{"passport": "database"})
+		t.AssertNil(err)
+		t.Assert(dbValue.Int64(), int64(3))
+
+		dbValue, err = db.InsertAndGetPrimaryKeyValue(ctx, table, g.List{
+			{"passport": "database-batch-1"},
+			{"passport": "database-batch-2"},
+		}, 1)
+		t.AssertNil(err)
+		t.Assert(dbValue.Int64(), int64(5))
+
+		err = db.Transaction(ctx, func(ctx context.Context, tx gdb.TX) error {
+			txValue, txErr := tx.InsertAndGetPrimaryKeyValue(table, g.Map{"passport": "transaction"})
+			if txErr != nil {
+				return txErr
+			}
+			t.Assert(txValue.Int64(), int64(6))
+
+			txValue, txErr = tx.InsertAndGetPrimaryKeyValue(table, g.List{{"passport": "transaction-batch"}}, 1)
+			if txErr != nil {
+				return txErr
+			}
+			t.Assert(txValue.Int64(), int64(7))
+			return nil
+		})
+		t.AssertNil(err)
+
+		emptyValue, err := db.Model(table).InsertAndGetPrimaryKeyValue()
+		t.Assert(emptyValue, nil)
+		t.AssertNE(err, nil)
 	})
 }
 

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -106,6 +106,10 @@ type DB interface {
 	// It's a convenience method combining Insert with LastInsertId.
 	InsertAndGetId(ctx context.Context, table string, data any, batch ...int) (int64, error)
 
+	// InsertAndGetPrimaryKeyValue inserts a record and returns the auto-generated primary key value.
+	// It supports generated values that cannot be represented as int64, such as UUIDs.
+	InsertAndGetPrimaryKeyValue(ctx context.Context, table string, data any, batch ...int) (Value, error)
+
 	// Replace inserts or replaces records using REPLACE INTO syntax.
 	// Existing records with same unique key will be deleted and re-inserted.
 	Replace(ctx context.Context, table string, data any, batch ...int) (sql.Result, error)
@@ -465,6 +469,10 @@ type TX interface {
 	// InsertAndGetId inserts one record and returns its id value.
 	// It's commonly used with auto-increment primary key.
 	InsertAndGetId(table string, data any, batch ...int) (int64, error)
+
+	// InsertAndGetPrimaryKeyValue inserts one record and returns its generated primary key value.
+	// It supports generated values that cannot be represented as int64, such as UUIDs.
+	InsertAndGetPrimaryKeyValue(table string, data any, batch ...int) (Value, error)
 
 	// Replace inserts or replaces records using REPLACE INTO syntax.
 	// Existing records with same unique key will be deleted and re-inserted.

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -106,7 +106,8 @@ type DB interface {
 	// It's a convenience method combining Insert with LastInsertId.
 	InsertAndGetId(ctx context.Context, table string, data any, batch ...int) (int64, error)
 
-	// InsertAndGetPrimaryKeyValue inserts a record and returns the auto-generated primary key value.
+	// InsertAndGetPrimaryKeyValue inserts record(s) and returns the generated primary-key value.
+	// For batch inserts, it returns the primary-key value of the last inserted row.
 	// It supports generated values that cannot be represented as int64, such as UUIDs.
 	InsertAndGetPrimaryKeyValue(ctx context.Context, table string, data any, batch ...int) (Value, error)
 

--- a/database/gdb/gdb_core.go
+++ b/database/gdb/gdb_core.go
@@ -5,6 +5,8 @@
 // You can obtain one at https://github.com/gogf/gf.
 //
 
+// This file implements core database operations and driver delegation.
+
 package gdb
 
 import (
@@ -359,6 +361,14 @@ func (c *Core) InsertAndGetId(ctx context.Context, table string, data any, batch
 		return c.Model(table).Ctx(ctx).Data(data).Batch(batch[0]).InsertAndGetId()
 	}
 	return c.Model(table).Ctx(ctx).Data(data).InsertAndGetId()
+}
+
+// InsertAndGetPrimaryKeyValue performs action Insert and returns the generated primary key value.
+func (c *Core) InsertAndGetPrimaryKeyValue(ctx context.Context, table string, data any, batch ...int) (Value, error) {
+	if len(batch) > 0 {
+		return c.Model(table).Ctx(ctx).Data(data).Batch(batch[0]).InsertAndGetPrimaryKeyValue()
+	}
+	return c.Model(table).Ctx(ctx).Data(data).InsertAndGetPrimaryKeyValue()
 }
 
 // Replace does "REPLACE INTO ..." statement for the table.

--- a/database/gdb/gdb_core_txcore.go
+++ b/database/gdb/gdb_core_txcore.go
@@ -4,6 +4,8 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file implements database operations bound to a transaction.
+
 package gdb
 
 import (
@@ -339,6 +341,14 @@ func (tx *TXCore) InsertAndGetId(table string, data any, batch ...int) (int64, e
 		return tx.Model(table).Ctx(tx.ctx).Data(data).Batch(batch[0]).InsertAndGetId()
 	}
 	return tx.Model(table).Ctx(tx.ctx).Data(data).InsertAndGetId()
+}
+
+// InsertAndGetPrimaryKeyValue performs action Insert and returns the generated primary key value.
+func (tx *TXCore) InsertAndGetPrimaryKeyValue(table string, data any, batch ...int) (Value, error) {
+	if len(batch) > 0 {
+		return tx.Model(table).Ctx(tx.ctx).Data(data).Batch(batch[0]).InsertAndGetPrimaryKeyValue()
+	}
+	return tx.Model(table).Ctx(tx.ctx).Data(data).InsertAndGetPrimaryKeyValue()
 }
 
 // Replace does "REPLACE INTO ..." statement for the table.

--- a/database/gdb/gdb_model_insert.go
+++ b/database/gdb/gdb_model_insert.go
@@ -4,6 +4,8 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file implements model data preparation and insert operations.
+
 package gdb
 
 import (
@@ -211,6 +213,19 @@ func (m *Model) InsertAndGetId(data ...any) (lastInsertId int64, err error) {
 		return 0, err
 	}
 	return result.LastInsertId()
+}
+
+// InsertAndGetPrimaryKeyValue performs action Insert and returns the generated primary key value.
+func (m *Model) InsertAndGetPrimaryKeyValue(data ...any) (lastInsertPrimaryKeyValue Value, err error) {
+	var ctx = m.GetCtx()
+	if len(data) > 0 {
+		return m.Data(data...).InsertAndGetPrimaryKeyValue()
+	}
+	result, err := m.doInsertWithOption(ctx, InsertOptionDefault)
+	if err != nil {
+		return nil, err
+	}
+	return getLastInsertPrimaryKeyValue(result)
 }
 
 // InsertIgnore does "INSERT IGNORE INTO ..." statement for the model.

--- a/database/gdb/gdb_result.go
+++ b/database/gdb/gdb_result.go
@@ -4,19 +4,31 @@
 // If a copy of the MIT was not distributed with this file,
 // You can obtain one at https://github.com/gogf/gf.
 
+// This file defines SQL execution result adapters and generated primary-key values.
+
 package gdb
 
 import (
 	"database/sql"
 
+	"github.com/gogf/gf/v2/container/gvar"
 	"github.com/gogf/gf/v2/errors/gerror"
 )
+
+// ResultWithPrimaryKeyValue extends sql.Result with access to a generated primary-key value
+// that cannot necessarily be represented as int64.
+type ResultWithPrimaryKeyValue interface {
+	sql.Result
+
+	// LastInsertPrimaryKeyValue returns the generated primary-key value from the last inserted row.
+	LastInsertPrimaryKeyValue() (Value, error)
+}
 
 // SqlResult is execution result for sql operations.
 // It also supports batch operation result for rowsAffected.
 type SqlResult struct {
-	Result   sql.Result
-	Affected int64
+	Result   sql.Result // Result is the most recent underlying SQL result.
+	Affected int64      // Affected is the accumulated number of affected rows.
 }
 
 // MustGetAffected returns the affected rows count, if any error occurs, it panics.
@@ -64,4 +76,25 @@ func (r *SqlResult) LastInsertId() (int64, error) {
 		return 0, nil
 	}
 	return r.Result.LastInsertId()
+}
+
+// LastInsertPrimaryKeyValue returns the generated primary-key value from the last inserted row.
+func (r *SqlResult) LastInsertPrimaryKeyValue() (Value, error) {
+	if r.Result == nil {
+		return gvar.New(nil), nil
+	}
+	return getLastInsertPrimaryKeyValue(r.Result)
+}
+
+// getLastInsertPrimaryKeyValue returns a driver's native primary-key value when available and
+// otherwise wraps the standard integer last-insert ID.
+func getLastInsertPrimaryKeyValue(result sql.Result) (Value, error) {
+	if valueResult, ok := result.(ResultWithPrimaryKeyValue); ok {
+		return valueResult.LastInsertPrimaryKeyValue()
+	}
+	lastInsertID, err := result.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+	return gvar.New(lastInsertID), nil
 }

--- a/database/gdb/gdb_result_primary_key_value_test.go
+++ b/database/gdb/gdb_result_primary_key_value_test.go
@@ -1,0 +1,122 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+// This file verifies native and fallback generated primary-key value results.
+
+package gdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/gogf/gf/v2/container/gvar"
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// TestInsertResultSignatureCompatibility verifies that existing insert APIs keep returning sql.Result.
+func TestInsertResultSignatureCompatibility(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			dbInsert    func(DB, context.Context, string, any, ...int) (sql.Result, error) = DB.Insert
+			txInsert    func(TX, string, any, ...int) (sql.Result, error)                  = TX.Insert
+			modelInsert func(*Model, ...any) (sql.Result, error)                           = (*Model).Insert
+		)
+		t.AssertNE(dbInsert, nil)
+		t.AssertNE(txInsert, nil)
+		t.AssertNE(modelInsert, nil)
+	})
+}
+
+// testSQLResult provides a standard integer-only SQL result for fallback tests.
+type testSQLResult struct {
+	lastInsertID      int64
+	lastInsertIDError error
+}
+
+// LastInsertId returns the configured integer ID and error.
+func (r testSQLResult) LastInsertId() (int64, error) {
+	return r.lastInsertID, r.lastInsertIDError
+}
+
+// RowsAffected returns one affected row for the test result.
+func (r testSQLResult) RowsAffected() (int64, error) {
+	return 1, nil
+}
+
+// testNativeResultWithPrimaryKeyValue provides a generated primary-key value independently of LastInsertId.
+type testNativeResultWithPrimaryKeyValue struct {
+	testSQLResult
+	lastInsertPrimaryKeyValue Value
+}
+
+// LastInsertPrimaryKeyValue returns the configured native generated primary-key value.
+func (r testNativeResultWithPrimaryKeyValue) LastInsertPrimaryKeyValue() (Value, error) {
+	return r.lastInsertPrimaryKeyValue, nil
+}
+
+// TestGetLastInsertPrimaryKeyValue verifies native values, integer fallbacks, and error propagation.
+func TestGetLastInsertPrimaryKeyValue(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		const expectedUUID = "c3e0d2e0-03ec-4db9-a7d5-e8c3ec3ff7f2"
+		var result sql.Result = testNativeResultWithPrimaryKeyValue{
+			lastInsertPrimaryKeyValue: gvar.New(expectedUUID),
+		}
+		valueResult, ok := result.(ResultWithPrimaryKeyValue)
+		t.Assert(ok, true)
+		value, err := valueResult.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(value.String(), expectedUUID)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		value, err := getLastInsertPrimaryKeyValue(testSQLResult{lastInsertID: 42})
+		t.AssertNil(err)
+		t.Assert(value.Int64(), int64(42))
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		expectedError := errors.New("last insert ID unavailable")
+		value, err := getLastInsertPrimaryKeyValue(testSQLResult{lastInsertIDError: expectedError})
+		t.Assert(value, nil)
+		t.Assert(errors.Is(err, expectedError), true)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		const expectedUUID = "db50b8d6-6e5a-4fc9-b61a-6d21297844e0"
+
+		result := testNativeResultWithPrimaryKeyValue{
+			testSQLResult: testSQLResult{
+				lastInsertIDError: errors.New("integer conversion must not be used"),
+			},
+			lastInsertPrimaryKeyValue: gvar.New(expectedUUID),
+		}
+		value, err := getLastInsertPrimaryKeyValue(result)
+		t.AssertNil(err)
+		t.Assert(value.String(), expectedUUID)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		const expectedUUID = "94e54331-16b7-4a07-8f45-71d6c6c2cb80"
+
+		result := &SqlResult{
+			Result: testNativeResultWithPrimaryKeyValue{
+				lastInsertPrimaryKeyValue: gvar.New(expectedUUID),
+			},
+		}
+		value, err := result.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(value.String(), expectedUUID)
+	})
+
+	gtest.C(t, func(t *gtest.T) {
+		result := &SqlResult{}
+		value, err := result.LastInsertPrimaryKeyValue()
+		t.AssertNil(err)
+		t.Assert(value.IsNil(), true)
+	})
+}


### PR DESCRIPTION

This pull request introduces a new cross-database API for retrieving the generated primary key value from an insert operation, supporting both traditional integer IDs and non-integer types such as UUIDs. The changes ensure that all major database drivers, models, and transaction interfaces can return the generated primary key value in a type-agnostic way, and include comprehensive tests for both integer and UUID scenarios. Existing APIs for integer IDs remain unchanged for backward compatibility.
This pull request introduces generic support for retrieving auto-generated primary key values (including non-integer types like UUIDs) from database insert operations. It extends the database API, model, and driver layers to enable access to these values, adds new interfaces and methods, and provides comprehensive tests for both PostgreSQL and SQLite. Existing APIs remain backward compatible.

Key changes include:

**API and Interface Enhancements:**

* Added `InsertAndGetPrimaryKeyValue` methods to the `DB`, `TX`, and `Model` interfaces and implementations, allowing retrieval of generated primary key values that may not be representable as `int64` (e.g., UUIDs). (`[[1]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R109-R112)`, `[[2]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R473-R476)`, `[[3]](diffhunk://#diff-b1bbe5e3995261813e4e0ac6ffee8a37c236eaa2759f2bd82e211711695a70bcR366-R373)`, `[[4]](diffhunk://#diff-366da63678be33092d2690aacb3527c0ff1fb43bcd9ac531ac71e0a22eea2f79R346-R353)`, `[[5]](diffhunk://#diff-88304ddb7791aedbd83dafb68374aecab286d1356a7f2f149a8e57ac1a7f40b4R218-R230)`)
* Introduced the `ResultWithPrimaryKeyValue` interface and related helpers in `gdb_result.go` to standardize access to primary key values from SQL results, with fallback to integer IDs when native support is unavailable. (`[[1]](diffhunk://#diff-497d95a509b381679fd7dfc51a8aba9f180d21fc0b44da6512329257c49ddbcdR7-R31)`, `[[2]](diffhunk://#diff-497d95a509b381679fd7dfc51a8aba9f180d21fc0b44da6512329257c49ddbcdR80-R100)`)

**Driver and Result Implementation:**

* Updated the PostgreSQL driver (`pgsql`) to capture and expose generated primary key values (including UUIDs) in its `Result` type, and implemented the required interface. (`[[1]](diffhunk://#diff-499a437593b8ec65fff3e1a144236d38d0c8776798f9d60ec3d30a519a3bece1R7-R8)`, `[[2]](diffhunk://#diff-499a437593b8ec65fff3e1a144236d38d0c8776798f9d60ec3d30a519a3bece1R77-R94)`, `[[3]](diffhunk://#diff-5fda5413b8bfadfc6907bd10a70af5e9da99426934be04e29d0f212345330ab7R7-R43)`)
* Provided detailed file-level documentation comments across modified files for clarity and maintainability. (`[[1]](diffhunk://#diff-499a437593b8ec65fff3e1a144236d38d0c8776798f9d60ec3d30a519a3bece1R7-R8)`, `[[2]](diffhunk://#diff-5fda5413b8bfadfc6907bd10a70af5e9da99426934be04e29d0f212345330ab7R7-R43)`, `[[3]](diffhunk://#diff-b1bbe5e3995261813e4e0ac6ffee8a37c236eaa2759f2bd82e211711695a70bcR8-R9)`, `[[4]](diffhunk://#diff-366da63678be33092d2690aacb3527c0ff1fb43bcd9ac531ac71e0a22eea2f79R7-R8)`, `[[5]](diffhunk://#diff-88304ddb7791aedbd83dafb68374aecab286d1356a7f2f149a8e57ac1a7f40b4R7-R8)`, `[[6]](diffhunk://#diff-b56394612dae245b43e80cfc122dfa60c1cecc19c0ae83f2ae174dc7dd58d941R7-R8)`, `[[7]](diffhunk://#diff-7d069597c4a387cb4976bb256155415b6cca62e5867603b707d82ed1eec4bbf5R7-R17)`)

**Testing and Verification:**

* Added comprehensive tests for primary key value retrieval, covering UUIDs and integer fallback, in both PostgreSQL and SQLite drivers, as well as generic database API and result helpers. (`[[1]](diffhunk://#diff-09b61fd6794ad91b82464a06ae146cfa10b2e3349fe0149ff5e5ea0d592ce865R1-R54)`, `[[2]](diffhunk://#diff-99d673a2839667fc3e25af2f520f1ec0a5c9d16c5a525d43e4f327021026cf01R1-R122)`, `[[3]](diffhunk://#diff-b56394612dae245b43e80cfc122dfa60c1cecc19c0ae83f2ae174dc7dd58d941R3436-R3482)`, `[[4]](diffhunk://#diff-7d069597c4a387cb4976bb256155415b6cca62e5867603b707d82ed1eec4bbf5R294-R337)`)

These changes make it possible to reliably retrieve generated primary key values of any type after insert operations, improving support for databases and schemas that use non-integer primary keys.

**Primary key value retrieval enhancements:**

* Added a new `InsertAndGetPrimaryKeyValue` method to the `DB`, `TX`, and `Model` interfaces, allowing retrieval of generated primary key values (including non-integer types like UUIDs) after insert operations. [[1]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R109-R112) [[2]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R473-R476) [[3]](diffhunk://#diff-88304ddb7791aedbd83dafb68374aecab286d1356a7f2f149a8e57ac1a7f40b4R218-R230) [[4]](diffhunk://#diff-b1bbe5e3995261813e4e0ac6ffee8a37c236eaa2759f2bd82e211711695a70bcR366-R373) [[5]](diffhunk://#diff-366da63678be33092d2690aacb3527c0ff1fb43bcd9ac531ac71e0a22eea2f79R346-R353)
* Introduced the `ResultWithPrimaryKeyValue` interface and `LastInsertPrimaryKeyValue` method, enabling drivers to return native primary key values, with fallback logic to integer IDs if not natively supported. [[1]](diffhunk://#diff-497d95a509b381679fd7dfc51a8aba9f180d21fc0b44da6512329257c49ddbcdR7-R31) [[2]](diffhunk://#diff-497d95a509b381679fd7dfc51a8aba9f180d21fc0b44da6512329257c49ddbcdR80-R100)

**PostgreSQL driver updates:**

* Updated the PostgreSQL driver to capture and return the generated primary key value (including UUIDs) in its execution result, and implemented the new interface for compatibility. [[1]](diffhunk://#diff-499a437593b8ec65fff3e1a144236d38d0c8776798f9d60ec3d30a519a3bece1R77-R94) [[2]](diffhunk://#diff-5fda5413b8bfadfc6907bd10a70af5e9da99426934be04e29d0f212345330ab7R7-R43)
* Added targeted tests for UUID and integer primary key value retrieval in PostgreSQL, verifying correct behavior across model, database, and transaction APIs. [[1]](diffhunk://#diff-09b61fd6794ad91b82464a06ae146cfa10b2e3349fe0149ff5e5ea0d592ce865R1-R54) [[2]](diffhunk://#diff-7d069597c4a387cb4976bb256155415b6cca62e5867603b707d82ed1eec4bbf5R294-R337)

**SQLite and generic tests:**

* Implemented and tested the new primary key value retrieval API for SQLite, ensuring correct fallback to integer IDs and verifying behavior across all relevant APIs.
* Added generic tests to ensure that existing insert APIs remain compatible and that the new API works for both native and fallback scenarios.

**Documentation and code clarity:**

* Added and improved file-level documentation to clarify the purpose of each file and the new API. [[1]](diffhunk://#diff-499a437593b8ec65fff3e1a144236d38d0c8776798f9d60ec3d30a519a3bece1R7-R8) [[2]](diffhunk://#diff-5fda5413b8bfadfc6907bd10a70af5e9da99426934be04e29d0f212345330ab7R7-R43) [[3]](diffhunk://#diff-7d069597c4a387cb4976bb256155415b6cca62e5867603b707d82ed1eec4bbf5R7-R17) [[4]](diffhunk://#diff-b56394612dae245b43e80cfc122dfa60c1cecc19c0ae83f2ae174dc7dd58d941R7-R8) [[5]](diffhunk://#diff-b1bbe5e3995261813e4e0ac6ffee8a37c236eaa2759f2bd82e211711695a70bcR8-R9) [[6]](diffhunk://#diff-366da63678be33092d2690aacb3527c0ff1fb43bcd9ac531ac71e0a22eea2f79R7-R8) [[7]](diffhunk://#diff-88304ddb7791aedbd83dafb68374aecab286d1356a7f2f149a8e57ac1a7f40b4R7-R8) [[8]](diffhunk://#diff-497d95a509b381679fd7dfc51a8aba9f180d21fc0b44da6512329257c49ddbcdR7-R31)

These changes provide a robust and extensible way to retrieve generated primary key values across different databases and key types, improving support for modern schema patterns and driver consistency.imization, such as improving code performance, reducing memory usage, etc.
    + `test`: Used for modifications to test cases, such as adding, deleting, or modifying test cases for code.
    + `chore`: Used for modifications to non-business-related code, such as changes to build processes or tool 
