### PR TITLE
fix(database/gdb): handle PostgreSQL schema in gdb and gen dao

### DIFF
--- a/cmd/gf/internal/cmd/cmd_z_unit_gen_dao_test.go
+++ b/cmd/gf/internal/cmd/cmd_z_unit_gen_dao_test.go
@@ -114,6 +114,67 @@ func Test_Gen_Dao_Default(t *testing.T) {
 	})
 }
 
+// Test_Gen_Dao_PostgreSQLSchema verifies that gen dao discovers tables in a selected PostgreSQL schema.
+func Test_Gen_Dao_PostgreSQLSchema(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		var (
+			schema = "gen_dao_" + guid.S()
+			table  = "table_user"
+			path   = gfile.Temp(guid.S())
+		)
+		t.AssertNE(testPgDB, nil)
+		_, err := testPgDB.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %s", schema))
+		t.AssertNil(err)
+		t.Cleanup(func() {
+			_, cleanupErr := testPgDB.Exec(ctx, fmt.Sprintf("DROP SCHEMA %s CASCADE", schema))
+			t.AssertNil(cleanupErr)
+		})
+
+		_, err = testPgDB.Exec(ctx, fmt.Sprintf(
+			"CREATE TABLE %s.%s (id serial PRIMARY KEY, name varchar(45))", schema, table,
+		))
+		t.AssertNil(err)
+		var group = "gen_dao_" + guid.S()
+		err = gdb.AddConfigNode(group, gdb.ConfigNode{Link: linkPg})
+		t.AssertNil(err)
+		schemaDB, err := gdb.Instance(group)
+		t.AssertNil(err)
+		tables, err := schemaDB.Schema(schema).Tables(ctx)
+		t.AssertNil(err)
+		t.AssertIN(table, tables)
+		err = gfile.Mkdir(path)
+		t.AssertNil(err)
+		t.Cleanup(func() {
+			t.AssertNil(gfile.Remove(path))
+		})
+		err = gfile.Copy(
+			gtest.DataPath("gendao", "go.mod.txt"),
+			gfile.Join(path, "go.mod"),
+		)
+		t.AssertNil(err)
+
+		in := gendao.CGenDaoInput{
+			Path:   path,
+			Link:   linkPg,
+			Schema: schema,
+			Tables: "*",
+		}
+		err = gutil.FillStructWithDefault(&in)
+		t.AssertNil(err)
+		_, err = gendao.CGenDao{}.Dao(ctx, in)
+		t.AssertNil(err)
+
+		files, err := gfile.ScanDir(path, "*.go", true)
+		t.AssertNil(err)
+		t.Assert(files, []string{
+			filepath.FromSlash(path + "/dao/internal/table_user.go"),
+			filepath.FromSlash(path + "/dao/table_user.go"),
+			filepath.FromSlash(path + "/model/do/table_user.go"),
+			filepath.FromSlash(path + "/model/entity/table_user.go"),
+		})
+	})
+}
+
 func Test_Gen_Dao_TypeMapping(t *testing.T) {
 	gtest.C(t, func(t *gtest.T) {
 		var (

--- a/cmd/gf/internal/cmd/gendao/gendao.go
+++ b/cmd/gf/internal/cmd/gendao/gendao.go
@@ -42,6 +42,7 @@ type (
 		TablesEx           string   `name:"tablesEx"            short:"x"  brief:"{CGenDaoBriefTablesEx}"`
 		ShardingPattern    []string `name:"shardingPattern"     short:"sp" brief:"{CGenDaoBriefShardingPattern}"`
 		Group              string   `name:"group"               short:"g"  brief:"{CGenDaoBriefGroup}" d:"default"`
+		Schema             string   `name:"schema"                         brief:"{CGenDaoBriefSchema}"`
 		Prefix             string   `name:"prefix"              short:"f"  brief:"{CGenDaoBriefPrefix}"`
 		RemovePrefix       string   `name:"removePrefix"        short:"r"  brief:"{CGenDaoBriefRemovePrefix}"`
 		RemoveFieldPrefix  string   `name:"removeFieldPrefix"   short:"rf" brief:"{CGenDaoBriefRemoveFieldPrefix}"`
@@ -185,6 +186,9 @@ func doGenDaoForArray(ctx context.Context, index int, in CGenDaoInput) {
 	}
 	if db == nil {
 		mlog.Fatal(`database initialization failed, may be invalid database configuration`)
+	}
+	if in.Schema != "" {
+		db = db.Schema(in.Schema)
 	}
 
 	var tableNames []string

--- a/cmd/gf/internal/cmd/gendao/gendao_tag.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_tag.go
@@ -19,6 +19,7 @@ const (
 gf gen dao
 gf gen dao -l "mysql:root:12345678@tcp(127.0.0.1:3306)/test"
 gf gen dao -p ./model -g user-center -t user,user_detail,user_login
+gf gen dao -l "pgsql:postgres:12345678@tcp(127.0.0.1:5432)/test" --schema tenant_a
 gf gen dao -r user_
 `
 
@@ -33,6 +34,8 @@ CONFIGURATION SUPPORT
 		- link:     "mysql:root:12345678@tcp(127.0.0.1:3306)/test"
 		  tables:   "order,products"
 		  jsonCase: "CamelLower"
+		- link:     "pgsql:postgres:12345678@tcp(127.0.0.1:5432)/test"
+		  schema:   "tenant_a"
 		- link:   "mysql:root:12345678@tcp(127.0.0.1:3306)/primary"
 		  path:   "./my-app"
 		  prefix: "primary_"
@@ -85,6 +88,7 @@ generated go file name case for dao/table/do/entity files, cases are as follows:
 specifying the configuration group name of database for generated ORM instance,
 it's not necessary and the default value is "default"
 `
+	CGenDaoBriefSchema   = `specifying the database schema used to discover and generate table models`
 	CGenDaoBriefJsonCase = `
 generated json tag case for model struct, cases are as follows:
 | Case            | Example            |
@@ -154,6 +158,7 @@ func init() {
 		`CGenDaoBriefFieldMapping`:       CGenDaoBriefFieldMapping,
 		`CGenDaoBriefShardingPattern`:    CGenDaoBriefShardingPattern,
 		`CGenDaoBriefGroup`:              CGenDaoBriefGroup,
+		`CGenDaoBriefSchema`:             CGenDaoBriefSchema,
 		`CGenDaoBriefJsonCase`:           CGenDaoBriefJsonCase,
 		`CGenDaoBriefTplDaoIndexPath`:    CGenDaoBriefTplDaoIndexPath,
 		`CGenDaoBriefTplDaoInternalPath`: CGenDaoBriefTplDaoInternalPath,

--- a/cmd/gf/internal/cmd/gendao/gendao_test.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_test.go
@@ -7,11 +7,22 @@
 package gendao
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/gogf/gf/v2/test/gtest"
 	"github.com/gogf/gf/v2/text/gstr"
 )
+
+// Test_CGenDaoInput_Schema verifies that gen dao exposes schema through command and configuration metadata.
+func Test_CGenDaoInput_Schema(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		field, ok := reflect.TypeFor[CGenDaoInput]().FieldByName("Schema")
+		t.Assert(ok, true)
+		t.Assert(field.Tag.Get("name"), "schema")
+		t.Assert(field.Tag.Get("brief"), "{CGenDaoBriefSchema}")
+	})
+}
 
 // Test containsWildcard function.
 func Test_containsWildcard(t *testing.T) {

--- a/contrib/drivers/pgsql/pgsql_tables.go
+++ b/contrib/drivers/pgsql/pgsql_tables.go
@@ -47,17 +47,17 @@ func init() {
 // Tables retrieves and returns the tables of current schema.
 // It's mainly used in cli tool chain for automatically generating the models.
 func (d *Driver) Tables(ctx context.Context, schema ...string) (tables []string, err error) {
-	var (
-		result     gdb.Result
-		usedSchema = gutil.GetOrDefaultStr(d.GetConfig().Namespace, schema...)
-	)
-	if usedSchema == "" {
-		usedSchema = defaultSchema
-	}
 	// DO NOT use `usedSchema` as parameter for function `SlaveLink`.
 	link, err := d.SlaveLink(schema...)
 	if err != nil {
 		return nil, err
+	}
+	var (
+		result     gdb.Result
+		usedSchema = gutil.GetOrDefaultStr(d.GetSchema(), schema...)
+	)
+	if usedSchema == "" {
+		usedSchema = defaultSchema
 	}
 
 	useRelpartbound := ""

--- a/contrib/drivers/pgsql/pgsql_z_unit_feature_metadata_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_feature_metadata_test.go
@@ -37,7 +37,7 @@ func Test_TableFields_Basic(t *testing.T) {
 }
 
 // Test_TableFields_Schema tests TableFields with explicit schema.
-// PgSQL uses the shared SchemaName ("test") declared in pgsql_z_unit_init_test.go.
+// PgSQL uses the shared SchemaName ("public") declared in pgsql_z_unit_init_test.go.
 func Test_TableFields_Schema(t *testing.T) {
 	table := createInitTable()
 	defer dropTable(table)

--- a/contrib/drivers/pgsql/pgsql_z_unit_filter_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_filter_test.go
@@ -157,7 +157,7 @@ func Test_Tables_Method(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		// Test with specific schema - use the test schema
-		tables, err := db.Tables(ctx, "test")
+		tables, err := db.Tables(ctx, SchemaName)
 		t.AssertNil(err)
 		t.Assert(len(tables) >= 0, true)
 	})
@@ -237,7 +237,7 @@ func Test_TableFields_WithSchema(t *testing.T) {
 
 	gtest.C(t, func(t *gtest.T) {
 		// Test with schema parameter
-		fields, err := db.TableFields(ctx, table, "test")
+		fields, err := db.TableFields(ctx, table, SchemaName)
 		t.AssertNil(err)
 		t.Assert(len(fields) > 0, true)
 	})

--- a/contrib/drivers/pgsql/pgsql_z_unit_init_test.go
+++ b/contrib/drivers/pgsql/pgsql_z_unit_init_test.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	TableSize   = 10
-	TablePrefix = "t_"
-	SchemaName  = "test"
-	CreateTime  = "2018-10-24 10:00:00"
+	TableSize    = 10
+	TablePrefix  = "t_"
+	DatabaseName = "test"
+	SchemaName   = "public"
+	CreateTime   = "2018-10-24 10:00:00"
 )
 
 var (
@@ -56,13 +57,20 @@ func init() {
 
 	if configNode.Name == "" {
 		schemaTemplate := "SELECT 'CREATE DATABASE %s' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '%s')"
-		if _, err := db.Exec(ctx, fmt.Sprintf(schemaTemplate, SchemaName, SchemaName)); err != nil {
+		if _, err := db.Exec(ctx, fmt.Sprintf(schemaTemplate, DatabaseName, DatabaseName)); err != nil {
 			gtest.Error(err)
 		}
-
-		db = db.Schema(SchemaName)
+		configNode.Link = `pgsql:postgres:12345678@tcp(127.0.0.1:5432)/` + DatabaseName
+		if err := gdb.SetConfigGroup(gdb.DefaultGroupName, gdb.ConfigGroup{configNode}); err != nil {
+			gtest.Error(err)
+		}
+		if r, err := gdb.NewByGroup(); err != nil {
+			gtest.Error(err)
+		} else {
+			db = r.Schema(SchemaName)
+		}
 	} else {
-		db = db.Schema(configNode.Name)
+		db = db.Schema(SchemaName)
 	}
 
 	// Invalid db (connection opens lazily; first query is expected to fail).

--- a/database/gdb/gdb.go
+++ b/database/gdb/gdb.go
@@ -716,6 +716,7 @@ const (
 	defaultModelSafe                      = false
 	defaultCharset                        = `utf8`
 	defaultProtocol                       = `tcp`
+	driverTypePgSQL                       = `pgsql`
 	unionTypeNormal                       = 0
 	unionTypeAll                          = 1
 	defaultMaxIdleConnCount               = 10               // Max idle connection count in pool.
@@ -1121,14 +1122,18 @@ func (c *Core) getSqlDb(master bool, schema ...string) (sqlDb *sql.DB, err error
 		n := *c.db.GetConfig()
 		node = &n
 	}
+	if node.Link != "" {
+		node, err = parseConfigNodeLink(node)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if node.Charset == "" {
 		node.Charset = defaultCharset
 	}
 	// Changes the schema.
 	nodeSchema := gutil.GetOrDefaultStr(c.schema, schema...)
-	if nodeSchema != "" {
-		node.Name = nodeSchema
-	}
+	setSchemaToConfigNode(node, nodeSchema)
 	// Update the configuration object in internal data.
 	if err = c.setConfigNodeToCtx(ctx, node); err != nil {
 		return
@@ -1177,4 +1182,16 @@ func (c *Core) getSqlDb(master bool, schema ...string) (sqlDb *sql.DB, err error
 		c.db.SetDryRun(node.DryRun)
 	}
 	return
+}
+
+// setSchemaToConfigNode applies schema to the driver-specific configuration field.
+func setSchemaToConfigNode(node *ConfigNode, schema string) {
+	if schema == "" {
+		return
+	}
+	if node.Type == driverTypePgSQL {
+		node.Namespace = schema
+		return
+	}
+	node.Name = schema
 }

--- a/database/gdb/gdb_core_config.go
+++ b/database/gdb/gdb_core_config.go
@@ -423,7 +423,12 @@ func (c *Core) GetPrefix() string {
 func (c *Core) GetSchema() string {
 	schema := c.schema
 	if schema == "" {
-		schema = c.db.GetConfig().Name
+		config := c.db.GetConfig()
+		if config.Type == driverTypePgSQL {
+			schema = config.Namespace
+		} else {
+			schema = config.Name
+		}
 	}
 	return schema
 }

--- a/database/gdb/gdb_z_unit_schema_test.go
+++ b/database/gdb/gdb_z_unit_schema_test.go
@@ -1,0 +1,36 @@
+// Copyright GoFrame Author(https://goframe.org). All Rights Reserved.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT was not distributed with this file,
+// You can obtain one at https://github.com/gogf/gf.
+
+// This file verifies driver-specific schema configuration handling.
+
+package gdb
+
+import (
+	"testing"
+
+	"github.com/gogf/gf/v2/test/gtest"
+)
+
+// Test_SetSchemaToConfigNode verifies PostgreSQL schema switching preserves its database name.
+func Test_SetSchemaToConfigNode(t *testing.T) {
+	gtest.C(t, func(t *gtest.T) {
+		pgsqlNode := &ConfigNode{
+			Type:      driverTypePgSQL,
+			Name:      "application",
+			Namespace: "public",
+		}
+		setSchemaToConfigNode(pgsqlNode, "tenant_a")
+		t.Assert(pgsqlNode.Name, "application")
+		t.Assert(pgsqlNode.Namespace, "tenant_a")
+
+		mysqlNode := &ConfigNode{
+			Type: "mysql",
+			Name: "application",
+		}
+		setSchemaToConfigNode(mysqlNode, "tenant_a")
+		t.Assert(mysqlNode.Name, "tenant_a")
+	})
+}


### PR DESCRIPTION

Fixes #4127

[fix(database/gdb): implement PostgreSQL schema handling](https://github.com/gogf/gf/commit/4f601fcccb56ad2f1162af74c725396ffad46600)
[fix(gendao): support PostgreSQL schema generation](https://github.com/gogf/gf/commit/717ff09d8da072bd8da16d871dad0458cdc9fa88)

This pull request introduces support for PostgreSQL schema selection in the `gen dao` command and improves schema handling across the codebase, especially for PostgreSQL. It adds a new `--schema` option, updates documentation and test coverage, and refines internal logic to correctly handle schema configuration for different drivers.

**PostgreSQL Schema Support in `gen dao`:**
- Added a `Schema` field to `CGenDaoInput`, exposed as the `--schema` command-line option and in config metadata, allowing users to specify which PostgreSQL schema to use when generating DAOs. [[1]](diffhunk://#diff-f41dbd9109189d3d8382643a5f38f7fc88e959c5e38ecd0c2fc04ffb6dffed76R45) [[2]](diffhunk://#diff-ed3c923043f3587b1fc29b1826dc52ce5e537906a6f0f071a0403ea01f6c4090R91) [[3]](diffhunk://#diff-724bdde22ae9abc1e46a983bda0c0f683b1d514bd4cfa1502424cf180c7eb457R10-R26)
- Updated the `doGenDaoForArray` function to switch the database context to the selected schema if specified.
- Introduced a new unit test (`Test_Gen_Dao_PostgreSQLSchema`) to verify DAO generation from a specific PostgreSQL schema.
- Enhanced documentation and usage examples to show how to use the new `--schema` option with PostgreSQL. [[1]](diffhunk://#diff-ed3c923043f3587b1fc29b1826dc52ce5e537906a6f0f071a0403ea01f6c4090R22) [[2]](diffhunk://#diff-ed3c923043f3587b1fc29b1826dc52ce5e537906a6f0f071a0403ea01f6c4090R37-R38)

**Internal Schema Handling Improvements:**
- Refactored schema handling in `gdb.Core` to use a new helper, `setSchemaToConfigNode`, which ensures PostgreSQL schema selection uses the `Namespace` field and does not overwrite the database name. [[1]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R1125-R1136) [[2]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R1186-R1197) [[3]](diffhunk://#diff-46213dba8cf15cd9b6931290833312ce1f615eab26aa673050dbfdb94308375dL426-R431) [[4]](diffhunk://#diff-64852c14563e556d8ea87f4c833df46786ae0cbe5f22f327ec7163d154ff1ab0R719)
- Added a dedicated test to verify correct schema assignment for PostgreSQL and MySQL drivers.

**PostgreSQL Driver and Test Adjustments:**
- Refactored how the PostgreSQL driver retrieves the schema for table discovery, using `GetSchema()` instead of `Namespace` directly.
- Updated test initialization and references to use `public` as the default PostgreSQL schema, improving test clarity and correctness. [[1]](diffhunk://#diff-440b3a0453235157bb0dd1a7e21224fb0c047421ed118aa34f359fcc1343fe94L26-R27) [[2]](diffhunk://#diff-440b3a0453235157bb0dd1a7e21224fb0c047421ed118aa34f359fcc1343fe94L59-R73) [[3]](diffhunk://#diff-6d2c4c8d374f45613a5a31f7d1194142d2e185ef67e05dfa5e1fa5304693cfc3L40-R40) [[4]](diffhunk://#diff-a2b02dc78fe24c10ea9dd24160edc43222281b4fabfa47e9e641919526acf3b2L160-R160) [[5]](diffhunk://#diff-a2b02dc78fe24c10ea9dd24160edc43222281b4fabfa47e9e641919526acf3b2L240-R240)

These changes ensure that schema selection is explicit, consistent, and driver-appropriate, especially for PostgreSQL users working with multiple schemas.